### PR TITLE
fix: gnosis-chain permit-info

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "(MIT OR Apache-2.0)",
   "dependencies": {
     "@cowprotocol/cow-sdk": "^5.1.0",
-    "@cowprotocol/permit-utils": "^0.1.2",
+    "@cowprotocol/permit-utils": "^0.2.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "ajv": "^8.12.0",
     "ajv-cli": "^5.0.0",

--- a/src/public/PermitInfo.100.json
+++ b/src/public/PermitInfo.100.json
@@ -1,229 +1,996 @@
 {
+  "0x0116e28b43a358162b96f70b4de14c98a4465f25": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "UniCrypt on xDai"
+  },
+  "0x01e92e3791f8c1d6599b2f80a4bff9b43949ac7c": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Wrapped NXM on xDai"
+  },
+  "0x020ae8fc1c19f4d1312cf6a72291f52849791e7c": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "VectorspaceAI on xDai"
+  },
+  "0x044f6ae3aef34fdb8fddc7c05f9cc17f19acd516": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Status Network Token on xDai"
+  },
+  "0x0811e451447d5819976a95a02f130c3b00d59346": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "tBTC on xDai"
+  },
+  "0x0939a7c3f8d37c1ce67fada4963ae7e0bd112ff3": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "VitaDAO Token from Mainnet"
+  },
+  "0x0acd91f92fe07606ab51ea97d8521e29d110fd09": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Celsius on xDai"
+  },
+  "0x0b7a1c1a3d314dcc271ea576da400b24e9ad3094": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Numeraire on xDai"
+  },
+  "0x0da1a02cdf84c44021671d183d616925164e08aa": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Republic Token on xDai"
+  },
+  "0x0dcfed2c3041e66b2d8c4ea39782c60355716316": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Energi on xDai"
+  },
+  "0x10a82313a4daef47c1ab9ef2bb00b22b3b0cc14c": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Wrapped XRP from Mainnet"
+  },
+  "0x10beea85519a704a63765d396415f9ea5aa30a17": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "PILLAR on xDai"
+  },
+  "0x12dabe79cffc1fde82fcd3b96dbe09fa4d8cd599": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "DAOstack on xDai"
+  },
+  "0x1319067e82f0b9981f19191e1c08bb6e6e055dd3": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "DeFireX DAI on xDai"
+  },
+  "0x14411aeca652f5131834bf0c8ff581b5ddf3bc03": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "coin_artist on xDai"
+  },
+  "0x1479ebfe327b62bff255c0749a242748d3e7347a": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Darwinia Network Native Token on xDai"
+  },
+  "0x1534fb3e82849314360c267fe20df3901a2ed3f9": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Kyber Network Crystal on xDai"
+  },
+  "0x16afe6e6754fa3694afd0ce48f4bea102efacc17": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Testa on xDai"
+  },
+  "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "CoW Protocol Token from Mainnet"
+  },
+  "0x18e9262e68cc6c6004db93105cc7c001bb103e49": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Raid Guild Token ⚔️ on xDai"
+  },
+  "0x1939d3431cf0e44b1d63b86e2ce489e5a341b1bf": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Cream on xDai"
+  },
+  "0x1bbca7491f14b46788ff9c834d97a668c4886523": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Frontier Token on xDai"
+  },
+  "0x1e37e5b504f7773460d6eb0e24d2e7c223b66ec7": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "HUSD on xDai"
+  },
+  "0x21a42669643f45bc0e086b8fc2ed70c23d67509d": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "FOX on xDai"
+  },
+  "0x226bcf0e417428a25012d0fa2183d37f92bcedf6": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "0x Protocol Token on xDai"
+  },
+  "0x22bd2a732b39dace37ae7e8f50a186f3d9702e87": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Curve.fi yDAI/yUSDC/yUSDT/yTUSD on xDai"
+  },
+  "0x248c54b3fc3bc8b20d0cdee059e17c67e4a3299d": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "CelerToken on xDai"
+  },
+  "0x26dc03e492763068ccfe7c39b93a22442807c360": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Nexo on xDai"
+  },
+  "0x26dd64bdcb2faf4f7e49a73145752e8d9cb34c94": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Pundi X Token on xDai"
+  },
+  "0x270de58f54649608d316faa795a9941b355a2bd0": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Freedom Reserve on xDai"
+  },
+  "0x2977893f4c04bfbd6efc68d0e46598d27810d3db": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Bidao on xDai"
+  },
+  "0x2995d1317dcd4f0ab89f4ae60f3f020a4f17c7ce": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "SushiToken on xDai"
+  },
+  "0x2be73bfeec620aa9b67535a4d3827bb1e29436d1": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "LoopringCoin V2 on xDai"
+  },
+  "0x2f0e755efe6b58238a67db420ff3513ec1fb31ef": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Rocket Pool on xDai"
+  },
+  "0x2fd0c73ad006407f0a96c984f06a9ce8415b094e": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Seed on xDai"
+  },
+  "0x309bc6dbcbfb9c84d26fdf65e8924367efccbdb9": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "OM Token on xDai"
+  },
+  "0x317eab07380d670ea814025cba40f5624354a32f": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "DeFiPIE Token on xDai"
+  },
+  "0x346b2968508d32f0192cd7a60ef3d9c39a3cf549": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "HoloToken on xDai"
+  },
+  "0x3581cc6a09de85e9b91ef93f2a5ef837706b84a5": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "AllianceBlock Token on xDai"
+  },
+  "0x35f346cb4149746272974a92d719fd48ae2f72fa": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Unisocks Edition 0 on xDai"
+  },
+  "0x37b60f4e9a31a64ccc0024dce7d0fd07eaa0f7b3": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Pinakion on xDai"
+  },
+  "0x3a00e08544d589e19a8e7d97d0294331341cdbf6": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Synthetix Network Token on xDai"
+  },
+  "0x3ae8c08cd61d05ad6e22973e4b675a92d412ee3c": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Serum on xDai"
+  },
+  "0x3c037849a8ffcf19886e2f5b04f293b7847d0377": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Liquid staked Ether 2.0 on xDai"
+  },
+  "0x3e33cf23073fd8d5ad1d48d1860a96c0d8e56193": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Standard on xDai"
+  },
+  "0x417602f4fbdd471a431ae29fb5fe0a681964c11b": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "JPY Coin on xDai"
+  },
+  "0x417ae38b3053a736b4274aed8dbd1a8a6fdbc974": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Rari Governance Token on xDai"
+  },
+  "0x437a044fb4693890e61d2c1c88e3718e928b8e90": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Aragon Network Token on xDai"
+  },
+  "0x4384a7c9498f905e433ee06b6552a18e1d7cd3a4": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "TrueFi on xDai"
+  },
+  "0x44b6bba599f100006143e82a60462d71ac1331da": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "API3 on xDai"
+  },
+  "0x44fa8e6f47987339850636f88629646662444217": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Dai Stablecoin on xDai"
+  },
+  "0x4537e328bf7e4efa29d05caea260d7fe26af9d74": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Uniswap on xDai"
+  },
+  "0x479e32cdff5f216f93060700c711d1cc8e811a6b": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Trips on xDai"
+  },
+  "0x48b1b0d077b4919b65b4e4114806dd803901e1d9": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Decentralized Insurance Protocol on xDai"
+  },
+  "0x4a88248baa5b39bb4a9caa697fb7f8ae0c3f0ddb": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "renBTC on xDai"
+  },
   "0x4b1e2c2762667331bc91648052f646d1b0d35984": {
     "type": "eip-2612",
     "version": "1",
     "name": "agEUR"
+  },
+  "0x4bc97997883c0397f556bd0f9da6fb71da22f9a2": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "aleph.im v2 on xDai"
+  },
+  "0x4be85acc1cd711f403dc7bde9e6cadfc5a94744b": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Rarible on xDai"
+  },
+  "0x4e1a2bffe81000f7be4807faf0315173c817d6f4": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Mask Network on xDai"
+  },
+  "0x4ea1172f4c4e8e8d3c9e1be4269b696bf19d24fe": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "SHIBA INU on xDai"
+  },
+  "0x4ecaba5870353805a9f068101a40e0f32ed605c6": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Tether USD on xDai"
+  },
+  "0x4efdfbb7cca540a79a7e4dcad1cb6ed14f21c43e": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "OKB on xDai"
+  },
+  "0x4f4f9b8d5b4d0dc10506e5551b0513b61fd59e75": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Giveth from Mainnet"
+  },
+  "0x512a2eb0277573ae9be0d48c782590b624048fdf": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "MEME on xDai"
+  },
+  "0x51732a6fc4673d1acca4c047f5465922716508ad": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Ocean Token on xDai"
+  },
+  "0x524b969793a64a602342d89bc2789d43a016b13a": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Donut on xDai"
+  },
+  "0x532801ed6f82fffd2dab70a19fc2d7b2772c4f4b": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Swapr on xDai"
+  },
+  "0x53ef00be819a062533a0e699077c621a28eaded1": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "PowerTrade Fuel Token on xDai"
+  },
+  "0x5a757f0bcadfdb78651b7bdbe67e44e8fd7f7f6b": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Enjin Coin on xDai"
+  },
+  "0x5a87eac5642bfed4e354ee8738dacd298e07d1af": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Reserve Rights on xDai"
+  },
+  "0x5b917d4fb9b27591353211c32f1552a527987afc": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "MoonToken on xDai"
+  },
+  "0x5bbfbfb123b72a255504be985bd2b474e481e866": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Sora Token on xDai"
+  },
+  "0x5f2852afd20c39849f6f56f4102b8c29ee141add": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "renZEC on xDai"
+  },
+  "0x5fd896d248fbfa54d26855c267859eb1b4daee72": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Maker on xDai"
+  },
+  "0x5fe9885226677f3eb5c9ad8ab6c421b4ea38535d": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "JOON on xDai"
+  },
+  "0x6062ec2a1ecfcd0026d9bd67aa5ad743adc03995": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "lien on xDai"
+  },
+  "0x6099280dc5fc97cbb61b456246316a1b8f79534b": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Polyient Games Governance Token on xDai"
+  },
+  "0x60e668f54106222adc1da80c169281b3355b8e5d": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "iEx.ec Network Token on xDai"
+  },
+  "0x64b17a95e6c45306fb23bc526eb2dc9e1331a1b1": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "CFX Quantum on xDai"
+  },
+  "0x699d001ef13b15335193bc5fad6cfc6747eee8be": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Base Protocol on xDai"
+  },
+  "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Wrapped Ether on xDai"
+  },
+  "0x6a8cb6714b1ee5b471a7d2ec4302cb4f5ff25ec2": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Energy Web Token Bridged on xDai"
   },
   "0x6ac78efae880282396a335ca2f79863a1e6831d4": {
     "type": "eip-2612",
     "version": "1",
     "name": "StakeWise Reward GNO"
   },
