### PR TITLE
[Hotfix] Major Version Bump

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -1,9 +1,9 @@
 {
   "name": "CoW Swap",
-  "timestamp": "2022-12-15T19:00:00+00:00",
+  "timestamp": "2023-02-22T16:00:00+00:00",
   "version": {
-    "major": 1,
-    "minor": 5,
+    "major": 2,
+    "minor": 0,
     "patch": 0
   },
   "logoURI": "https://gnosis.mypinata.cloud/ipfs/Qme9B6jRpGtZsRFcPjHvA5T4ugFuL4c3SzWfxyMPa59AMo",


### PR DESCRIPTION
We changed the address for the OHM token. Since this is a non backward-compatible change, we need a major version bump, otherwise the frontend doesn't use the new list:

<img width="1654" alt="image" src="https://user-images.githubusercontent.com/1200333/220679216-02fe83e6-12b2-418d-adc3-cdd4f480b32d.png">
