### PR TITLE
chore: upgrade to latest permit-utils pkg version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "license": "(MIT OR Apache-2.0)",
   "dependencies": {
-    "@cowprotocol/permit-utils": "^0.0.1",
+    "@cowprotocol/permit-utils": "^0.1.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "ajv": "^8.12.0",
     "ajv-cli": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,10 +54,10 @@
     json-stringify-deterministic "^1.0.8"
     multiformats "^9.6.4"
 
-"@cowprotocol/permit-utils@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/permit-utils/-/permit-utils-0.0.1.tgz#bb11336be564bf1b9a83589077fcec5e89e577a3"
-  integrity sha512-1KjV9zzspkCHrTENVyuPcMwXWcvzWZEuqd6KY0L9OrzxwfC8C4CIAcFi39jQxyF7pBoP7yOMCeRdHuXV4dDKyQ==
+"@cowprotocol/permit-utils@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/permit-utils/-/permit-utils-0.1.2.tgz#999b866f2113f2ce03c2197dd65cedfb27833b7d"
+  integrity sha512-ueqte15EkyULKViGRsQDnlWA8+1UjIhsd6SlXW0haPO0rxvJgUShgmLy/zVevX3yCLP3pVTeMfeOpSsUEu3huw==
   dependencies:
     "@1inch/permit-signed-approvals-utils" "^1.4.10"
     "@cowprotocol/app-data" "^1.1.0"


### PR DESCRIPTION
# Summary

Upgrade to latest permit-utils

No actual permit changes as it was used to generate the permit list before while it was unpublished.