+  "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Wrapped liquid staked Ether 2.0 from Mainnet"
+  },
+  "0x6d237bb2248d3b40b1a54f3417667b2f39984fc8": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "PieDAO DOUGH v2 on xDai"
+  },
+  "0x6eeceab954efdbd7a8a8d9387bc719959b04b9ca": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Aragon Network Token on xDai"
+  },
+  "0x6f09cf96558d44584db07f8477dd3490599aa63e": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Bitgear on xDai"
+  },
+  "0x703120f2f2011a0d03a03a531ac0e84e81f15989": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "UNCL on xDai"
+  },
+  "0x7122d7661c4564b7c6cd4878b06766489a6028a2": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Matic Token on xDai"
+  },
+  "0x712b3d230f3c1c19db860d80619288b1f0bdd0bd": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Curve DAO Token on xDai"
+  },
+  "0x743a991365ba94bfc90ad0002cad433c7a33cb4a": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "AirSwap Token on xDai"
+  },
+  "0x75481a953a4bba6b3c445907db403e4b5d222174": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "PolkastarterToken on xDai"
+  },
+  "0x75886f00c1a20ec1511111fb4ec3c51de65b1fe7": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "FTT on xDai"
+  },
+  "0x76eafffa1873a8acd43864b66a728bd873c5e08a": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "SwissBorg Token on xDai"
+  },
+  "0x778aa03021b0cd2b798b0b506403e070125d81c9": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "BlackDragon Token on xDai"
+  },
+  "0x7838796b6802b18d7ef58fc8b757705d6c9d12b3": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Decentraland MANA on xDai"
+  },
+  "0x79cf2029717e2e78c8927f65f079ab8da21781ee": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "LUKSO Token on xDai"
+  },
+  "0x7a7d81657a1a66b38a6ca2565433a9873c6913b2": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Enigma on xDai"
+  },
+  "0x7c16c63684d86bacc52e8793b08a5a1a3cb1ba1e": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Davincij15 Token on xDai"
+  },
+  "0x7da0bfe9d26c5b64c7580c04bb1425364273e4b0": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Concentrated Voting Power on xDai"
+  },
+  "0x7db0be7a41b5395268e065776e800e27181c81ab": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Livepeer Token on xDai"
+  },
+  "0x7ea8af7301b763451b7fb25f8fc2406819a7e36f": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Phala on xDai"
+  },
+  "0x7ecf26cd9a36990b8ea477853663092333f59979": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Perpetual on xDai"
+  },
+  "0x7ef541e2a22058048904fe5744f9c7e4c57af717": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Balancer on xDai"
+  },
+  "0x7f7440c5098462f833e123b44b8a03e1d9785bab": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "1INCH Token on xDai"
+  },
+  "0x82dfe19164729949fd66da1a37bc70dd6c4746ce": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "BaoToken on xDai"
+  },
+  "0x8395f7123ba3ffad52e7414433d825931c81c879": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "OMGToken on xDai"
+  },
+  "0x83ff60e2f93f8edd0637ef669c69d5fb4f64ca8e": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Bright on xDai"
+  },
+  "0x860182180e146300df38aab8d328c6e80bec9547": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "UniTrade on xDai"
+  },
+  "0x8a95ea379e1fa4c749dd0a7a21377162028c479e": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Audius on xDai"
+  },
+  "0x8c88ea1fd60462ef7004b9e288afcb4680a3c50c": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "0xMonero on xDai"
+  },
+  "0x8d02b73904856de6998ffdf6e7ee18cc21137a79": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "MetaFactory on xDai"
+  },
+  "0x8e1a12da00bbf9db10d48bd66ff818be933964d5": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "NFTX on xDai"
+  },
+  "0x8e5bbbb09ed1ebde8674cda39a0c169401db4252": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Wrapped BTC on xDai"
+  },
+  "0x8e7ab03ca7d17996b097d5866bfaa1e251c35c6a": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Unit Protocol on xDai"
+  },
+  "0x8f365b41b98fe84acb287540b4b4ab633e07edb2": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Synth sETH on xDai"
+  },
+  "0x8fbedd16904b561e30ea402f459900e9d90614af": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Unilayer on xDai"
+  },
+  "0x915742cb77124761015f63e079089ad0eff1b57c": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "decentral.games on xDai"
+  },
+  "0x921557ac88f770aab08eef6ac32106f00c7a5e72": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Prime from Mainnet"
+  },
+  "0x97edc0e345fbbbd8460847fcfa3bc2a13bf8641f": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "DAOSquare Governance Token on xDai"
+  },
+  "0x981fb9ba94078a2275a8fc906898ea107b9462a8": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Panvala pan on xDai"
+  },
+  "0x985e144eb355273c4b4d51e448b68b657f482e26": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "POA ERC20 on Foundation on xDai"
+  },
+  "0x9a495a281d959192343b0e007284bf130bd05f86": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Bancor Network Token on xDai"
+  },
+  "0x9bd5e0ce813d5172859b0b70ff7bb3c325cee913": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Ethereum Meta on xDai"
+  },
+  "0x9c58bacc331c9aa871afd802db6379a98e80cedb": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Gnosis Token on xDai"
+  },
+  "0xa2fec95b3d3fecb39098e81f108533e1abf22ccf": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Yield on xDai"
+  },
   "0xa4ef9da5ba71cc0d2e5e877a910a37ec43420445": {
     "type": "eip-2612",
     "version": "1",
     "name": "StakeWise Staked GNO"
+  },
+  "0xa9e5cd4efc86c01fae9a9fcd6e8669b97c92a937": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "prophet.finance on xDai"
+  },
+  "0xaad66432d27737ecf6ed183160adc5ef36ab99f2": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Tellor Tributes from Mainnet"
+  },
+  "0xabef652195f98a91e490f047a5006b71c85f058d": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Curve.Fi USD Stablecoin from Mainnet"
+  },
+  "0xad601530859513371fa107ae6a7e18e08d69f155": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Hakka Finance on xDai"
   },
   "0xaf204776c7245bf4147c2612bf6e5972ee483701": {
     "type": "eip-2612",
     "version": "1",
     "name": "Savings xDAI"
   },
