### PR TITLE
fix: only consider an update when token address and chainId match

### DIFF
--- a/src/scripts/workflow_helper.py
+++ b/src/scripts/workflow_helper.py
@@ -1,7 +1,6 @@
-import sys
 import json
 import os
-
+import sys
 
 LIST_PATH = os.environ["LIST_PATH"]
 
@@ -12,7 +11,7 @@ def handle_add_update_token(data):
 
         for token in token_list["tokens"]:
             # update
-            if token["address"].lower() == data["address"].lower():
+            if token["address"].lower() == data["address"].lower() and token["chainId"] == int(data["chainId"]):
                 token["address"] = data["address"].lower()
                 token["symbol"] = data["symbol"]
                 token["name"] = data["name"]


### PR DESCRIPTION
# Summary

When adding a token to a new network, when one with the same address already existed in another, the original one was removed: https://github.com/cowprotocol/token-lists/pull/733/commits/00c9cbee71c0c9b1d2451e3a58d882ad5cc50abc

This change makes sure it takes chainId into account to consider an update vs a new token.