### PR TITLE
Use public gateway

### DIFF
--- a/src/public/ArbitrumOneCoingeckoTokensList.json
+++ b/src/public/ArbitrumOneCoingeckoTokensList.json
@@ -3,7 +3,7 @@
   "timestamp": "2024-05-24T13:35:46.782Z",
   "version": {
     "major": 0,
-    "minor": 7,
+    "minor": 8,
     "patch": 0
   },
   "logoURI": "https://support.coingecko.com/hc/article_attachments/4499575478169/CoinGecko_logo.png",

--- a/src/public/ArbitrumOneCoingeckoTokensList.json
+++ b/src/public/ArbitrumOneCoingeckoTokensList.json
@@ -19,7 +19,7 @@
       "name": "USDe",
       "symbol": "USDe",
       "decimals": 18,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/usde.svg"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/usde.svg"
     },
     {
       "chainId": 42161,
@@ -162,7 +162,7 @@
       "chainId": 42161,
       "name": "Wrapped eETH",
       "symbol": "weETH",
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/weeth.png",
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/weeth.png",
       "decimals": 18,
       "address": "0x35751007a407ca6feffe80b3cb397736d2cf4dbe",
       "extensions": {}
@@ -180,7 +180,7 @@
       "chainId": 42161,
       "name": "Renzo Restaked ETH",
       "symbol": "ezETH",
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/ezeth.png",
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/ezeth.png",
       "decimals": 18,
       "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
       "extensions": {}
@@ -207,7 +207,7 @@
       "name": "TIA",
       "symbol": "TIA.n",
       "decimals": 6,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/tia.png"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/tia.png"
     },
     {
       "chainId": 42161,
@@ -330,7 +330,7 @@
       "name": "Premia",
       "symbol": "PREMIA",
       "decimals": 18,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/premia.jpg"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/premia.jpg"
     },
     {
       "chainId": 42161,
@@ -359,7 +359,7 @@
       "name": "D2",
       "symbol": "D2",
       "decimals": 18,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/d2.jpg"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/d2.jpg"
     },
     {
       "chainId": 42161,
@@ -404,7 +404,7 @@
       "name": "Factor",
       "symbol": "FCTR",
       "decimals": 18,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/fctr.jpg"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/fctr.jpg"
     },
     {
       "chainId": 42161,
@@ -412,7 +412,7 @@
       "name": "Penpie Token",
       "symbol": "PNP",
       "decimals": 18,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/pnp.jpg"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/pnp.jpg"
     },
     {
       "chainId": 42161,

--- a/src/public/ArbitrumOneUniswapTokensList.json
+++ b/src/public/ArbitrumOneUniswapTokensList.json
@@ -19,7 +19,7 @@
       "name": "USDe",
       "symbol": "USDe",
       "decimals": 18,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/usde.svg"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/usde.svg"
     },
     {
       "chainId": 42161,
@@ -201,7 +201,7 @@
       "name": "TIA",
       "symbol": "TIA.n",
       "decimals": 6,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/tia.png"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/tia.png"
     },
     {
       "chainId": 42161,
@@ -321,7 +321,7 @@
       "name": "Premia",
       "symbol": "PREMIA",
       "decimals": 18,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/premia.jpg"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/premia.jpg"
     },
     {
       "chainId": 42161,
@@ -350,7 +350,7 @@
       "name": "D2",
       "symbol": "D2",
       "decimals": 18,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/d2.jpg"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/d2.jpg"
     },
     {
       "chainId": 42161,
@@ -393,7 +393,7 @@
       "name": "Factor",
       "symbol": "FCTR",
       "decimals": 18,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/fctr.jpg"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/fctr.jpg"
     },
     {
       "chainId": 42161,
@@ -401,7 +401,7 @@
       "name": "Penpie Token",
       "symbol": "PNP",
       "decimals": 18,
-      "logoURI": "https://ipfs.cow.fi/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/pnp.jpg"
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/pnp.jpg"
     },
     {
       "chainId": 42161,

--- a/src/public/ArbitrumOneUniswapTokensList.json
+++ b/src/public/ArbitrumOneUniswapTokensList.json
@@ -3,7 +3,7 @@
   "timestamp": "2024-04-29T18:27:01.188Z",
   "version": {
     "major": 11,
-    "minor": 22,
+    "minor": 23,
     "patch": 0
   },
   "tags": {},

--- a/src/public/CoinGecko.json
+++ b/src/public/CoinGecko.json
@@ -3,7 +3,7 @@
   "timestamp": "2024-05-24T13:35:46.782Z",
   "version": {
     "major": 0,
-    "minor": 7,
+    "minor": 8,
     "patch": 0
   },
   "logoURI": "https://support.coingecko.com/hc/article_attachments/4499575478169/CoinGecko_logo.png",

--- a/src/public/GnosisUniswapTokensList.json
+++ b/src/public/GnosisUniswapTokensList.json
@@ -3,7 +3,7 @@
   "timestamp": "2024-04-29T18:27:01.188Z",
   "version": {
     "major": 11,
-    "minor": 22,
+    "minor": 23,
     "patch": 0
   },
   "tags": {},


### PR DESCRIPTION
Pinata wants currently a token we don't want to expose, so I'm using a public gateway instead for the images

## Test

Add this to CoW Swap lists (manage lists in your token selector)
https://raw.githubusercontent.com/cowprotocol/token-lists/c559c11c0489dedd7e4d1bb7bff1e7caff12fc5b/src/public/ArbitrumOneCoingeckoTokensList.json

Search for one of the tokens with images fixed 
<img width="738" alt="image" src="https://github.com/cowprotocol/token-lists/assets/2352112/2c3e1fb2-7252-47f4-be61-799f647431b7">