+  "0xb0c5f3100a4d9d9532a4cfd68c55f1ae8da987eb": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "DAOhaus Token on xDai"
+  },
+  "0xb1950fb2c9c0cbc8553578c67db52aa110a93393": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Synth sUSD on xDai"
+  },
+  "0xb31a2595e4cf66efbc1fe348b1429e5730891382": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "BarnBridge Governance Token on xDai"
+  },
+  "0xb4b6f80d8e573e9867c90163bfdb00e29d92716a": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Metronome on xDai"
+  },
+  "0xb714654e905edad1ca1940b7790a8239ece5a9ff": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "TrueUSD on xDai"
+  },
+  "0xb7d311e2eb55f2f68a9440da38e7989210b9a05e": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "STAKE on xDai"
+  },
+  "0xb90d6bec20993be5d72a5ab353343f7a0281f158": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "DXdao on xDai"
+  },
+  "0xbab3cbdcbcc578445480a79ed80269c50bb5b718": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "MEDOOZA Ecosystem v2.0 on xDai"
+  },
+  "0xbc650b9cc12db4da14b2417c60ccd6f4d77c3998": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "StorjToken on xDai"
+  },
+  "0xbcfb2b889f7baa29dd7a7b447b6c87aca572f4f4": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Aave Interest bearing DAI on xDai"
+  },
+  "0xbdb90bdadae84af0b07abf4cefcc7989f909f9bd": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "bns.finance on xDai"
+  },
+  "0xbde011911128f6bd4abb1d18f39fdc3614ca2cfe": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Axie Infinity Shard on xDai"
+  },
+  "0xbf65bfcb5da067446cee6a706ba3fe2fb1a9fdfd": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "yearn.finance on xDai"
+  },
+  "0xc12956b840b403b600014a3092f6ebd9259738fe": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "SURF.Finance on xDai"
+  },
+  "0xc1b42bdb485deb24c74f58399288d7915a726c1d": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "EthLend Token on xDai"
+  },
+  "0xc439e5b1dee4f866b681e7c5e5df140aa47fbf19": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Dai Stablecoin v1.0 on xDai"
+  },
+  "0xc45b3c1c24d5f54e7a2cf288ac668c74dd507a84": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Symmetric on xDai"
+  },
   "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc": {
     "type": "eip-2612",
     "version": "1",
     "name": "Hop"
+  },
+  "0xc577cddabb7893cc2ca15ef4b5d5e5e13c3feed3": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "McDonaldsCoin on xDai"
+  },
+  "0xc60e38c6352875c051b481cbe79dd0383adb7817": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "DAppNode DAO Token on xDai"
+  },
+  "0xc6cc63f4aa25bbd4453eb5f3a0dfe546fef9b2f3": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Basic Attention Token on xDai"
+  },
+  "0xc81c785653d97766b995d867cf91f56367742eac": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "AriesFinancial on xDai"
+  },
+  "0xc84dd5b971521b6c9fa5e10d25e6428b19710e05": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Ampleforth on xDai"
+  },
+  "0xc9b6218affe8aba68a13899cbf7cf7f14ddd304c": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Colony Network Token on xDai"
+  },
+  "0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Autonolas from Mainnet"
+  },
+  "0xcf9dc2de2a67d7db1a7171e3b8456d2171e4da75": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Layer 2 Index on xDai"
+  },
+  "0xd057604a14982fe8d88c5fc25aac3267ea142a08": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "HOPR Token on xDai"
+  },
+  "0xd27e1ecc4748f42e052331bea917d89beb883fc3": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Akropolis on xDai"
+  },
+  "0xd361c1fd663d8f2dc36ae07ff6f3623532cabdd3": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "MCDEX Token on xDai"
+  },
+  "0xd3b93ff74e43ba9568e5019b38addb804fef719b": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "UniBright on xDai"
+  },
+  "0xd3d47d5578e55c880505dc40648f7f9307c3e7a8": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "DefiPulse Index on xDai"
+  },
+  "0xd51e1ddd116fff9a71c1b8feeb58113afa2b4d93": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "AMIS on xDai"
+  },
+  "0xd87eaa26dcfb0c0a6160ccf8c8a01beb1c15fb00": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Flex Ungovernance Token from Mainnet"
+  },
+  "0xd9fa47e33d4ff7a1aca489de1865ac36c042b07a": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "HEX on xDai"
+  },
+  "0xdbf3ea6f5bee45c02255b2c26a16f300502f68da": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "BZZ on xDai"
+  },
+  "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "USD//C on xDai"
+  },
+  "0xde1e70ed71936e4c249a7d43e550f0b99fccddfc": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "FalconSwap Token on xDai"
+  },
+  "0xdf613af6b44a31299e48131e9347f034347e2f00": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Aave Token on xDai"
+  },
+  "0xdf6ff92bfdc1e8be45177dc1f4845d391d3ad8fd": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Compound on xDai"
+  },
+  "0xdfc20ae04ed70bd9c7d720f449eedae19f659d65": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Badger on xDai"
+  },
+  "0xe0cf6c7ed5ca334bd39f86366defbc3fc6dbbcab": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Coinbase Wrapped Staked ETH from Mainnet"
+  },
+  "0xe154a435408211ac89757b76c4fbe4dc9ed2ef27": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "BandToken on xDai"
+  },
+  "0xe2e73a1c69ecf83f464efce6a5be353a37ca09b2": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "ChainLink Token on xDai"
+  },
+  "0xe6a1f98b0f4368559bd16639c844510f5db6fe48": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "bZx Protocol Token on xDai"
+  },
+  "0xe6ff35dc3227a0c46e92b640bcb5c5895ad8c687": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "The 4th Pillar Token on xDai"
+  },
+  "0xe746a0476b833f2fa658e2b549dcfa5abbb9c3c9": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Bincentive Token from Mainnet"
+  },
+  "0xe7ef58d8180cc269c6620ded3e6cc536a52e2ebd": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "BlockMesh on xDai"
+  },
+  "0xe959db3c04376b017b37c95618bbaeb59f51abba": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Mai Stablecoin from Mainnet"
+  },
+  "0xeaacce3e5bcc10fb32c2553f8d6fc4c3888ffdad": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "TrustSwap Token on xDai"
+  },
+  "0xeb2bcabb0cdc099978a74cfe4ab4d45e7e677a45": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Terra Virtua Kolect on xDai"
+  },
+  "0xec3f3e6d7907acda3a7431abd230196cda3fbb19": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Ethix on xDai"
+  },
+  "0xec84a3bb48d70553c2599ac2d0db07b2dfdf6364": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "BNS Token on xDai"
+  },
+  "0xeddd81e0792e764501aae206eb432399a0268db5": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Trace Token on xDai"
+  },
+  "0xf54b47b00b6916974c73b81b7d9929a4f443db49": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Robonomics on xDai"
+  },
+  "0xf99efeb34aff6d3099c41605e9ee778caec39317": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Meridian Network on xDai"
+  },
+  "0xfadc59d012ba3c110b08a15b7755a5cb7cbe77d7": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Graph Token on xDai"
+  },
+  "0xfb23cfd35046466fdba7f73dc2fccb5b17abf1aa": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "AlbCoin on xDai"
   },
   "0xfbdd194376de19a88118e84e279b977f165d01b8": {
     "type": "eip-2612",
     "version": "1",
     "name": "DeHive.finance"
   },
-  "0x0116e28b43a358162b96f70b4de14c98a4465f25": {
-    "type": "unsupported",
-    "name": "UniCrypt on xDai"
+  "0xfd4e5f45ea24ec50c4db4367380b014875caf219": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "XY Oracle on xDai"
   },
-  "0x01e92e3791f8c1d6599b2f80a4bff9b43949ac7c": {
-    "type": "unsupported",
-    "name": "Wrapped NXM on xDai"
+  "0xfe7ed09c4956f7cdb54ec4ffcb9818db2d7025b8": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "USDP Stablecoin on xDai"
   },
-  "0x020ae8fc1c19f4d1312cf6a72291f52849791e7c": {
-    "type": "unsupported",
-    "name": "VectorspaceAI on xDai"
-  },
-  "0x044f6ae3aef34fdb8fddc7c05f9cc17f19acd516": {
-    "type": "unsupported",
-    "name": "Status Network Token on xDai"
-  },
-  "0x0811e451447d5819976a95a02f130c3b00d59346": {
-    "type": "unsupported",
-    "name": "tBTC on xDai"
-  },
-  "0x0939a7c3f8d37c1ce67fada4963ae7e0bd112ff3": {
-    "type": "unsupported",
-    "name": "VitaDAO Token from Mainnet"
-  },
-  "0x0acd91f92fe07606ab51ea97d8521e29d110fd09": {
-    "type": "unsupported",
-    "name": "Celsius on xDai"
-  },
-  "0x0b7a1c1a3d314dcc271ea576da400b24e9ad3094": {
-    "type": "unsupported",
-    "name": "Numeraire on xDai"
-  },
-  "0x0da1a02cdf84c44021671d183d616925164e08aa": {
-    "type": "unsupported",
-    "name": "Republic Token on xDai"
+  "0xff0ce179a303f26017019acf78b951cb743b8d9b": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Contribute on xDai"
   },
   "0x0dae13fae64180d3cadcad22329a4abcaef15ca6": {
     "type": "unsupported",
     "name": "SHE Sweatpants"
   },
