### PR TITLE
fix: update cowfi-tokens action deps

### DIFF
--- a/.github/workflows/cowFi-tokens.yml
+++ b/.github/workflows/cowFi-tokens.yml
@@ -68,7 +68,7 @@ jobs:
         run: USE_CACHE=false yarn cowFi:tokens
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cowFi-tokens.json
           path: src/cowFi/cowFi-tokens.json


### PR DESCRIPTION
The action fails https://github.com/cowprotocol/token-lists/actions/runs/12159971793.

Because:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```