### PR TITLE
Updating icETH with smaller logoURI

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -1,6 +1,6 @@
 {
   "name": "CoW Swap",
-  "timestamp": "2022-03-01T14:54:18+00:00",
+  "timestamp": "2022-12-08T19:00:00+00:00",
   "version": {
     "major": 1,
     "minor": 0,


### PR DESCRIPTION
The other one was 1.2MB, this one is 3.5KB