-  "0x0dcfed2c3041e66b2d8c4ea39782c60355716316": {
-    "type": "unsupported",
-    "name": "Energi on xDai"
-  },
-  "0x10a82313a4daef47c1ab9ef2bb00b22b3b0cc14c": {
-    "type": "unsupported",
-    "name": "Wrapped XRP from Mainnet"
-  },
-  "0x10beea85519a704a63765d396415f9ea5aa30a17": {
-    "type": "unsupported",
-    "name": "PILLAR on xDai"
-  },
-  "0x12dabe79cffc1fde82fcd3b96dbe09fa4d8cd599": {
-    "type": "unsupported",
-    "name": "DAOstack on xDai"
-  },
-  "0x1319067e82f0b9981f19191e1c08bb6e6e055dd3": {
-    "type": "unsupported",
-    "name": "DeFireX DAI on xDai"
-  },
-  "0x14411aeca652f5131834bf0c8ff581b5ddf3bc03": {
-    "type": "unsupported",
-    "name": "coin_artist on xDai"
-  },
-  "0x1479ebfe327b62bff255c0749a242748d3e7347a": {
-    "type": "unsupported",
-    "name": "Darwinia Network Native Token on xDai"
-  },
   "0x1509706a6c66ca549ff0cb464de88231ddbe213b": {
     "type": "unsupported",
     "name": "Aura"
-  },
-  "0x1534fb3e82849314360c267fe20df3901a2ed3f9": {
-    "type": "unsupported",
-    "name": "Kyber Network Crystal on xDai"
-  },
-  "0x16afe6e6754fa3694afd0ce48f4bea102efacc17": {
-    "type": "unsupported",
-    "name": "Testa on xDai"
-  },
-  "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
-    "type": "unsupported",
-    "name": "CoW Protocol Token from Mainnet"
-  },
-  "0x18e9262e68cc6c6004db93105cc7c001bb103e49": {
-    "type": "unsupported",
-    "name": "Raid Guild Token ⚔️ on xDai"
-  },
-  "0x1939d3431cf0e44b1d63b86e2ce489e5a341b1bf": {
-    "type": "unsupported",
-    "name": "Cream on xDai"
-  },
-  "0x1bbca7491f14b46788ff9c834d97a668c4886523": {
-    "type": "unsupported",
-    "name": "Frontier Token on xDai"
   },
   "0x1e16aa4df73d29c029d94ceda3e3114ec191e25a": {
     "type": "unsupported",
     "name": "Moons on xDai"
   },
-  "0x1e37e5b504f7773460d6eb0e24d2e7c223b66ec7": {
-    "type": "unsupported",
-    "name": "HUSD on xDai"
-  },
-  "0x21a42669643f45bc0e086b8fc2ed70c23d67509d": {
-    "type": "unsupported",
-    "name": "FOX on xDai"
-  },
-  "0x226bcf0e417428a25012d0fa2183d37f92bcedf6": {
-    "type": "unsupported",
-    "name": "0x Protocol Token on xDai"
-  },
-  "0x22bd2a732b39dace37ae7e8f50a186f3d9702e87": {
-    "type": "unsupported",
-    "name": "Curve.fi yDAI/yUSDC/yUSDT/yTUSD on xDai"
-  },
-  "0x248c54b3fc3bc8b20d0cdee059e17c67e4a3299d": {
-    "type": "unsupported",
-    "name": "CelerToken on xDai"
-  },
-  "0x26dc03e492763068ccfe7c39b93a22442807c360": {
-    "type": "unsupported",
-    "name": "Nexo on xDai"
-  },
-  "0x26dd64bdcb2faf4f7e49a73145752e8d9cb34c94": {
-    "type": "unsupported",
-    "name": "Pundi X Token on xDai"
-  },
-  "0x270de58f54649608d316faa795a9941b355a2bd0": {
-    "type": "unsupported",
-    "name": "Freedom Reserve on xDai"
-  },
   "0x27b9c2bd4baea18abdf49169054c1c1c12af9862": {
     "type": "unsupported",
     "name": "SNAFU"
-  },
-  "0x2977893f4c04bfbd6efc68d0e46598d27810d3db": {
-    "type": "unsupported",
-    "name": "Bidao on xDai"
-  },
-  "0x2995d1317dcd4f0ab89f4ae60f3f020a4f17c7ce": {
-    "type": "unsupported",
-    "name": "SushiToken on xDai"
-  },
-  "0x2be73bfeec620aa9b67535a4d3827bb1e29436d1": {
-    "type": "unsupported",
-    "name": "LoopringCoin V2 on xDai"
   },
   "0x2bf2ba13735160624a0feae98f6ac8f70885ea61": {
     "type": "unsupported",
     "name": "Own a fraction"
   },
-  "0x2f0e755efe6b58238a67db420ff3513ec1fb31ef": {
-    "type": "unsupported",
-    "name": "Rocket Pool on xDai"
-  },
-  "0x2fd0c73ad006407f0a96c984f06a9ce8415b094e": {
-    "type": "unsupported",
-    "name": "Seed on xDai"
-  },
   "0x30610f98b61593de963b2303aeeaee69823f561f": {
     "type": "unsupported",
     "name": "Golden Bull Token on xDai"
   },
-  "0x309bc6dbcbfb9c84d26fdf65e8924367efccbdb9": {
-    "type": "unsupported",
-    "name": "OM Token on xDai"
-  },
-  "0x317eab07380d670ea814025cba40f5624354a32f": {
-    "type": "unsupported",
-    "name": "DeFiPIE Token on xDai"
-  },
-  "0x346b2968508d32f0192cd7a60ef3d9c39a3cf549": {
-    "type": "unsupported",
-    "name": "HoloToken on xDai"
-  },
-  "0x3581cc6a09de85e9b91ef93f2a5ef837706b84a5": {
-    "type": "unsupported",
-    "name": "AllianceBlock Token on xDai"
-  },
-  "0x35f346cb4149746272974a92d719fd48ae2f72fa": {
-    "type": "unsupported",
-    "name": "Unisocks Edition 0 on xDai"
-  },
-  "0x37b60f4e9a31a64ccc0024dce7d0fd07eaa0f7b3": {
-    "type": "unsupported",
-    "name": "Pinakion on xDai"
-  },
   "0x38fb649ad3d6ba1113be5f57b927053e97fc5bf7": {
     "type": "unsupported",
     "name": "xDai Native Comb"
-  },
-  "0x3a00e08544d589e19a8e7d97d0294331341cdbf6": {
-    "type": "unsupported",
-    "name": "Synthetix Network Token on xDai"
   },
   "0x3a3e9715018d80916740e8ac300713fdf6614d19": {
     "type": "unsupported",
@@ -233,26 +1000,6 @@
     "type": "unsupported",
     "name": "Agave Token"
   },
-  "0x3ae8c08cd61d05ad6e22973e4b675a92d412ee3c": {
-    "type": "unsupported",
-    "name": "Serum on xDai"
-  },
-  "0x3c037849a8ffcf19886e2f5b04f293b7847d0377": {
-    "type": "unsupported",
-    "name": "Liquid staked Ether 2.0 on xDai"
-  },
-  "0x3e33cf23073fd8d5ad1d48d1860a96c0d8e56193": {
-    "type": "unsupported",
-    "name": "Standard on xDai"
-  },
-  "0x417602f4fbdd471a431ae29fb5fe0a681964c11b": {
-    "type": "unsupported",
-    "name": "JPY Coin on xDai"
-  },
-  "0x417ae38b3053a736b4274aed8dbd1a8a6fdbc974": {
-    "type": "unsupported",
-    "name": "Rari Governance Token on xDai"
-  },
   "0x4291f029b9e7acb02d49428458cf6fceac545f81": {
     "type": "unsupported",
     "name": "Water Token"
@@ -261,89 +1008,9 @@
     "type": "unsupported",
     "name": "xREAP"
   },
