### PR TITLE
Replace logoURI with github hosted version where possible

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -4,7 +4,7 @@
   "version": {
     "major": 2,
     "minor": 9,
-    "patch": 0
+    "patch": 1
   },
   "logoURI": "https://ipfs.cow.fi/ipfs/Qme9B6jRpGtZsRFcPjHvA5T4ugFuL4c3SzWfxyMPa59AMo",
   "keywords": ["default", "list", "cowswap"],
@@ -15,7 +15,7 @@
       "address": "0x090185f2135308bad17527004364ebcc2d37e5f6",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x090185f2135308bad17527004364ebcc2d37e5f6.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x090185f2135308bad17527004364ebcc2d37e5f6/logo.png"
     },
     {
       "symbol": "STAKE",
@@ -23,7 +23,7 @@
       "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x0ae055097c6d159879521c384f1d2123d1f195e6.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x0ae055097c6d159879521c384f1d2123d1f195e6/logo.png"
     },
     {
       "symbol": "BTC2x-FLI",
@@ -31,7 +31,7 @@
       "address": "0x0b498ff89709d3838a063f1dfa463091f9801c2b",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmXGX9qiyNJmQyZYqnSvQPNW9iYtjYbsHNG9SBjVUZv6Cj"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x0b498ff89709d3838a063f1dfa463091f9801c2b/logo.png"
     },
     {
       "symbol": "YFI",
@@ -39,7 +39,7 @@
       "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e/logo.png"
     },
     {
       "symbol": "wNXM",
@@ -47,7 +47,7 @@
       "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x0d438f3b5175bebc262bf23753c1e53d03432bde.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x0d438f3b5175bebc262bf23753c1e53d03432bde/logo.png"
     },
     {
       "symbol": "SYN",
@@ -55,7 +55,7 @@
       "address": "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x0f2d719407fdbeff09d87557abb7232601fd9f29.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x0f2d719407fdbeff09d87557abb7232601fd9f29/logo.png"
     },
     {
       "symbol": "1INCH",
@@ -63,7 +63,7 @@
       "address": "0x111111111117dc0aa78b770fa6a738034120c302",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x111111111117dc0aa78b770fa6a738034120c302.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x111111111117dc0aa78b770fa6a738034120c302/logo.png"
     },
     {
       "symbol": "DPI",
@@ -71,7 +71,7 @@
       "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQdUquL6hCAXVMNHLjnJECTgVxZHsTWQwWKMMpEhqaiw9"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b/logo.png"
     },
     {
       "symbol": "EDEN",
@@ -79,7 +79,7 @@
       "address": "0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559/logo.png"
     },
     {
       "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
@@ -111,7 +111,7 @@
       "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44/logo.png"
     },
     {
       "symbol": "UNI",
@@ -119,7 +119,7 @@
       "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984/logo.png"
     },
     {
       "symbol": "WBTC",
@@ -127,7 +127,7 @@
       "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
       "decimals": 8,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/logo.png"
     },
     {
       "symbol": "BED",
@@ -135,7 +135,7 @@
       "address": "0x2af1df3ab0ab157e1e2ad8f88a7d04fbea0c7dc6",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmVDi7bWp8fbbf76vLcDQBhXtVRJSYMspRvrWRJAwATj83"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x2af1df3ab0ab157e1e2ad8f88a7d04fbea0c7dc6/logo.png"
     },
     {
       "symbol": "HEX",
@@ -143,7 +143,7 @@
       "address": "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
       "decimals": 8,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x2b591e99afe9f32eaa6214f7b7629768c40eeb39.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x2b591e99afe9f32eaa6214f7b7629768c40eeb39/logo.png"
     },
     {
       "symbol": "TOKE",
@@ -151,7 +151,7 @@
       "address": "0x2e9d63788249371f1dfc918a52f8d799f4a38c94",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x2e9d63788249371f1dfc918a52f8d799f4a38c94.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x2e9d63788249371f1dfc918a52f8d799f4a38c94/logo.png"
     },
     {
       "symbol": "dsETH",
@@ -159,7 +159,7 @@
       "address": "0x341c05c0E9b33C0E38d64de76516b2Ce970bB3BE",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQdY1CaAUJ1xLeR7tHLbDmH5q2cKoXDaC99KUZVJ6MtxU"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x341c05c0E9b33C0E38d64de76516b2Ce970bB3BE/logo.png"
     },
     {
       "symbol": "FXS",
@@ -167,7 +167,7 @@
       "address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0/logo.png"
     },
     {
       "symbol": "BADGER",
@@ -175,7 +175,7 @@
       "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x3472a5a71965499acd81997a54bba8d852c6e53d.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x3472a5a71965499acd81997a54bba8d852c6e53d/logo.png"
     },
     {
       "symbol": "gtcETH",
@@ -183,7 +183,7 @@
       "address": "0x36c833Eed0D376f75D1ff9dFDeE260191336065e",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQqhbpWjQhw2i4DoLgcpRFfoNYrvfx1yuCjszKH8YCAon"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x36c833Eed0D376f75D1ff9dFDeE260191336065e/logo.png"
     },
     {
       "symbol": "SAND",
@@ -191,7 +191,7 @@
       "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x3845badade8e6dff049820680d1f14bd3903a5d0.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x3845badade8e6dff049820680d1f14bd3903a5d0/logo.png"
     },
     {
       "symbol": "ACX",
@@ -215,7 +215,7 @@
       "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x4e15361fd6b4bb609fa63c81a2be19d873717870.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x4e15361fd6b4bb609fa63c81a2be19d873717870/logo.png"
     },
     {
       "symbol": "CVX",
@@ -223,7 +223,7 @@
       "address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b/logo.png"
     },
     {
       "symbol": "LINK",
@@ -231,7 +231,7 @@
       "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x514910771af9ca656af840dff83e8264ecf986ca.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x514910771af9ca656af840dff83e8264ecf986ca/logo.png"
     },
     {
       "symbol": "LDO",
@@ -239,7 +239,7 @@
       "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x5a98fcbea516cf06857215779fd812ca3bef1b32.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x5a98fcbea516cf06857215779fd812ca3bef1b32/logo.png"
     },
     {
       "symbol": "LUSD",
@@ -247,7 +247,7 @@
       "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x5f98805a4e8be255a32880fdec7f6728c6568ba0/logo.png"
     },
     {
       "symbol": "RBN",
@@ -255,7 +255,7 @@
       "address": "0x6123b0049f904d730db3c36a31167d9d4121fa6b",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x6123b0049f904d730db3c36a31167d9d4121fa6b.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x6123b0049f904d730db3c36a31167d9d4121fa6b/logo.png"
     },
     {
       "symbol": "auraBAL",
@@ -263,7 +263,7 @@
       "address": "0x616e8BfA43F920657B3497DBf40D6b1A02D4608d",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQMZCDeq9ryW92u4w6o5GHRVHVmbkAUZ7CX6oXiFyDozP"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x616e8BfA43F920657B3497DBf40D6b1A02D4608d/logo.png"
     },
     {
       "symbol": "FLX",
@@ -271,7 +271,7 @@
       "address": "0x6243d8cea23066d098a15582d81a598b4e8391f4",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x6243d8cea23066d098a15582d81a598b4e8391f4.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x6243d8cea23066d098a15582d81a598b4e8391f4/logo.png"
     },
     {
       "symbol": "OHM",
@@ -279,7 +279,7 @@
       "address": "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5",
       "decimals": 9,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmPqfuMJG3Kp7PADcneabNckgppNRF1SpkSXCLoUGev8yG"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5/logo.png"
     },
     {
       "symbol": "USDN",
@@ -287,7 +287,7 @@
       "address": "0x674c6ad92fd080e4004b2312b45f796a192d27a0",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x674c6ad92fd080e4004b2312b45f796a192d27a0.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x674c6ad92fd080e4004b2312b45f796a192d27a0/logo.png"
     },
     {
       "symbol": "GNO",
@@ -295,7 +295,7 @@
       "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x6810e776880c02933d47db1b9fc05908e5386b96.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x6810e776880c02933d47db1b9fc05908e5386b96/logo.png"
     },
     {
       "symbol": "DAI",
@@ -303,7 +303,7 @@
       "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x6b175474e89094c44da98b954eedeac495271d0f.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x6b175474e89094c44da98b954eedeac495271d0f/logo.png"
     },
     {
       "symbol": "SUSHI",
@@ -311,7 +311,7 @@
       "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x6b3595068778dd592e39a122f4f5a5cf09c90fe2.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x6b3595068778dd592e39a122f4f5a5cf09c90fe2/logo.png"
     },
     {
       "symbol": "LQTY",
@@ -319,7 +319,7 @@
       "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d/logo.png"
     },
     {
       "symbol": "MVI",
@@ -327,7 +327,7 @@
       "address": "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmXuSCtT64PDUQ2MZYeBP7ESYHQ5DrSPxx2Nguxoh8ht3i"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x72e364f2abdc788b7e918bc238b21f109cd634d7/logo.png"
     },
     {
       "symbol": "icETH",
@@ -335,7 +335,7 @@
       "address": "0x7C07F7aBe10CE8e33DC6C5aD68FE033085256A84",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmVhF8WZ1knNtug6MxzbNAXuy1R1RwiN7vuDzRg7rN5gYn"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x7C07F7aBe10CE8e33DC6C5aD68FE033085256A84/logo.png"
     },
     {
       "symbol": "MATIC",
@@ -343,7 +343,7 @@
       "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0/logo.png"
     },
     {
       "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
@@ -359,7 +359,7 @@
       "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9/logo.png"
     },
     {
       "address": "0x81994b9607e06ab3d5cf3afff9a67374f05f27d7",
@@ -375,7 +375,7 @@
       "address": "0x853d955acef822db058eb8505911ed77f175b99e",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x853d955acef822db058eb8505911ed77f175b99e.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x853d955acef822db058eb8505911ed77f175b99e/logo.png"
     },
     {
       "address": "0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3",
@@ -391,7 +391,7 @@
       "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab/logo.png"
     },
     {
       "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -407,7 +407,7 @@
       "address": "0x900db999074d9277c5da2a43f252d74366230da0",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmPNEmEz9FoxeXRkpr9dvaeg4n7Gg24uv5ykePVrY38df8"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x900db999074d9277c5da2a43f252d74366230da0/logo.png"
     },
     {
       "symbol": "FEI",
@@ -415,7 +415,7 @@
       "address": "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x956f47f50a910163d8bf957cf5846d573e7f87ca.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x956f47f50a910163d8bf957cf5846d573e7f87ca/logo.png"
     },
     {
       "symbol": "SHIB",
@@ -423,7 +423,7 @@
       "address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce/logo.png"
     },
     {
       "symbol": "STRONG",
@@ -431,7 +431,7 @@
       "address": "0x990f341946a3fdb507ae7e52d17851b87168017c",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x990f341946a3fdb507ae7e52d17851b87168017c.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x990f341946a3fdb507ae7e52d17851b87168017c/logo.png"
     },
     {
       "symbol": "MIM",
@@ -439,7 +439,7 @@
       "address": "0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3/logo.png"
     },
     {
       "symbol": "USDC",
@@ -447,7 +447,7 @@
       "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
       "decimals": 6,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/logo.png"
     },
     {
       "symbol": "ETH2x-FLI",
@@ -455,7 +455,7 @@
       "address": "0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmXGX9qiyNJmQyZYqnSvQPNW9iYtjYbsHNG9SBjVUZv6Cj"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd/logo.png"
     },
     {
       "address": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
@@ -479,7 +479,7 @@
       "address": "0xba100000625a3754423978a60c9317c58a424e3d",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xba100000625a3754423978a60c9317c58a424e3d.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xba100000625a3754423978a60c9317c58a424e3d/logo.png"
     },
     {
       "symbol": "alUSD",
@@ -487,7 +487,7 @@
       "address": "0xbc6da0fe9ad5f3b0d58160288917aa56653660e9",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/Qmf4wqJi6G6kuMhwKbiv8n6JfNJYXPf9BvwaA4b8KgBV8d"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xbc6da0fe9ad5f3b0d58160288917aa56653660e9/logo.png"
     },
     {
       "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
@@ -503,7 +503,7 @@
       "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f/logo.png"
     },
     {
       "symbol": "WETH",
@@ -511,7 +511,7 @@
       "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/logo.png"
     },
     {
       "symbol": "AURA",
@@ -519,7 +519,7 @@
       "address": "0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmcBPqkGYc7c1HNekQp98uk5mHSpbgc83kw4VcLcgR2utL"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF/logo.png"
     },
     {
       "symbol": "HOP",
@@ -527,7 +527,7 @@
       "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmSxuQpx3UadQY4B2i5AQAaU97JZqkhcm9dCZXXNsNziYR"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc/logo.png"
     },
     {
       "symbol": "BTRFLY",
@@ -535,7 +535,7 @@
       "address": "0xc55126051B22eBb829D00368f4B12Bde432de5Da",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmcfUASZpQ8wxKgdPytULDuyjfSZ4fzcL4b1P3u4tqY2C1"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xc55126051B22eBb829D00368f4B12Bde432de5Da/logo.png"
     },
     {
       "symbol": "TRIBE",
@@ -543,7 +543,7 @@
       "address": "0xc7283b66eb1eb5fb86327f08e1b5816b0720212b",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xc7283b66eb1eb5fb86327f08e1b5816b0720212b.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xc7283b66eb1eb5fb86327f08e1b5816b0720212b/logo.png"
     },
     {
       "symbol": "FOLD",
@@ -551,7 +551,7 @@
       "address": "0xd084944d3c05cd115c09d072b9f44ba3e0e45921",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xd084944d3c05cd115c09d072b9f44ba3e0e45921.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xd084944d3c05cd115c09d072b9f44ba3e0e45921/logo.png"
     },
     {
       "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
@@ -567,7 +567,7 @@
       "address": "0xd46ba6d942050d489dbd938a2c909a5d5039a161",
       "decimals": 9,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xd46ba6d942050d489dbd938a2c909a5d5039a161.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xd46ba6d942050d489dbd938a2c909a5d5039a161/logo.png"
     },
     {
       "symbol": "CRV",
@@ -575,7 +575,7 @@
       "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xd533a949740bb3306d119cc777fa900ba034cd52.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xd533a949740bb3306d119cc777fa900ba034cd52/logo.png"
     },
     {
       "symbol": "USDT",
@@ -583,7 +583,7 @@
       "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
       "decimals": 6,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xdac17f958d2ee523a2206206994597c13d831ec7.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xdac17f958d2ee523a2206206994597c13d831ec7/logo.png"
     },
     {
       "symbol": "ALCX",
@@ -591,7 +591,7 @@
       "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xdbdb4d16eda451d0503b854cf79d55697f90c8df.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xdbdb4d16eda451d0503b854cf79d55697f90c8df/logo.png"
     },
     {
       "address": "0xdd1ad9a21ce722c151a836373babe42c868ce9a4",
@@ -607,7 +607,7 @@
       "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f/logo.png"
     },
     {
       "symbol": "COW",
@@ -615,7 +615,7 @@
       "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://ipfs.cow.fi/ipfs/Qme9B6jRpGtZsRFcPjHvA5T4ugFuL4c3SzWfxyMPa59AMo"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB/logo.png"
     },
     {
       "address": "0xe2ba8693ce7474900a045757fe0efca900f6530b",
@@ -639,7 +639,7 @@
       "address": "0xed40834a13129509a89be39a9be9c0e96a0ddd71",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xed40834a13129509a89be39a9be9c0e96a0ddd71.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xed40834a13129509a89be39a9be9c0e96a0ddd71/logo.png"
     },
     {
       "symbol": "ICE",
@@ -647,7 +647,7 @@
       "address": "0xf16e81dce15b08f326220742020379b855b87df9",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xf16e81dce15b08f326220742020379b855b87df9.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xf16e81dce15b08f326220742020379b855b87df9/logo.png"
     },
     {
       "symbol": "VISR",
@@ -655,7 +655,7 @@
       "address": "0xf938424f7210f31df2aee3011291b658f872e91e",
       "decimals": 18,
       "chainId": 1,
-      "logoURI": "https://tokens.1inch.io/0xf938424f7210f31df2aee3011291b658f872e91e.png"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xf938424f7210f31df2aee3011291b658f872e91e/logo.png"
     },
     {
       "address": "0xfcf8eda095e37a41e002e266daad7efc1579bc0a",
@@ -679,7 +679,7 @@
       "address": "0x177127622c4A00F3d409B75571e12cB3c8973d3c",
       "decimals": 18,
       "chainId": 100,
-      "logoURI": "https://ipfs.cow.fi/ipfs/Qme9B6jRpGtZsRFcPjHvA5T4ugFuL4c3SzWfxyMPa59AMo"
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0x177127622c4A00F3d409B75571e12cB3c8973d3c/logo.png"
     },
     {
       "address": "0x2bF2ba13735160624a0fEaE98f6aC8F70885eA61",
@@ -818,4 +818,4 @@
       "logoURI": "https://raw.githubusercontent.com/centfinance/assets/master/blockchains/xdai/assets/0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d/logo.png"
     }
   ]
-}
+}  

--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -818,4 +818,4 @@
       "logoURI": "https://raw.githubusercontent.com/centfinance/assets/master/blockchains/xdai/assets/0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d/logo.png"
     }
   ]
-}  
+}


### PR DESCRIPTION
This PR changes all the URL of logos which we have stored in this repository with the corresponding rar github perma links (in case one of these non github hosted sources goes down)

Wrote a little script the checks all links are working

```
cat CowSwap.json | jq '.tokens[] | .logoURI' | sed 's/"//g' | while read -r logoURI; do
    echo "Checking $logoURI"
    curl -s -w "%{http_code}" "$logoURI"
done
```

Which actually showed that the `Minerva Wallet SuperToken` and `FRACTION` logos are no longer available (but also not yet hosted by us)