### PR TITLE
ci: run cowfi tokens update every two hours

### DIFF
--- a/.github/workflows/cowFi-tokens.yml
+++ b/.github/workflows/cowFi-tokens.yml
@@ -2,7 +2,7 @@ name: 'Cron: cow.fi tokens list'
 
 on:
   schedule:
-    - cron: '30 * * * *'
+    - cron: '0 */3 * * *'
 
 # Required for authenticating with AWS IAM
 permissions:


### PR DESCRIPTION
Since the script takes ~3 hours, it doesn't make sense to run it every 30 mins.
After this change it will be runned each 3 hours.

<img width="1370" alt="image" src="https://github.com/user-attachments/assets/f314e6db-f97c-48d6-b474-0252060e60f8">