-  "0x437a044fb4693890e61d2c1c88e3718e928b8e90": {
-    "type": "unsupported",
-    "name": "Aragon Network Token on xDai"
-  },
-  "0x4384a7c9498f905e433ee06b6552a18e1d7cd3a4": {
-    "type": "unsupported",
-    "name": "TrueFi on xDai"
-  },
-  "0x44b6bba599f100006143e82a60462d71ac1331da": {
-    "type": "unsupported",
-    "name": "API3 on xDai"
-  },
-  "0x44fa8e6f47987339850636f88629646662444217": {
-    "type": "unsupported",
-    "name": "Dai Stablecoin on xDai"
-  },
-  "0x4537e328bf7e4efa29d05caea260d7fe26af9d74": {
-    "type": "unsupported",
-    "name": "Uniswap on xDai"
-  },
-  "0x479e32cdff5f216f93060700c711d1cc8e811a6b": {
-    "type": "unsupported",
-    "name": "Trips on xDai"
-  },
-  "0x48b1b0d077b4919b65b4e4114806dd803901e1d9": {
-    "type": "unsupported",
-    "name": "Decentralized Insurance Protocol on xDai"
-  },
-  "0x4a88248baa5b39bb4a9caa697fb7f8ae0c3f0ddb": {
-    "type": "unsupported",
-    "name": "renBTC on xDai"
-  },
-  "0x4bc97997883c0397f556bd0f9da6fb71da22f9a2": {
-    "type": "unsupported",
-    "name": "aleph.im v2 on xDai"
-  },
-  "0x4be85acc1cd711f403dc7bde9e6cadfc5a94744b": {
-    "type": "unsupported",
-    "name": "Rarible on xDai"
-  },
-  "0x4e1a2bffe81000f7be4807faf0315173c817d6f4": {
-    "type": "unsupported",
-    "name": "Mask Network on xDai"
-  },
-  "0x4ea1172f4c4e8e8d3c9e1be4269b696bf19d24fe": {
-    "type": "unsupported",
-    "name": "SHIBA INU on xDai"
-  },
-  "0x4ecaba5870353805a9f068101a40e0f32ed605c6": {
-    "type": "unsupported",
-    "name": "Tether USD on xDai"
-  },
   "0x4ef1d9a329a0cb0658156aff55c406cc4393a987": {
     "type": "unsupported",
     "name": "Daibase xDAI v0.1.61"
-  },
-  "0x4efdfbb7cca540a79a7e4dcad1cb6ed14f21c43e": {
-    "type": "unsupported",
-    "name": "OKB on xDai"
-  },
-  "0x4f4f9b8d5b4d0dc10506e5551b0513b61fd59e75": {
-    "type": "unsupported",
-    "name": "Giveth from Mainnet"
-  },
-  "0x512a2eb0277573ae9be0d48c782590b624048fdf": {
-    "type": "unsupported",
-    "name": "MEME on xDai"
-  },
-  "0x51732a6fc4673d1acca4c047f5465922716508ad": {
-    "type": "unsupported",
-    "name": "Ocean Token on xDai"
-  },
-  "0x524b969793a64a602342d89bc2789d43a016b13a": {
-    "type": "unsupported",
-    "name": "Donut on xDai"
-  },
-  "0x532801ed6f82fffd2dab70a19fc2d7b2772c4f4b": {
-    "type": "unsupported",
-    "name": "Swapr on xDai"
-  },
-  "0x53ef00be819a062533a0e699077c621a28eaded1": {
-    "type": "unsupported",
-    "name": "PowerTrade Fuel Token on xDai"
   },
   "0x57e93bb58268de818b42e3795c97bad58afcd3fe": {
     "type": "unsupported",
@@ -352,22 +1019,6 @@
   "0x59715d8d206b3d4748cec55e7c2de26f23af45d5": {
     "type": "unsupported",
     "name": "Alvin"
-  },
-  "0x5a757f0bcadfdb78651b7bdbe67e44e8fd7f7f6b": {
-    "type": "unsupported",
-    "name": "Enjin Coin on xDai"
-  },
-  "0x5a87eac5642bfed4e354ee8738dacd298e07d1af": {
-    "type": "unsupported",
-    "name": "Reserve Rights on xDai"
-  },
-  "0x5b917d4fb9b27591353211c32f1552a527987afc": {
-    "type": "unsupported",
-    "name": "MoonToken on xDai"
-  },
-  "0x5bbfbfb123b72a255504be985bd2b474e481e866": {
-    "type": "unsupported",
-    "name": "Sora Token on xDai"
   },
   "0x5c8c83e5d5f7be815863b810d45d7bc706d7b15b": {
     "type": "unsupported",
@@ -381,361 +1032,41 @@
     "type": "unsupported",
     "name": "Token Engineering Commons"
   },
-  "0x5f2852afd20c39849f6f56f4102b8c29ee141add": {
-    "type": "unsupported",
-    "name": "renZEC on xDai"
-  },
-  "0x5fd896d248fbfa54d26855c267859eb1b4daee72": {
-    "type": "unsupported",
-    "name": "Maker on xDai"
-  },
-  "0x5fe9885226677f3eb5c9ad8ab6c421b4ea38535d": {
-    "type": "unsupported",
-    "name": "JOON on xDai"
-  },
-  "0x6062ec2a1ecfcd0026d9bd67aa5ad743adc03995": {
-    "type": "unsupported",
-    "name": "lien on xDai"
-  },
-  "0x6099280dc5fc97cbb61b456246316a1b8f79534b": {
-    "type": "unsupported",
-    "name": "Polyient Games Governance Token on xDai"
-  },
-  "0x60e668f54106222adc1da80c169281b3355b8e5d": {
-    "type": "unsupported",
-    "name": "iEx.ec Network Token on xDai"
-  },
   "0x63e62989d9eb2d37dfdb1f93a22f063635b07d51": {
     "type": "unsupported",
     "name": "Minerva Wallet SuperToken"
-  },
-  "0x64b17a95e6c45306fb23bc526eb2dc9e1331a1b1": {
-    "type": "unsupported",
-    "name": "CFX Quantum on xDai"
-  },
-  "0x699d001ef13b15335193bc5fad6cfc6747eee8be": {
-    "type": "unsupported",
-    "name": "Base Protocol on xDai"
-  },
-  "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1": {
-    "type": "unsupported",
-    "name": "Wrapped Ether on xDai"
-  },
-  "0x6a8cb6714b1ee5b471a7d2ec4302cb4f5ff25ec2": {
-    "type": "unsupported",
-    "name": "Energy Web Token Bridged on xDai"
   },
   "0x6b0f8a3fb7cb257ad7c72ada469ba1d3c19c5094": {
     "type": "unsupported",
     "name": "xdai dao"
   },
-  "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6": {
-    "type": "unsupported",
-    "name": "Wrapped liquid staked Ether 2.0 from Mainnet"
-  },
-  "0x6d237bb2248d3b40b1a54f3417667b2f39984fc8": {
-    "type": "unsupported",
-    "name": "PieDAO DOUGH v2 on xDai"
-  },
   "0x6de572faa138048ce8142c4a206eb09a8ec39e45": {
     "type": "unsupported",
     "name": "Humans of Gnosis"
-  },
-  "0x6eeceab954efdbd7a8a8d9387bc719959b04b9ca": {
-    "type": "unsupported",
-    "name": "Aragon Network Token on xDai"
-  },
-  "0x6f09cf96558d44584db07f8477dd3490599aa63e": {
-    "type": "unsupported",
-    "name": "Bitgear on xDai"
-  },
-  "0x703120f2f2011a0d03a03a531ac0e84e81f15989": {
-    "type": "unsupported",
-    "name": "UNCL on xDai"
-  },
-  "0x7122d7661c4564b7c6cd4878b06766489a6028a2": {
-    "type": "unsupported",
-    "name": "Matic Token on xDai"
-  },
-  "0x712b3d230f3c1c19db860d80619288b1f0bdd0bd": {
-    "type": "unsupported",
-    "name": "Curve DAO Token on xDai"
   },
   "0x71850b7e9ee3f13ab46d67167341e4bdc905eef9": {
     "type": "unsupported",
     "name": "Honey"
   },
-  "0x743a991365ba94bfc90ad0002cad433c7a33cb4a": {
-    "type": "unsupported",
-    "name": "AirSwap Token on xDai"
-  },
-  "0x75481a953a4bba6b3c445907db403e4b5d222174": {
-    "type": "unsupported",
-    "name": "PolkastarterToken on xDai"
-  },
-  "0x75886f00c1a20ec1511111fb4ec3c51de65b1fe7": {
-    "type": "unsupported",
-    "name": "FTT on xDai"
-  },
-  "0x76eafffa1873a8acd43864b66a728bd873c5e08a": {
-    "type": "unsupported",
-    "name": "SwissBorg Token on xDai"
-  },
-  "0x778aa03021b0cd2b798b0b506403e070125d81c9": {
-    "type": "unsupported",
-    "name": "BlackDragon Token on xDai"
-  },
-  "0x7838796b6802b18d7ef58fc8b757705d6c9d12b3": {
-    "type": "unsupported",
-    "name": "Decentraland MANA on xDai"
-  },
-  "0x79cf2029717e2e78c8927f65f079ab8da21781ee": {
-    "type": "unsupported",
-    "name": "LUKSO Token on xDai"
-  },
-  "0x7a7d81657a1a66b38a6ca2565433a9873c6913b2": {
-    "type": "unsupported",
-    "name": "Enigma on xDai"
-  },
-  "0x7c16c63684d86bacc52e8793b08a5a1a3cb1ba1e": {
-    "type": "unsupported",
-    "name": "Davincij15 Token on xDai"
-  },
-  "0x7da0bfe9d26c5b64c7580c04bb1425364273e4b0": {
-    "type": "unsupported",
-    "name": "Concentrated Voting Power on xDai"
-  },
-  "0x7db0be7a41b5395268e065776e800e27181c81ab": {
-    "type": "unsupported",
-    "name": "Livepeer Token on xDai"
-  },
-  "0x7ea8af7301b763451b7fb25f8fc2406819a7e36f": {
-    "type": "unsupported",
-    "name": "Phala on xDai"
-  },
-  "0x7ecf26cd9a36990b8ea477853663092333f59979": {
-    "type": "unsupported",
-    "name": "Perpetual on xDai"
-  },
-  "0x7ef541e2a22058048904fe5744f9c7e4c57af717": {
-    "type": "unsupported",
-    "name": "Balancer on xDai"
-  },
-  "0x7f7440c5098462f833e123b44b8a03e1d9785bab": {
-    "type": "unsupported",
-    "name": "1INCH Token on xDai"
-  },
-  "0x82dfe19164729949fd66da1a37bc70dd6c4746ce": {
-    "type": "unsupported",
-    "name": "BaoToken on xDai"
-  },
-  "0x8395f7123ba3ffad52e7414433d825931c81c879": {
-    "type": "unsupported",
-    "name": "OMGToken on xDai"
-  },
-  "0x83ff60e2f93f8edd0637ef669c69d5fb4f64ca8e": {
-    "type": "unsupported",
-    "name": "Bright on xDai"
-  },
-  "0x860182180e146300df38aab8d328c6e80bec9547": {
-    "type": "unsupported",
-    "name": "UniTrade on xDai"
-  },
-  "0x8a95ea379e1fa4c749dd0a7a21377162028c479e": {
-    "type": "unsupported",
-    "name": "Audius on xDai"
-  },
-  "0x8c88ea1fd60462ef7004b9e288afcb4680a3c50c": {
-    "type": "unsupported",
-    "name": "0xMonero on xDai"
-  },
-  "0x8d02b73904856de6998ffdf6e7ee18cc21137a79": {
-    "type": "unsupported",
-    "name": "MetaFactory on xDai"
-  },
-  "0x8e1a12da00bbf9db10d48bd66ff818be933964d5": {
-    "type": "unsupported",
-    "name": "NFTX on xDai"
-  },
-  "0x8e5bbbb09ed1ebde8674cda39a0c169401db4252": {
-    "type": "unsupported",
-    "name": "Wrapped BTC on xDai"
-  },
-  "0x8e7ab03ca7d17996b097d5866bfaa1e251c35c6a": {
-    "type": "unsupported",
-    "name": "Unit Protocol on xDai"
-  },
-  "0x8f365b41b98fe84acb287540b4b4ab633e07edb2": {
-    "type": "unsupported",
-    "name": "Synth sETH on xDai"
-  },
-  "0x8fbedd16904b561e30ea402f459900e9d90614af": {
-    "type": "unsupported",
-    "name": "Unilayer on xDai"
-  },
-  "0x915742cb77124761015f63e079089ad0eff1b57c": {
-    "type": "unsupported",
-    "name": "decentral.games on xDai"
-  },
-  "0x921557ac88f770aab08eef6ac32106f00c7a5e72": {
-    "type": "unsupported",
-    "name": "Prime from Mainnet"
-  },
-  "0x97edc0e345fbbbd8460847fcfa3bc2a13bf8641f": {
-    "type": "unsupported",
-    "name": "DAOSquare Governance Token on xDai"
-  },
-  "0x981fb9ba94078a2275a8fc906898ea107b9462a8": {
-    "type": "unsupported",
-    "name": "Panvala pan on xDai"
-  },
-  "0x985e144eb355273c4b4d51e448b68b657f482e26": {
-    "type": "unsupported",
-    "name": "POA ERC20 on Foundation on xDai"
-  },
-  "0x9a495a281d959192343b0e007284bf130bd05f86": {
-    "type": "unsupported",
-    "name": "Bancor Network Token on xDai"
-  },
-  "0x9bd5e0ce813d5172859b0b70ff7bb3c325cee913": {
-    "type": "unsupported",
-    "name": "Ethereum Meta on xDai"
-  },
-  "0x9c58bacc331c9aa871afd802db6379a98e80cedb": {
-    "type": "unsupported",
-    "name": "Gnosis Token on xDai"
-  },
   "0xa106739de31fa7a9df4a93c9bea3e1bade0924e2": {
     "type": "unsupported",
     "name": "FreeToken"
-  },
-  "0xa2fec95b3d3fecb39098e81f108533e1abf22ccf": {
-    "type": "unsupported",
-    "name": "Yield on xDai"
-  },
-  "0xa9e5cd4efc86c01fae9a9fcd6e8669b97c92a937": {
-    "type": "unsupported",
-    "name": "prophet.finance on xDai"
-  },
-  "0xaad66432d27737ecf6ed183160adc5ef36ab99f2": {
-    "type": "unsupported",
-    "name": "Tellor Tributes from Mainnet"
-  },
-  "0xabef652195f98a91e490f047a5006b71c85f058d": {
-    "type": "unsupported",
-    "name": "Curve.Fi USD Stablecoin from Mainnet"
-  },
-  "0xad601530859513371fa107ae6a7e18e08d69f155": {
-    "type": "unsupported",
-    "name": "Hakka Finance on xDai"
-  },
-  "0xb0c5f3100a4d9d9532a4cfd68c55f1ae8da987eb": {
-    "type": "unsupported",
-    "name": "DAOhaus Token on xDai"
   },
   "0xb17d999e840e0c1b157ca5ab8039bd958b5fa317": {
     "type": "unsupported",
     "name": "Wrapped ETHO"
   },
-  "0xb1950fb2c9c0cbc8553578c67db52aa110a93393": {
-    "type": "unsupported",
-    "name": "Synth sUSD on xDai"
-  },
   "0xb2ae7983a8142401d45546aab981e5fbff520991": {
     "type": "unsupported",
     "name": "BTCCB"
-  },
-  "0xb31a2595e4cf66efbc1fe348b1429e5730891382": {
-    "type": "unsupported",
-    "name": "BarnBridge Governance Token on xDai"
-  },
-  "0xb4b6f80d8e573e9867c90163bfdb00e29d92716a": {
-    "type": "unsupported",
-    "name": "Metronome on xDai"
   },
   "0xb5d592f85ab2d955c25720ebe6ff8d4d1e1be300": {
     "type": "unsupported",
     "name": "Particle"
   },
-  "0xb714654e905edad1ca1940b7790a8239ece5a9ff": {
-    "type": "unsupported",
-    "name": "TrueUSD on xDai"
-  },
-  "0xb7d311e2eb55f2f68a9440da38e7989210b9a05e": {
-    "type": "unsupported",
-    "name": "STAKE on xDai"
-  },
-  "0xb90d6bec20993be5d72a5ab353343f7a0281f158": {
-    "type": "unsupported",
-    "name": "DXdao on xDai"
-  },
-  "0xbab3cbdcbcc578445480a79ed80269c50bb5b718": {
-    "type": "unsupported",
-    "name": "MEDOOZA Ecosystem v2.0 on xDai"
-  },
-  "0xbc650b9cc12db4da14b2417c60ccd6f4d77c3998": {
-    "type": "unsupported",
-    "name": "StorjToken on xDai"
-  },
-  "0xbcfb2b889f7baa29dd7a7b447b6c87aca572f4f4": {
-    "type": "unsupported",
-    "name": "Aave Interest bearing DAI on xDai"
-  },
-  "0xbdb90bdadae84af0b07abf4cefcc7989f909f9bd": {
-    "type": "unsupported",
-    "name": "bns.finance on xDai"
-  },
-  "0xbde011911128f6bd4abb1d18f39fdc3614ca2cfe": {
-    "type": "unsupported",
-    "name": "Axie Infinity Shard on xDai"
-  },
-  "0xbf65bfcb5da067446cee6a706ba3fe2fb1a9fdfd": {
-    "type": "unsupported",
-    "name": "yearn.finance on xDai"
-  },
-  "0xc12956b840b403b600014a3092f6ebd9259738fe": {
-    "type": "unsupported",
-    "name": "SURF.Finance on xDai"
-  },
-  "0xc1b42bdb485deb24c74f58399288d7915a726c1d": {
-    "type": "unsupported",
-    "name": "EthLend Token on xDai"
-  },
   "0xc25af3123d2420054c8fcd144c21113aa2853f39": {
     "type": "unsupported",
     "name": "Xion Global Token"
-  },
-  "0xc439e5b1dee4f866b681e7c5e5df140aa47fbf19": {
-    "type": "unsupported",
-    "name": "Dai Stablecoin v1.0 on xDai"
-  },
-  "0xc45b3c1c24d5f54e7a2cf288ac668c74dd507a84": {
-    "type": "unsupported",
-    "name": "Symmetric on xDai"
-  },
-  "0xc577cddabb7893cc2ca15ef4b5d5e5e13c3feed3": {
-    "type": "unsupported",
-    "name": "McDonaldsCoin on xDai"
-  },
-  "0xc60e38c6352875c051b481cbe79dd0383adb7817": {
-    "type": "unsupported",
-    "name": "DAppNode DAO Token on xDai"
-  },
-  "0xc6cc63f4aa25bbd4453eb5f3a0dfe546fef9b2f3": {
-    "type": "unsupported",
-    "name": "Basic Attention Token on xDai"
-  },
-  "0xc81c785653d97766b995d867cf91f56367742eac": {
-    "type": "unsupported",
-    "name": "AriesFinancial on xDai"
-  },
-  "0xc84dd5b971521b6c9fa5e10d25e6428b19710e05": {
-    "type": "unsupported",
-    "name": "Ampleforth on xDai"
-  },
-  "0xc9b6218affe8aba68a13899cbf7cf7f14ddd304c": {
-    "type": "unsupported",
-    "name": "Colony Network Token on xDai"
   },
   "0xcb444e90d8198415266c6a2724b7900fb12fc56e": {
     "type": "unsupported",
@@ -745,168 +1076,24 @@
     "type": "unsupported",
     "name": "MORPHINE"
   },
-  "0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f": {
-    "type": "unsupported",
-    "name": "Autonolas from Mainnet"
-  },
-  "0xcf9dc2de2a67d7db1a7171e3b8456d2171e4da75": {
-    "type": "unsupported",
-    "name": "Layer 2 Index on xDai"
-  },
-  "0xd057604a14982fe8d88c5fc25aac3267ea142a08": {
-    "type": "unsupported",
-    "name": "HOPR Token on xDai"
-  },
-  "0xd27e1ecc4748f42e052331bea917d89beb883fc3": {
-    "type": "unsupported",
-    "name": "Akropolis on xDai"
-  },
-  "0xd361c1fd663d8f2dc36ae07ff6f3623532cabdd3": {
-    "type": "unsupported",
-    "name": "MCDEX Token on xDai"
-  },
-  "0xd3b93ff74e43ba9568e5019b38addb804fef719b": {
-    "type": "unsupported",
-    "name": "UniBright on xDai"
-  },
-  "0xd3d47d5578e55c880505dc40648f7f9307c3e7a8": {
-    "type": "unsupported",
-    "name": "DefiPulse Index on xDai"
-  },
   "0xd4fdec44db9d44b8f2b6d529620f9c0c7066a2c1": {
     "type": "unsupported",
     "name": "Wrapped xHOPR Token"
-  },
-  "0xd51e1ddd116fff9a71c1b8feeb58113afa2b4d93": {
-    "type": "unsupported",
-    "name": "AMIS on xDai"
-  },
-  "0xd87eaa26dcfb0c0a6160ccf8c8a01beb1c15fb00": {
-    "type": "unsupported",
-    "name": "Flex Ungovernance Token from Mainnet"
-  },
-  "0xd9fa47e33d4ff7a1aca489de1865ac36c042b07a": {
-    "type": "unsupported",
-    "name": "HEX on xDai"
   },
   "0xdbcade285846131a5e7384685eaddbdfd9625557": {
     "type": "unsupported",
     "name": "COLD TRUTH CASH"
   },
-  "0xdbf3ea6f5bee45c02255b2c26a16f300502f68da": {
-    "type": "unsupported",
-    "name": "BZZ on xDai"
-  },
-  "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83": {
-    "type": "unsupported",
-    "name": "USD//C on xDai"
-  },
-  "0xde1e70ed71936e4c249a7d43e550f0b99fccddfc": {
-    "type": "unsupported",
-    "name": "FalconSwap Token on xDai"
-  },
-  "0xdf613af6b44a31299e48131e9347f034347e2f00": {
-    "type": "unsupported",
-    "name": "Aave Token on xDai"
-  },
-  "0xdf6ff92bfdc1e8be45177dc1f4845d391d3ad8fd": {
-    "type": "unsupported",
-    "name": "Compound on xDai"
-  },
-  "0xdfc20ae04ed70bd9c7d720f449eedae19f659d65": {
-    "type": "unsupported",
-    "name": "Badger on xDai"
-  },
-  "0xe0cf6c7ed5ca334bd39f86366defbc3fc6dbbcab": {
-    "type": "unsupported",
-    "name": "Coinbase Wrapped Staked ETH from Mainnet"
-  },
   "0xe0d0b1dbbcf3dd5cac67edaf9243863fd70745da": {
     "type": "unsupported",
     "name": "Baocx Token"
-  },
-  "0xe154a435408211ac89757b76c4fbe4dc9ed2ef27": {
-    "type": "unsupported",
-    "name": "BandToken on xDai"
-  },
-  "0xe2e73a1c69ecf83f464efce6a5be353a37ca09b2": {
-    "type": "unsupported",
-    "name": "ChainLink Token on xDai"
-  },
-  "0xe6a1f98b0f4368559bd16639c844510f5db6fe48": {
-    "type": "unsupported",
-    "name": "bZx Protocol Token on xDai"
-  },
-  "0xe6ff35dc3227a0c46e92b640bcb5c5895ad8c687": {
-    "type": "unsupported",
-    "name": "The 4th Pillar Token on xDai"
-  },
-  "0xe746a0476b833f2fa658e2b549dcfa5abbb9c3c9": {
-    "type": "unsupported",
-    "name": "Bincentive Token from Mainnet"
-  },
-  "0xe7ef58d8180cc269c6620ded3e6cc536a52e2ebd": {
-    "type": "unsupported",
-    "name": "BlockMesh on xDai"
   },
   "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d": {
     "type": "unsupported",
     "name": "Wrapped XDAI"
   },
-  "0xe959db3c04376b017b37c95618bbaeb59f51abba": {
-    "type": "unsupported",
-    "name": "Mai Stablecoin from Mainnet"
-  },
-  "0xeaacce3e5bcc10fb32c2553f8d6fc4c3888ffdad": {
-    "type": "unsupported",
-    "name": "TrustSwap Token on xDai"
-  },
-  "0xeb2bcabb0cdc099978a74cfe4ab4d45e7e677a45": {
-    "type": "unsupported",
-    "name": "Terra Virtua Kolect on xDai"
-  },
-  "0xec3f3e6d7907acda3a7431abd230196cda3fbb19": {
-    "type": "unsupported",
-    "name": "Ethix on xDai"
-  },
-  "0xec84a3bb48d70553c2599ac2d0db07b2dfdf6364": {
-    "type": "unsupported",
-    "name": "BNS Token on xDai"
-  },
-  "0xeddd81e0792e764501aae206eb432399a0268db5": {
-    "type": "unsupported",
-    "name": "Trace Token on xDai"
-  },
-  "0xf54b47b00b6916974c73b81b7d9929a4f443db49": {
-    "type": "unsupported",
-    "name": "Robonomics on xDai"
-  },
-  "0xf99efeb34aff6d3099c41605e9ee778caec39317": {
-    "type": "unsupported",
-    "name": "Meridian Network on xDai"
-  },
   "0xfa57aa7beed63d03aaf85ffd1753f5f6242588fb": {
     "type": "unsupported",
     "name": "MtPelerin Shares"
-  },
-  "0xfadc59d012ba3c110b08a15b7755a5cb7cbe77d7": {
-    "type": "unsupported",
-    "name": "Graph Token on xDai"
-  },
-  "0xfb23cfd35046466fdba7f73dc2fccb5b17abf1aa": {
-    "type": "unsupported",
-    "name": "AlbCoin on xDai"
-  },
-  "0xfd4e5f45ea24ec50c4db4367380b014875caf219": {
-    "type": "unsupported",
-    "name": "XY Oracle on xDai"
-  },
-  "0xfe7ed09c4956f7cdb54ec4ffcb9818db2d7025b8": {
-    "type": "unsupported",
-    "name": "USDP Stablecoin on xDai"
-  },
-  "0xff0ce179a303f26017019acf78b951cb743b8d9b": {
-    "type": "unsupported",
-    "name": "Contribute on xDai"
   }
 }

