### PR TITLE
Added FLEX - Native token of OPNX.com

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -556,6 +556,14 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://gateway.pinata.cloud/ipfs/QmQqhbpWjQhw2i4DoLgcpRFfoNYrvfx1yuCjszKH8YCAon"
-    }
+    },
+    {
+    "symbol": "FLEX",
+    "name": "Flex Coin",
+    "address": "0xfcf8eda095e37a41e002e266daad7efc1579bc0a",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/9108/large/coinflex_logo.png"
+  }
   ]
 }


### PR DESCRIPTION
OPNX.com will be launching in coming weeks as the major claims trading place. FLEX is its native token. Please add it so that traders may not be confused.

https://etherscan.io/token/0xfcf8eda095e37a41e002e266daad7efc1579bc0a

Thanks!