### PR TITLE
Use number type for decimals

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -561,7 +561,7 @@
       "address": "0xfcf8eda095e37a41e002e266daad7efc1579bc0a",
       "symbol": "FLEX",
       "name": "Flex Coin",
-      "decimals": "18",
+      "decimals": 18,
       "chainId": 1,
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xfcf8eda095e37a41e002e266daad7efc1579bc0a/logo.png"
     }

--- a/src/scripts/workflow_helper.py
+++ b/src/scripts/workflow_helper.py
@@ -27,8 +27,8 @@ def handle_add_update_token(data):
                     "address": data["address"].lower(),
                     "symbol": data["symbol"],
                     "name": data["name"],
-                    "decimals": data["decimals"],
-                    "chainId": data["chainId"],
+                    "decimals": int(data["decimals"]),
+                    "chainId": int(data["chainId"]),
                     "logoURI": data["logoURI"],
                 }
             )


### PR DESCRIPTION
An external team (Tally) [reported](https://cowservices.slack.com/archives/C04L2MZ5917/p1678730034965639) that our token list uses `number` and `string` inconsistently for token decimals.
This PR fixes this issue.

Note: I also updated the type for `chainId` for consistency with the code above my changes. This is arguably not needed as the input file for the script already stores `chainId` as a number.

Another inconsistency that I didn't touch is that sometimes the addresses are checksummed, sometimes not.

### Test plan

<details><summary>Checkout code to before introducing FLEX</summary>

```sh
git checkout 8ca81e6e595186bddfd0f4e5dc57f9010bcae111
```
</details>

<details><summary>Mimic setup from GitHub action</summary>

```sh
export LIST_PATH='src/public/CowSwap.json'
cat <<"EOF" >data.json
 {"network":"MAINNET","symbol":"FLEX","name":"Flex Coin","url":"https://assets.coingecko.com/coins/images/9108/large/coinflex_logo.png","decimals":"18","address":"0xfcf8eda095e37a41e002e266daad7efc1579bc0a","reason":"A user request was submitted for this token.","chainId":1,"blockExplorer":"etherscan","prImageUrl":"https://raw.githubusercontent.com/cowprotocol/token-lists/{0}/1_0xfcf8eda095e37a41e002e266daad7efc1579bc0a/src/public/images/1/0xfcf8eda095e37a41e002e266daad7efc1579bc0a/logo.png","logoURI":"https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xfcf8eda095e37a41e002e266daad7efc1579bc0a/logo.png"}
EOF
mkdir -p src/public/images/1/0xfcf8eda095e37a41e002e266daad7efc1579bc0a/
touch "src/public/images/1/0xfcf8eda095e37a41e002e266daad7efc1579bc0a/info.json"
```
</details>

<details><summary>Execute locally and confirm that the new decimals are of number type </summary>

```sh
python3 src/scripts/workflow_helper.py addToken data.json
git diff
[...]
+      "decimals": 18,
[...]
```
</details>

Also, I checked that FLEX is the only token that has string decimals.