--- a/src/public/PermitInfo.100.json
+++ b/src/public/PermitInfo.100.json
@@ -4,6 +4,11 @@
     "version": "1",
     "name": "UniCrypt on xDai"
   },
+  "0x012e2cafebc30a603c049159d946c9d344d979a8": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Ethereum Name Service from Mainnet"
+  },
   "0x01e92e3791f8c1d6599b2f80a4bff9b43949ac7c": {
     "type": "eip-2612",
     "version": "1",
@@ -13,6 +18,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "VectorspaceAI on xDai"
+  },
+  "0x03959ac65e621e8c95d5e0f75ea96e5c03a15009": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "ROOK on xDai"
   },
   "0x044f6ae3aef34fdb8fddc7c05f9cc17f19acd516": {
     "type": "eip-2612",
@@ -28,6 +38,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "VitaDAO Token from Mainnet"
+  },
+  "0x0987c6b9357dee87404dfea0483c337de530be5a": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Axie Infinity Shard on xDai"
   },
   "0x0acd91f92fe07606ab51ea97d8521e29d110fd09": {
     "type": "eip-2612",
@@ -49,6 +64,11 @@
     "version": "1",
     "name": "Energi on xDai"
   },
+  "0x0e9f346de9780fb966eeb763aa89d254d606b9d8": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Wootrade Network on xDai"
+  },
   "0x10a82313a4daef47c1ab9ef2bb00b22b3b0cc14c": {
     "type": "eip-2612",
     "version": "1",
@@ -69,6 +89,11 @@
     "version": "1",
     "name": "DeFireX DAI on xDai"
   },
