### PR TITLE
35/issue template forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/addImageForm.yml
+++ b/.github/ISSUE_TEMPLATE/addImageForm.yml
@@ -1,5 +1,5 @@
-name: Add Token
-description: Creates a request to add a token to CoW Swap's default token list
+name: Add Image
+description: Creates a request to add a token image to CoW Swap's image repository
 title: "[AddImage] `SYMBOL` on `NETWORK`"
 labels: []
 

--- a/.github/ISSUE_TEMPLATE/addImageForm.yml
+++ b/.github/ISSUE_TEMPLATE/addImageForm.yml
@@ -1,0 +1,43 @@
+name: Add Token
+description: Creates a request to add a token to CoW Swap's default token list
+title: "[AddImage] `SYMBOL` on `NETWORK`"
+labels: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Request to ADD image
+        Thank you for contributing to CoW Swap's image repository.
+        
+        Please fill in all the required fields in the form.
+        We will process and evaluate your request as soon as possible.
+        
+        Also, don't forget to update the issue title adding your token's `SYMBOL` and `NETWORK` (MAINNET or GNOSIS_CHAIN) 
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      description: The network this token is deployed to. If more than one, open another request.
+      multiple: false
+      options:
+        - MAINNET
+        - GNOSIS_CHAIN
+    validations:
+      required: true
+  - type: input
+    id: address
+    attributes:
+      label: Address
+      placeholder: 0x...
+    validations:
+      required: true
+  - type: input
+    id: imageIpfsCid
+    attributes:
+      label: Image IPFS url
+      description: Upload your image to IPFS and put the IPFS CID here
+      placeholder: QmcBPqkG...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/addTokenForm.yml
+++ b/.github/ISSUE_TEMPLATE/addTokenForm.yml
@@ -1,0 +1,70 @@
+name: Add Token
+description: Creates a request to add a token to CoW Swap's default token list
+title: "[AddToken] `SYMBOL` on `NETWORK`"
+labels: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Request to ADD token
+        Thank you for contributing to CoW Swap's default token list.
+        
+        Please fill in all the required fields in the form. 
+        We will process and evaluate your request as soon as possible.
+        
+        Also, don't forget to update the issue title adding your token's `SYMBOL` and `NETWORK` (MAINNET or GNOSIS_CHAIN) 
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      description: The network this token is deployed to. If more than one, open another request.
+      multiple: false
+      options:
+        - MAINNET
+        - GNOSIS_CHAIN
+    validations:
+      required: true
+  - type: input
+    id: symbol
+    attributes:
+      label: Token Symbol
+      placeholder: SYMBOL
+    validations:
+      required: true
+  - type: input
+    id: name
+    attributes:
+      label: Token Name
+      placeholder: My Token
+    validations:
+      required: true
+  - type: input
+    id: decimals
+    attributes:
+      label: Decimals
+      value: 18
+    validations:
+      required: true
+  - type: input
+    id: address
+    attributes:
+      label: Address
+      placeholder: 0x...
+    validations:
+      required: true
+  - type: input
+    id: imageIpfsCid
+    attributes:
+      label: Image IPFS url
+      description: Upload your image to IPFS and put the IPFS CID here
+      placeholder: QmcBPqkG...
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why should we add this token? How do we know it's not a scam? Does it have enough liquidity on selected chain?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/removeTokenForm.yml
+++ b/.github/ISSUE_TEMPLATE/removeTokenForm.yml
@@ -1,0 +1,41 @@
+name: Add Token
+description: Creates a request to add a token to CoW Swap's default token list
+title: "[RemoveToken] `SYMBOL` on `NETWORK`"
+labels: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Request to REMOVE token
+        Thank you for contributing to CoW Swap's default token list.
+        
+        Please fill in all the required fields in the form. 
+        We will process and evaluate your request as soon as possible.
+        
+        Also, don't forget to update the issue title adding your token's `SYMBOL` and `NETWORK` (MAINNET or GNOSIS_CHAIN) 
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      description: The network this token is deployed to. If more than one, open another request.
+      multiple: false
+      options:
+        - MAINNET
+        - GNOSIS_CHAIN
+    validations:
+      required: true
+  - type: input
+    id: address
+    attributes:
+      label: Address
+      placeholder: 0x...
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why should we remove this token?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/removeTokenForm.yml
+++ b/.github/ISSUE_TEMPLATE/removeTokenForm.yml
@@ -1,5 +1,5 @@
-name: Add Token
-description: Creates a request to add a token to CoW Swap's default token list
+name: Remove Token
+description: Creates a request to remove a token from CoW Swap's default token list
 title: "[RemoveToken] `SYMBOL` on `NETWORK`"
 labels: []
 


### PR DESCRIPTION
# Summary

Part of #35 

Adding issue template forms:

- Add token
- Remove token
- Add image

For more info, see GH's docs on [templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) and the [form syntax](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema)

# Testing

Not possible to test until this is merged to `main`