### PR TITLE
Prevent spaces in token symbols

### DIFF
--- a/.github/ISSUE_TEMPLATE/addTokenForm.yml
+++ b/.github/ISSUE_TEMPLATE/addTokenForm.yml
@@ -30,6 +30,7 @@ body:
     id: symbol
     attributes:
       label: Token Symbol
+      description: The token symbol should not contain spaces
       placeholder: SYMBOL
     validations:
       required: true

--- a/.github/workflows/processRequest.yml
+++ b/.github/workflows/processRequest.yml
@@ -126,6 +126,12 @@ jobs:
           echo "${{ env.NETWORK }} ${{ env.URL }} ${{ env.ADDRESS }}"
           echo "::error title={Validation failed}::{Missing required fields for adding a token}"
           exit 1
+      - name: Validate symbol
+        if: env.SYMBOL
+        run: |
+          validate_symbol=$(echo ${{ env.SYMBOL }} | grep '\s' -qE)
+          validate_symbol && echo "::error title={Validation failed}::{Symbol cannot contain spaces}"
+          exit validate_symbol
       - name: Validate removeToken
         if: contains(github.event.issue.labels.*.name, 'removeToken') && (!env.NETWORK || !env.REASON || !env.ADDRESS)
         run: |


### PR DESCRIPTION
# Summary

Adds validation to `addToken` form to prevent symbols with spaces

# Testing

* Tested it locally using `act`
* To be tested after this PR is merged to `develop`