+  "0x1326f053e2452e73c66f38914fb338c8de331684": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Wrapped MIR Token on xDai"
+  },
   "0x14411aeca652f5131834bf0c8ff581b5ddf3bc03": {
     "type": "eip-2612",
     "version": "1",
@@ -78,6 +103,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "Darwinia Network Native Token on xDai"
+  },
+  "0x1509465afbd36c09b2f6501bcc1384a12ef22d66": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "KEEP Token on xDai"
   },
   "0x1534fb3e82849314360c267fe20df3901a2ed3f9": {
     "type": "eip-2612",
@@ -134,6 +164,11 @@
     "version": "1",
     "name": "CelerToken on xDai"
   },
+  "0x260b0cc1de83e4f8db8361e81acf73d1f597a695": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Amp on xDai"
+  },
   "0x26dc03e492763068ccfe7c39b93a22442807c360": {
     "type": "eip-2612",
     "version": "1",
@@ -148,6 +183,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "Freedom Reserve on xDai"
+  },
+  "0x2853f6e9605419ccf38d102fb1fb3961904ae263": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Gitcoin from Mainnet"
   },
   "0x2977893f4c04bfbd6efc68d0e46598d27810d3db": {
     "type": "eip-2612",
@@ -223,6 +263,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "Standard on xDai"
+  },
+  "0x3e76f9caaf9b47089810b4579c598228735e7a11": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Paxos Gold from Mainnet"
   },
   "0x417602f4fbdd471a431ae29fb5fe0a681964c11b": {
     "type": "eip-2612",
@@ -339,6 +384,21 @@
     "version": "1",
     "name": "PowerTrade Fuel Token on xDai"
   },
+  "0x54e4cb2a4fa0ee46e3d9a98d13bea119666e09f6": {
+    "type": "eip-2612",
+    "version": "2",
+    "name": "Bridged EURC (Gnosis)"
+  },
+  "0x55b6228758fcdb9135db500bc184473ad5fccd98": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "agEUR from Mainnet"
+  },
+  "0x5806212bec491beb309e3f5c1f911eac6f24cd6b": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "UMA Voting Token v1 on xDai"
+  },
   "0x5a757f0bcadfdb78651b7bdbe67e44e8fd7f7f6b": {
     "type": "eip-2612",
     "version": "1",
@@ -348,6 +408,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "Reserve Rights on xDai"
+  },
+  "0x5b449ea0e550c143074146abc89a6328d9e70798": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Keep3rV1 on xDai"
   },
   "0x5b917d4fb9b27591353211c32f1552a527987afc": {
     "type": "eip-2612",
@@ -374,6 +439,11 @@
     "version": "1",
     "name": "JOON on xDai"
   },
+  "0x6052245ec516d0f653794052d24efca8a39fcbc3": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Index on xDai"
+  },
   "0x6062ec2a1ecfcd0026d9bd67aa5ad743adc03995": {
     "type": "eip-2612",
     "version": "1",
@@ -384,15 +454,30 @@
     "version": "1",
     "name": "Polyient Games Governance Token on xDai"
   },
+  "0x60e663eb97bd747566bad4fb736ddc671fabbe95": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "NuCypher on xDai"
+  },
   "0x60e668f54106222adc1da80c169281b3355b8e5d": {
     "type": "eip-2612",
     "version": "1",
     "name": "iEx.ec Network Token on xDai"
   },
+  "0x62d963c32cf49215948e2855529790e7f41bda71": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "CircuitsOfValue on xDai"
+  },
   "0x64b17a95e6c45306fb23bc526eb2dc9e1331a1b1": {
     "type": "eip-2612",
     "version": "1",
     "name": "CFX Quantum on xDai"
+  },
+  "0x679922d1edca00d2f41ec9aeb023ccc1d58d045f": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Ampleforth Governance on xDai"
   },
   "0x699d001ef13b15335193bc5fad6cfc6747eee8be": {
     "type": "eip-2612",
@@ -449,6 +534,11 @@
     "version": "1",
     "name": "Curve DAO Token on xDai"
   },
+  "0x7300aafc0ef0d47daeb850f8b6a1931b40acab33": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "mStable USD on xDai"
+  },
   "0x743a991365ba94bfc90ad0002cad433c7a33cb4a": {
     "type": "eip-2612",
     "version": "1",
@@ -463,6 +553,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "FTT on xDai"
+  },
+  "0x7671cbe4320c0772c00b5ce157ac94b936cb083f": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Muse on xDai"
   },
   "0x76eafffa1873a8acd43864b66a728bd873c5e08a": {
     "type": "eip-2612",
@@ -494,6 +589,11 @@
     "version": "1",
     "name": "Davincij15 Token on xDai"
   },
+  "0x7cc4d60a3c83e91d8c2ec2127a10bab5c6ab209d": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Swipe on xDai"
+  },
   "0x7da0bfe9d26c5b64c7580c04bb1425364273e4b0": {
     "type": "eip-2612",
     "version": "1",
@@ -503,6 +603,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "Livepeer Token on xDai"
+  },
+  "0x7e40559c80e0512e75fba5e0ce80fc4d54174bb4": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "SUKU on xDai"
   },
   "0x7ea8af7301b763451b7fb25f8fc2406819a7e36f": {
     "type": "eip-2612",
@@ -543,6 +648,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "UniTrade on xDai"
+  },
+  "0x874623a3e613b43efa4dcc2cb04a03da1442db6c": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Reputation on xDai"
   },
   "0x8a95ea379e1fa4c749dd0a7a21377162028c479e": {
     "type": "eip-2612",
@@ -589,10 +699,20 @@
     "version": "1",
     "name": "decentral.games on xDai"
   },
+  "0x91c22f57df810d541239fbb262afb36cef2814c5": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Rally from Mainnet"
+  },
   "0x921557ac88f770aab08eef6ac32106f00c7a5e72": {
     "type": "eip-2612",
     "version": "1",
     "name": "Prime from Mainnet"
+  },
+  "0x96e334926454cd4b7b4efb8a8fcb650a738ad244": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Lido DAO Token on xDai"
   },
   "0x97edc0e345fbbbd8460847fcfa3bc2a13bf8641f": {
     "type": "eip-2612",
@@ -634,6 +754,11 @@
     "version": "1",
     "name": "StakeWise Staked GNO"
   },
+  "0xa83eca53705f21a99e9de9eedddf2d1d9a5593c4": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "district0x Network Token on xDai"
+  },
   "0xa9e5cd4efc86c01fae9a9fcd6e8669b97c92a937": {
     "type": "eip-2612",
     "version": "1",
@@ -659,6 +784,11 @@
     "version": "1",
     "name": "Savings xDAI"
   },
+  "0xaf4d17a2077e1de12de66a44de1b4f14c120d32d": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "MATH Token on xDai"
+  },
   "0xb0c5f3100a4d9d9532a4cfd68c55f1ae8da987eb": {
     "type": "eip-2612",
     "version": "1",
@@ -673,6 +803,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "BarnBridge Governance Token on xDai"
+  },
+  "0xb4698f7fc287eef3e70a6206110d5c4a367a0e59": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "SuperRare from Mainnet"
   },
   "0xb4b6f80d8e573e9867c90163bfdb00e29d92716a": {
     "type": "eip-2612",
@@ -779,6 +914,11 @@
     "version": "1",
     "name": "Colony Network Token on xDai"
   },
+  "0xca5d82e40081f220d59f7ed9e2e1428deaf55355": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Frax on xDai"
+  },
   "0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f": {
     "type": "eip-2612",
     "version": "1",
@@ -818,6 +958,16 @@
     "type": "eip-2612",
     "version": "1",
     "name": "AMIS on xDai"
+  },
+  "0xd5fe5f651dde69f6fc444d123f2c0cfb804542cd": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Binance USD on xDai"
+  },
+  "0xd7a28aa9c470e7e9d8c676bcd5dd2f40c5683afa": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Rai Reflex Index from Mainnet"
   },
   "0xd87eaa26dcfb0c0a6160ccf8c8a01beb1c15fb00": {
     "type": "eip-2612",
@@ -884,6 +1034,11 @@
     "version": "1",
     "name": "The 4th Pillar Token on xDai"
   },
+  "0xe73d646157765f8b8b8f28506df0c99178256fb9": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Injective Token on xDai"
+  },
   "0xe746a0476b833f2fa658e2b549dcfa5abbb9c3c9": {
     "type": "eip-2612",
     "version": "1",
@@ -893,6 +1048,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "BlockMesh on xDai"
+  },
+  "0xe7f0cfc2043b8872f35dbef4ebf6eea41a8b2bbe": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "SKALE from Mainnet"
   },
   "0xe959db3c04376b017b37c95618bbaeb59f51abba": {
     "type": "eip-2612",
@@ -924,6 +1084,16 @@
     "version": "1",
     "name": "Trace Token on xDai"
   },
+  "0xeefea398213938ba56b1c5d282187862c9ca5d0d": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Fantom Token from Mainnet"
+  },
+  "0xf0dd817ff483535f4059781441596aea4f32a4b9": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "Melon Token on xDai"
+  },
   "0xf54b47b00b6916974c73b81b7d9929a4f443db49": {
     "type": "eip-2612",
     "version": "1",
@@ -948,6 +1118,11 @@
     "type": "eip-2612",
     "version": "1",
     "name": "DeHive.finance"
+  },
+  "0xfcb0320d0ce08536a58495b75bf4262e4acc04af": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "JasmyCoin on xDai"
   },
   "0xfd4e5f45ea24ec50c4db4367380b014875caf219": {
     "type": "eip-2612",

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,10 +73,10 @@
     graphql-request "^4.3.0"
     limiter "^2.1.0"
 
-"@cowprotocol/permit-utils@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/@cowprotocol/permit-utils/-/permit-utils-0.1.2.tgz"
-  integrity sha512-ueqte15EkyULKViGRsQDnlWA8+1UjIhsd6SlXW0haPO0rxvJgUShgmLy/zVevX3yCLP3pVTeMfeOpSsUEu3huw==
+"@cowprotocol/permit-utils@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/permit-utils/-/permit-utils-0.2.0.tgz#9ddf042600be4fa7c2b632203904ab2cedc73349"
+  integrity sha512-ZbVnfO/znEyAw6MkOvXdFbIAebiaiT1a3bg9kKOoXUBfNMlhbp8+QX0FPdCRWD2mMsSd0lSyP/4UbfYg9zFJeQ==
   dependencies:
     "@1inch/permit-signed-approvals-utils" "^1.4.10"
     "@cowprotocol/app-data" "^1.1.0"


### PR DESCRIPTION
# Summary

Re-ran the permit script on gnosis chain (from https://github.com/cowprotocol/cowswap/pull/4152) and found a few more supported tokens

Basically, any token bridged from mainnet should be supported now.

Other networks did not yield any new token.