### PR TITLE
feat: coingecko top 500

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coingecko": "yarn run-script src/scripts/coingecko.js",
     "downloadImages": "yarn run-script src/scripts/downloadImages",
     "cowFi:tokens": "yarn run-script ./src/scripts/cowFi-tokens.js",
-    "baseChainTopTokens": "node ./src/scripts/baseChainTopTokens.js",
+    "coingeckoTop500": "node src/scripts/coingeckoTop500.js",
     "uniswapToGnosisChainList": "yarn run-script src/scripts/mapTokenListToBridge.ts 100 uniswap",
     "coingeckoToGnosisChainList": "yarn run-script src/scripts/mapTokenListToBridge.ts 100 coingecko",
     "coingeckoToArbitrumOneList": "yarn run-script src/scripts/mapTokenListToBridge.ts 42161 coingecko",

--- a/src/public/CoinGecko.1.json
+++ b/src/public/CoinGecko.1.json
@@ -1,5 +1,5 @@
 {
-  "name": "Coingecko top 500 on ethereum",
+  "name": "Coingecko top 500 on Ethereum",
   "logoURI": "https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png",
   "keywords": [
     "defi"
@@ -28,14 +28,6 @@
     },
     {
       "chainId": 1,
-      "address": "0xc5f0f7b66764f6ec8c8dff7ba683102295e16409",
-      "name": "First Digital USD",
-      "symbol": "FDUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31079/large/FDUSD_icon_black.png?1731097953"
-    },
-    {
-      "chainId": 1,
       "address": "0x6982508145454ce325ddbe47a25d4ec3d2311933",
       "name": "Pepe",
       "symbol": "PEPE",
@@ -44,35 +36,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xb8c77482e45f1f44de1745f52c74426c631bdd52",
-      "name": "BNB",
-      "symbol": "BNB",
+      "address": "0xc5f0f7b66764f6ec8c8dff7ba683102295e16409",
+      "name": "First Digital USD",
+      "symbol": "FDUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/825/large/bnb-icon2_2x.png?1696501970"
-    },
-    {
-      "chainId": 1,
-      "address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
-      "name": "Shiba Inu",
-      "symbol": "SHIB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11939/large/shiba.png?1696511800"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7420b4b9a0110cdc71fb720908340c03f9bc03ec",
-      "name": "JasmyCoin",
-      "symbol": "JASMY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13876/large/JASMY200x200.jpg?1696513620"
-    },
-    {
-      "chainId": 1,
-      "address": "0x163f8c2467924be0ae7b5347228cabf260318753",
-      "name": "Worldcoin",
-      "symbol": "WLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31069/large/worldcoin.jpeg?1696529903"
+      "logoURI": "https://assets.coingecko.com/coins/images/31079/large/FDUSD_icon_black.png?1731097953"
     },
     {
       "chainId": 1,
@@ -84,11 +52,19 @@
     },
     {
       "chainId": 1,
-      "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
-      "name": "Curve DAO",
-      "symbol": "CRV",
+      "address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+      "name": "Shiba Inu",
+      "symbol": "SHIB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12124/large/Curve.png?1696511967"
+      "logoURI": "https://assets.coingecko.com/coins/images/11939/large/shiba.png?1696511800"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb8c77482e45f1f44de1745f52c74426c631bdd52",
+      "name": "BNB",
+      "symbol": "BNB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/825/large/bnb-icon2_2x.png?1696501970"
     },
     {
       "chainId": 1,
@@ -100,11 +76,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xaea46a60368a7bd060eec7df8cba43b7ef41ad85",
-      "name": "Artificial Superintelligence Alliance",
-      "symbol": "FET",
+      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "name": "WETH",
+      "symbol": "WETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5681/large/ASI.png?1719827289"
+      "logoURI": "https://assets.coingecko.com/coins/images/2518/large/weth.png?1696503332"
     },
     {
       "chainId": 1,
@@ -124,59 +100,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xa3ee21c306a700e682abcdfe9baa6a08f3820419",
-      "name": "Creditcoin",
-      "symbol": "CTC",
+      "address": "0x163f8c2467924be0ae7b5347228cabf260318753",
+      "name": "Worldcoin",
+      "symbol": "WLD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10569/large/ctc.png?1696510552"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe41d2489571d322189246dafa5ebde1f4699f498",
-      "name": "0x Protocol",
-      "symbol": "ZRX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/863/large/0x.png?1696501996"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
-      "name": "The Sandbox",
-      "symbol": "SAND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12129/large/sandbox_logo.jpg?1696511971"
-    },
-    {
-      "chainId": 1,
-      "address": "0x57e114b691db790c35207b2e685d4a43181e6061",
-      "name": "Ethena",
-      "symbol": "ENA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36530/large/ethena.png?1711701436"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
-      "name": "Render",
-      "symbol": "RENDER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11636/large/rndr.png?1696511529"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-      "name": "WETH",
-      "symbol": "WETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2518/large/weth.png?1696503332"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd1d2eb1b1e90b638588728b4130137d262c87cae",
-      "name": "GALA",
-      "symbol": "GALA",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/12493/large/GALA_token_image_-_200PNG.png?1709725869"
+      "logoURI": "https://assets.coingecko.com/coins/images/31069/large/worldcoin.jpeg?1696529903"
     },
     {
       "chainId": 1,
@@ -188,86 +116,6 @@
     },
     {
       "chainId": 1,
-      "address": "0x1151cb3d861920e07a38e03eead12c32178567f6",
-      "name": "Bonk",
-      "symbol": "BONK",
-      "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/28600/large/bonk.jpg?1696527587"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
-      "name": "Ethereum Name Service",
-      "symbol": "ENS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19785/large/ENS.jpg?1727872989"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
-      "name": "LayerZero",
-      "symbol": "ZRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
-      "name": "Wrapped Bitcoin",
-      "symbol": "WBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1696507857"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
-      "name": "Coinbase Wrapped BTC",
-      "symbol": "CBBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
-    },
-    {
-      "chainId": 1,
-      "address": "0x582d872a1b094fc48f5de31d3b73f2d9be47def1",
-      "name": "Toncoin",
-      "symbol": "TON",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/17980/large/photo_2024-09-10_17.09.00.jpeg?1725963446"
-    },
-    {
-      "chainId": 1,
-      "address": "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
-      "name": "POL  ex MATIC ",
-      "symbol": "POL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32440/large/polygon.png?1698233684"
-    },
-    {
-      "chainId": 1,
-      "address": "0x92d6c1e31e14520e676a687f0a93788b716beff5",
-      "name": "dYdX",
-      "symbol": "ETHDYDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17500/large/hjnIm9bV.jpg?1696517040"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe28b3b32b6c345a34ff64674606124dd5aceca30",
-      "name": "Injective",
-      "symbol": "INJ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12882/large/Secondary_Symbol.png?1696512670"
-    },
-    {
-      "chainId": 1,
-      "address": "0x58b6a8a3302369daec383334672404ee733ab239",
-      "name": "Livepeer",
-      "symbol": "LPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7137/large/badge-logo-circuit-green.png?1719357686"
-    },
-    {
-      "chainId": 1,
       "address": "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
       "name": "FLOKI",
       "symbol": "FLOKI",
@@ -276,51 +124,35 @@
     },
     {
       "chainId": 1,
-      "address": "0xfe0c30065b384f05761f15d0cc899d4f9f9cc0eb",
-      "name": "Ether fi",
-      "symbol": "ETHFI",
+      "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+      "name": "Curve DAO",
+      "symbol": "CRV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35958/large/etherfi.jpeg?1710254562"
+      "logoURI": "https://assets.coingecko.com/coins/images/12124/large/Curve.png?1696511967"
     },
     {
       "chainId": 1,
-      "address": "0x579cea1889991f68acc35ff5c3dd0621ff29b0c9",
-      "name": "IQ",
-      "symbol": "IQ",
+      "address": "0x57e114b691db790c35207b2e685d4a43181e6061",
+      "name": "Ethena",
+      "symbol": "ENA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5010/large/YAIS3fUh.png?1696505542"
+      "logoURI": "https://assets.coingecko.com/coins/images/36530/large/ethena.png?1711701436"
     },
     {
       "chainId": 1,
-      "address": "0xfaba6f8e4a5e8ab82f62fe7c39859fa577269be3",
-      "name": "Ondo",
-      "symbol": "ONDO",
+      "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+      "name": "The Sandbox",
+      "symbol": "SAND",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26580/large/ONDO.png?1696525656"
+      "logoURI": "https://assets.coingecko.com/coins/images/12129/large/sandbox_logo.jpg?1696511971"
     },
     {
       "chainId": 1,
-      "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
-      "name": "Lido DAO",
-      "symbol": "LDO",
+      "address": "0xaea46a60368a7bd060eec7df8cba43b7ef41ad85",
+      "name": "Artificial Superintelligence Alliance",
+      "symbol": "FET",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1696513326"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4d224452801aced8b2f0aebe155379bb5d594381",
-      "name": "ApeCoin",
-      "symbol": "APE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24383/large/apecoin.jpg?1696523566"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
-      "name": "The Graph",
-      "symbol": "GRT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13397/large/Graph_Token.png?1696513159"
+      "logoURI": "https://assets.coingecko.com/coins/images/5681/large/ASI.png?1719827289"
     },
     {
       "chainId": 1,
@@ -332,163 +164,67 @@
     },
     {
       "chainId": 1,
-      "address": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
-      "name": "Eigenlayer",
-      "symbol": "EIGEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37441/large/eigen.jpg?1728023974"
+      "address": "0x582d872a1b094fc48f5de31d3b73f2d9be47def1",
+      "name": "Toncoin",
+      "symbol": "TON",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17980/large/photo_2024-09-10_17.09.00.jpeg?1725963446"
     },
     {
       "chainId": 1,
-      "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
-      "name": "Decentraland",
-      "symbol": "MANA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/878/large/decentraland-mana.png?1696502010"
+      "address": "0x1151cb3d861920e07a38e03eead12c32178567f6",
+      "name": "Bonk",
+      "symbol": "BONK",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28600/large/bonk.jpg?1696527587"
     },
     {
       "chainId": 1,
-      "address": "0x6e2a43be0b1d33b726f0ca3b8de60b3482b8b050",
-      "name": "Arkham",
-      "symbol": "ARKM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30929/large/Arkham_Logo_CG.png?1696529771"
+      "address": "0xd1d2eb1b1e90b638588728b4130137d262c87cae",
+      "name": "GALA",
+      "symbol": "GALA",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12493/large/GALA_token_image_-_200PNG.png?1709725869"
     },
     {
       "chainId": 1,
-      "address": "0x3506424f91fd33084466f402d5d97f05f8e3b4af",
-      "name": "Chiliz",
-      "symbol": "CHZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8834/large/CHZ_Token_updated.png?1696508986"
+      "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      "name": "Wrapped Bitcoin",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1696507857"
     },
     {
       "chainId": 1,
-      "address": "0x320623b8e4ff03373931769a31fc52a4e78b5d70",
-      "name": "Reserve Rights",
-      "symbol": "RSR",
+      "address": "0xfaba6f8e4a5e8ab82f62fe7c39859fa577269be3",
+      "name": "Ondo",
+      "symbol": "ONDO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
+      "logoURI": "https://assets.coingecko.com/coins/images/26580/large/ONDO.png?1696525656"
     },
     {
       "chainId": 1,
-      "address": "0xaaee1a9723aadb7afa2810263653a34ba2c21c7a",
-      "name": "Mog Coin",
-      "symbol": "MOG",
+      "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+      "name": "Ethereum Name Service",
+      "symbol": "ENS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png?1696529893"
+      "logoURI": "https://assets.coingecko.com/coins/images/19785/large/ENS.jpg?1727872989"
     },
     {
       "chainId": 1,
-      "address": "0x58d97b57bb95320f9a05dc918aef65434969c2b2",
-      "name": "Morpho",
-      "symbol": "MORPHO",
+      "address": "0x7420b4b9a0110cdc71fb720908340c03f9bc03ec",
+      "name": "JasmyCoin",
+      "symbol": "JASMY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
+      "logoURI": "https://assets.coingecko.com/coins/images/13876/large/JASMY200x200.jpg?1696513620"
     },
     {
       "chainId": 1,
-      "address": "0xca14007eff0db1f8135f4c25b34de49ab0d42766",
-      "name": "Starknet",
-      "symbol": "STRK",
+      "address": "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
+      "name": "POL  ex MATIC ",
+      "symbol": "POL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26433/large/starknet.png?1696525507"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb0ffa8000886e57f86dd5264b9582b2ad87b2b91",
-      "name": "Wormhole",
-      "symbol": "W",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35087/large/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
-    },
-    {
-      "chainId": 1,
-      "address": "0x152649ea73beab28c5b49b26eb48f7ead6d4c898",
-      "name": "PancakeSwap",
-      "symbol": "CAKE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
-      "name": "Compound",
-      "symbol": "COMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10775/large/COMP.png?1696510737"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb528edbef013aff855ac3c50b381f253af13b997",
-      "name": "Aevo",
-      "symbol": "AEVO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35893/large/aevo.png?1710138340"
-    },
-    {
-      "chainId": 1,
-      "address": "0x50327c6c5a14dcade707abad2e27eb517df87ab5",
-      "name": "Wrapped Tron",
-      "symbol": "WTRX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/22471/large/xOesRfpN_400x400.jpg?1696521795"
-    },
-    {
-      "chainId": 1,
-      "address": "0x44ff8620b8ca30902395a7bd3f2407e1a091bf73",
-      "name": "Virtuals Protocol",
-      "symbol": "VIRTUAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34057/large/LOGOMARK.png?1708356054"
-    },
-    {
-      "chainId": 1,
-      "address": "0x808507121b80c02388fad14726482e061b8da827",
-      "name": "Pendle",
-      "symbol": "PENDLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
-    },
-    {
-      "chainId": 1,
-      "address": "0x54d2252757e1672eead234d27b1270728ff90581",
-      "name": "Bitget Token",
-      "symbol": "BGB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11610/large/icon_colour.png?1696511504"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
-      "name": "Ethena USDe",
-      "symbol": "USDE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33613/large/USDE.png?1716355685"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1f57da732a77636d913c9a75d685b26cc85dcc3a",
-      "name": "OPENLOOT",
-      "symbol": "OL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51801/large/_OPENLOOT_token-icon_black_%282%29.png?1731989426"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7a58c0be72be218b41c608b7fe7c5bb630736c71",
-      "name": "ConstitutionDAO",
-      "symbol": "PEOPLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20612/large/GN_UVm3d_400x400.jpg?1696520017"
-    },
-    {
-      "chainId": 1,
-      "address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
-      "name": "Across Protocol",
-      "symbol": "ACX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+      "logoURI": "https://assets.coingecko.com/coins/images/32440/large/polygon.png?1698233684"
     },
     {
       "chainId": 1,
@@ -500,11 +236,75 @@
     },
     {
       "chainId": 1,
-      "address": "0x8290333cef9e6d528dd5618fb97a76f268f3edd4",
-      "name": "Ankr Network",
-      "symbol": "ANKR",
+      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+      "name": "Coinbase Wrapped BTC",
+      "symbol": "CBBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe28b3b32b6c345a34ff64674606124dd5aceca30",
+      "name": "Injective",
+      "symbol": "INJ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1696504928"
+      "logoURI": "https://assets.coingecko.com/coins/images/12882/large/Secondary_Symbol.png?1696512670"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
+      "name": "Render",
+      "symbol": "RENDER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11636/large/rndr.png?1696511529"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4d224452801aced8b2f0aebe155379bb5d594381",
+      "name": "ApeCoin",
+      "symbol": "APE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24383/large/apecoin.jpg?1696523566"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "name": "LayerZero",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+      "name": "Lido DAO",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1696513326"
+    },
+    {
+      "chainId": 1,
+      "address": "0xac57de9c1a09fec648e93eb98875b212db0d460b",
+      "name": "Baby Doge Coin",
+      "symbol": "BABYDOGE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16125/large/babydoge.jpg?1696515731"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfe0c30065b384f05761f15d0cc899d4f9f9cc0eb",
+      "name": "Ether fi",
+      "symbol": "ETHFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35958/large/etherfi.jpeg?1710254562"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7a58c0be72be218b41c608b7fe7c5bb630736c71",
+      "name": "ConstitutionDAO",
+      "symbol": "PEOPLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20612/large/GN_UVm3d_400x400.jpg?1696520017"
     },
     {
       "chainId": 1,
@@ -516,6 +316,30 @@
     },
     {
       "chainId": 1,
+      "address": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
+      "name": "Eigenlayer",
+      "symbol": "EIGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37441/large/eigen.jpg?1728023974"
+    },
+    {
+      "chainId": 1,
+      "address": "0x152649ea73beab28c5b49b26eb48f7ead6d4c898",
+      "name": "PancakeSwap",
+      "symbol": "CAKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e2a43be0b1d33b726f0ca3b8de60b3482b8b050",
+      "name": "Arkham",
+      "symbol": "ARKM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30929/large/Arkham_Logo_CG.png?1696529771"
+    },
+    {
+      "chainId": 1,
       "address": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
       "name": "Axie Infinity",
       "symbol": "AXS",
@@ -524,19 +348,19 @@
     },
     {
       "chainId": 1,
-      "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
-      "name": "Maker",
-      "symbol": "MKR",
+      "address": "0xca14007eff0db1f8135f4c25b34de49ab0d42766",
+      "name": "Starknet",
+      "symbol": "STRK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1364/large/Mark_Maker.png?1696502423"
+      "logoURI": "https://assets.coingecko.com/coins/images/26433/large/starknet.png?1696525507"
     },
     {
       "chainId": 1,
-      "address": "0x3c3a81e81dc49a522a592e7622a7e711c06bf354",
-      "name": "Mantle",
-      "symbol": "MNT",
+      "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+      "name": "Decentraland",
+      "symbol": "MANA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30980/large/token-logo.png?1696529819"
+      "logoURI": "https://assets.coingecko.com/coins/images/878/large/decentraland-mana.png?1696502010"
     },
     {
       "chainId": 1,
@@ -548,19 +372,19 @@
     },
     {
       "chainId": 1,
-      "address": "0x69af81e73a73b40adf4f3d4223cd9b1ece623074",
-      "name": "Mask Network",
-      "symbol": "MASK",
+      "address": "0x3506424f91fd33084466f402d5d97f05f8e3b4af",
+      "name": "Chiliz",
+      "symbol": "CHZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14051/large/Mask_Network.jpg?1696513776"
+      "logoURI": "https://assets.coingecko.com/coins/images/8834/large/CHZ_Token_updated.png?1696508986"
     },
     {
       "chainId": 1,
-      "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
-      "name": "yearn finance",
-      "symbol": "YFI",
+      "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+      "name": "Maker",
+      "symbol": "MKR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11849/large/yearn.jpg?1696511720"
+      "logoURI": "https://assets.coingecko.com/coins/images/1364/large/Mark_Maker.png?1696502423"
     },
     {
       "chainId": 1,
@@ -572,91 +396,43 @@
     },
     {
       "chainId": 1,
-      "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
-      "name": "Dai",
-      "symbol": "DAI",
+      "address": "0x808507121b80c02388fad14726482e061b8da827",
+      "name": "Pendle",
+      "symbol": "PENDLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9956/large/Badge_Dai.png?1696509996"
+      "logoURI": "https://assets.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
     },
     {
       "chainId": 1,
-      "address": "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9",
-      "name": "FTX",
-      "symbol": "FTT",
+      "address": "0x3c3a81e81dc49a522a592e7622a7e711c06bf354",
+      "name": "Mantle",
+      "symbol": "MNT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9026/large/F.png?1696509161"
+      "logoURI": "https://assets.coingecko.com/coins/images/30980/large/token-logo.png?1696529819"
     },
     {
       "chainId": 1,
-      "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
-      "name": "Tellor Tributes",
-      "symbol": "TRB",
+      "address": "0xb0ffa8000886e57f86dd5264b9582b2ad87b2b91",
+      "name": "Wormhole",
+      "symbol": "W",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9644/large/Blk_icon_current.png?1696509713"
+      "logoURI": "https://assets.coingecko.com/coins/images/35087/large/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
     },
     {
       "chainId": 1,
-      "address": "0xf57e7e7c23978c3caec3c3548e3d615c346e79ff",
-      "name": "Immutable",
-      "symbol": "IMX",
+      "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+      "name": "The Graph",
+      "symbol": "GRT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17233/large/immutableX-symbol-BLK-RGB.png?1696516787"
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/large/Graph_Token.png?1696513159"
     },
     {
       "chainId": 1,
-      "address": "0xff20817765cb7f73d4bde2e66e067e58d11095c2",
-      "name": "Amp",
-      "symbol": "AMP",
+      "address": "0x320623b8e4ff03373931769a31fc52a4e78b5d70",
+      "name": "Reserve Rights",
+      "symbol": "RSR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12409/large/amp-200x200.png?1696512231"
-    },
-    {
-      "chainId": 1,
-      "address": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
-      "name": "Yield Guild Games",
-      "symbol": "YGG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17358/large/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5283d291dbcf85356a21ba090e6db59121208b44",
-      "name": "Blur",
-      "symbol": "BLUR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28453/large/blur.png?1696527448"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9c7beba8f6ef6643abd725e45a4e8387ef260649",
-      "name": "Gravity",
-      "symbol": "G",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39200/large/gravity.jpg?1721020647"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2dff88a56767223a5529ea5960da7a3f5f766406",
-      "name": "SPACE ID",
-      "symbol": "ID",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29468/large/sid_token_logo_%28green2%29.png?1696528413"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
-      "name": "Synthetix Network",
-      "symbol": "SNX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3406/large/SNX.png?1696504103"
-    },
-    {
-      "chainId": 1,
-      "address": "0x62d0a8458ed7719fdaf978fe5929c6d342b0bfce",
-      "name": "Beam",
-      "symbol": "BEAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32417/large/chain-logo.png?1698114384"
+      "logoURI": "https://assets.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
     },
     {
       "chainId": 1,
@@ -668,11 +444,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x9d65ff81a3c488d585bbfb0bfe3c7707c7917f54",
-      "name": "SSV Network",
-      "symbol": "SSV",
+      "address": "0x92d6c1e31e14520e676a687f0a93788b716beff5",
+      "name": "dYdX",
+      "symbol": "ETHDYDX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19155/large/ssv.png?1696518606"
+      "logoURI": "https://assets.coingecko.com/coins/images/17500/large/hjnIm9bV.jpg?1696517040"
     },
     {
       "chainId": 1,
@@ -684,379 +460,115 @@
     },
     {
       "chainId": 1,
-      "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
-      "name": "Basic Attention",
-      "symbol": "BAT",
+      "address": "0xb528edbef013aff855ac3c50b381f253af13b997",
+      "name": "Aevo",
+      "symbol": "AEVO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/677/large/basic-attention-token.png?1696501867"
+      "logoURI": "https://assets.coingecko.com/coins/images/35893/large/aevo.png?1710138340"
     },
     {
       "chainId": 1,
-      "address": "0x4d1c297d39c5c1277964d0e3f8aa901493664530",
-      "name": "Puffer",
-      "symbol": "PUFFER",
+      "address": "0x62d0a8458ed7719fdaf978fe5929c6d342b0bfce",
+      "name": "Beam",
+      "symbol": "BEAM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50630/large/PUFFER_token_Logo.png?1729574024"
+      "logoURI": "https://assets.coingecko.com/coins/images/32417/large/chain-logo.png?1698114384"
     },
     {
       "chainId": 1,
-      "address": "0x1bbe973bef3a977fc51cbed703e8ffdefe001fed",
-      "name": "Portal",
-      "symbol": "PORTAL",
+      "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
+      "name": "Tellor Tributes",
+      "symbol": "TRB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35436/large/portal.jpeg?1708590254"
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/large/Blk_icon_current.png?1696509713"
     },
     {
       "chainId": 1,
-      "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
-      "name": "Wrapped stETH",
-      "symbol": "WSTETH",
+      "address": "0x69af81e73a73b40adf4f3d4223cd9b1ece623074",
+      "name": "Mask Network",
+      "symbol": "MASK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
+      "logoURI": "https://assets.coingecko.com/coins/images/14051/large/Mask_Network.jpg?1696513776"
     },
     {
       "chainId": 1,
-      "address": "0x8457ca5040ad67fdebbcc8edce889a335bc0fbfb",
-      "name": "AltLayer",
-      "symbol": "ALT",
+      "address": "0x5283d291dbcf85356a21ba090e6db59121208b44",
+      "name": "Blur",
+      "symbol": "BLUR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34608/large/Logomark_200x200.png?1715107868"
+      "logoURI": "https://assets.coingecko.com/coins/images/28453/large/blur.png?1696527448"
     },
     {
       "chainId": 1,
-      "address": "0xaedf386b755465871ff874e3e37af5976e247064",
-      "name": "Fasttoken",
-      "symbol": "FTN",
+      "address": "0x54d2252757e1672eead234d27b1270728ff90581",
+      "name": "Bitget Token",
+      "symbol": "BGB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28478/large/lightenicon_200x200.png?1696527472"
+      "logoURI": "https://assets.coingecko.com/coins/images/11610/large/icon_colour.png?1696511504"
     },
     {
       "chainId": 1,
-      "address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
-      "name": "Convex Finance",
-      "symbol": "CVX",
+      "address": "0xf57e7e7c23978c3caec3c3548e3d615c346e79ff",
+      "name": "Immutable",
+      "symbol": "IMX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15585/large/convex.png?1696515221"
+      "logoURI": "https://assets.coingecko.com/coins/images/17233/large/immutableX-symbol-BLK-RGB.png?1696516787"
     },
     {
       "chainId": 1,
-      "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
-      "name": "Quant",
-      "symbol": "QNT",
+      "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+      "name": "Compound",
+      "symbol": "COMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3370/large/5ZOu7brX_400x400.jpg?1696504070"
+      "logoURI": "https://assets.coingecko.com/coins/images/10775/large/COMP.png?1696510737"
     },
     {
       "chainId": 1,
-      "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
-      "name": "Loopring",
-      "symbol": "LRC",
+      "address": "0x44ff8620b8ca30902395a7bd3f2407e1a091bf73",
+      "name": "Virtuals Protocol",
+      "symbol": "VIRTUAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/913/large/LRC.png?1696502034"
+      "logoURI": "https://assets.coingecko.com/coins/images/34057/large/LOGOMARK.png?1708356054"
     },
     {
       "chainId": 1,
-      "address": "0xe3c408bd53c31c085a1746af401a4042954ff740",
-      "name": "GMT",
-      "symbol": "GMT",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/23597/large/token-gmt-200x200.png?1703153841"
-    },
-    {
-      "chainId": 1,
-      "address": "0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7",
-      "name": "SKALE",
-      "symbol": "SKL",
+      "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+      "name": "yearn finance",
+      "symbol": "YFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13245/large/SKALE_token_300x300.png?1696513021"
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/large/yearn.jpg?1696511720"
     },
     {
       "chainId": 1,
-      "address": "0xfd418e42783382e86ae91e445406600ba144d162",
-      "name": "Zircuit",
-      "symbol": "ZRC",
+      "address": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+      "name": "0x Protocol",
+      "symbol": "ZRX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35960/large/zircuit_token_icon_2.png?1732502352"
+      "logoURI": "https://assets.coingecko.com/coins/images/863/large/0x.png?1696501996"
     },
     {
       "chainId": 1,
-      "address": "0x11eef04c884e24d9b7b4760e7476d06ddf797f36",
-      "name": "MX",
-      "symbol": "MX",
+      "address": "0xa3ee21c306a700e682abcdfe9baa6a08f3820419",
+      "name": "Creditcoin",
+      "symbol": "CTC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8545/large/MEXC_GLOBAL_LOGO.jpeg?1696508719"
+      "logoURI": "https://assets.coingecko.com/coins/images/10569/large/ctc.png?1696510552"
     },
     {
       "chainId": 1,
-      "address": "0x3429d03c6f7521aec737a0bbf2e5ddcef2c3ae31",
-      "name": "Pixels",
-      "symbol": "PIXEL",
+      "address": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
+      "name": "Yield Guild Games",
+      "symbol": "YGG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35100/large/pixel-icon.png?1708339519"
+      "logoURI": "https://assets.coingecko.com/coins/images/17358/large/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
     },
     {
       "chainId": 1,
-      "address": "0x5afe3855358e112b5647b952709e6165e1c1eeee",
-      "name": "Safe",
-      "symbol": "SAFE",
+      "address": "0x58b6a8a3302369daec383334672404ee733ab239",
+      "name": "Livepeer",
+      "symbol": "LPT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27032/large/Artboard_1_copy_8circle-1.png?1696526084"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfee293840d23b0b2de8c55e1cf7a9f01c157767c",
-      "name": "Degen  Base ",
-      "symbol": "DEGEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
-      "name": "Enjin Coin",
-      "symbol": "ENJ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1102/large/Symbol_Only_-_Purple.png?1709725966"
-    },
-    {
-      "chainId": 1,
-      "address": "0xed04915c23f00a313a544955524eb7dbd823143d",
-      "name": "Alchemy Pay",
-      "symbol": "ACH",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/12390/large/ACH_%281%29.png?1696512213"
-    },
-    {
-      "chainId": 1,
-      "address": "0xddb3422497e61e13543bea06989c0789117555c5",
-      "name": "COTI",
-      "symbol": "COTI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2962/large/Coti.png?1696503705"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6fb3e0a217407efff7ca062d46c26e5d60a14d69",
-      "name": "IoTeX",
-      "symbol": "IOTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3334/large/Token_Icon_Token_Icon.png?1727899869"
-    },
-    {
-      "chainId": 1,
-      "address": "0xae12c5930881c53715b369cec7606b70d8eb229f",
-      "name": "Coin98",
-      "symbol": "C98",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17117/large/logo.png?1696516677"
-    },
-    {
-      "chainId": 1,
-      "address": "0x32353a6c91143bfd6c7d363b546e62a9a2489a20",
-      "name": "Adventure Gold",
-      "symbol": "AGLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18125/large/lpgblc4h_400x400.jpg?1696517628"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbe0ed4138121ecfc5c0e56b40517da27e6c5226b",
-      "name": "Aethir",
-      "symbol": "ATH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf091867ec603a6628ed83d274e835539d82e9cc8",
-      "name": "ZetaChain",
-      "symbol": "ZETA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26718/large/Twitter_icon.png?1696525788"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa9b1eb5908cfc3cdf91f9b8b3a74108598009096",
-      "name": "Bounce",
-      "symbol": "AUCTION",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13860/large/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1696513606"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7dd9c5cba05e151c895fde1cf355c9a1d5da6429",
-      "name": "Golem",
-      "symbol": "GLM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/542/large/Golem_Submark_Positive_RGB.png?1696501761"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b",
-      "name": "Cronos",
-      "symbol": "CRO",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/7310/large/cro_token_logo.png?1696507599"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc669928185dbce49d2230cc9b0979be6dc797957",
-      "name": "BitTorrent",
-      "symbol": "BTT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22457/large/btt_logo.png?1696521780"
-    },
-    {
-      "chainId": 1,
-      "address": "0x767fe9edc9e0df98e07454847909b5e959d7ca0e",
-      "name": "Illuvium",
-      "symbol": "ILV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14468/large/logo-200x200.png?1696514154"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
-      "name": "Holo",
-      "symbol": "HOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3348/large/Holologo_Profile.png?1696504052"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6e15a54b5ecac17e58dadeddbe8506a7560252f9",
-      "name": "SynFutures",
-      "symbol": "F",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52186/large/synfutures_f_token_light_200.png?1732722899"
-    },
-    {
-      "chainId": 1,
-      "address": "0x80c62fe4487e1351b47ba49809ebd60ed085bf52",
-      "name": "Clover Finance",
-      "symbol": "CLV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15278/large/photo_2022-03-24_10-22-33.jpg?1696514930"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
-      "name": "WOO",
-      "symbol": "WOO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
-      "name": "Frax Share",
-      "symbol": "FXS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1696513183"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
-      "name": "Stargate Finance",
-      "symbol": "STG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
-      "name": "TrueFi",
-      "symbol": "TRU",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/13180/large/truefi_glyph_color.png?1696512963"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb0c7a3ba49c7a6eaba6cd4a96c55a1391070ac9a",
-      "name": "Treasure",
-      "symbol": "MAGIC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18623/large/magic.png?1696518095"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0a6e7ba5042b38349e437ec6db6214aec7b35676",
-      "name": "Swell",
-      "symbol": "SWELL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28777/large/swell1.png?1727899715"
-    },
-    {
-      "chainId": 1,
-      "address": "0x61ec85ab89377db65762e234c946b5c25a56e99e",
-      "name": "HTX DAO",
-      "symbol": "HTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35491/large/Frame_1321318576.png?1708908626"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe53ec727dbdeb9e2d5456c3be40cff031ab40a55",
-      "name": "SuperVerse",
-      "symbol": "SUPER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14040/large/SV-Logo-200x200.png?1706880312"
-    },
-    {
-      "chainId": 1,
-      "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
-      "name": "Status",
-      "symbol": "SNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/779/large/status.png?1696501931"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
-      "name": "CARV",
-      "symbol": "CARV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
-      "name": "TrueUSD",
-      "symbol": "TUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3449/large/tusd.png?1696504140"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8a2279d4a90b6fe1c4b30fa660cc9f926797baa2",
-      "name": "Chromia",
-      "symbol": "CHR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/5000/large/Chromia.png?1696505533"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7da2641000cbb407c329310c461b2cb9c70c3046",
-      "name": "Delysium",
-      "symbol": "AGI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29299/large/AGI_logo_200.png?1696528251"
-    },
-    {
-      "chainId": 1,
-      "address": "0x10dea67478c5f8c5e2d90e5e9b26dbe60c54d800",
-      "name": "Taiko",
-      "symbol": "TAIKO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38058/large/icon.png?1717626867"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb23d80f5fefcddaa212212f028021b41ded428cf",
-      "name": "Echelon Prime",
-      "symbol": "PRIME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/prime-logo-small-border_%282%29.png?1696528020"
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/large/badge-logo-circuit-green.png?1719357686"
     },
     {
       "chainId": 1,
@@ -1068,11 +580,123 @@
     },
     {
       "chainId": 1,
-      "address": "0x03dde9e5bb31ee40a471476e2fccf75c67921062",
-      "name": "EML Protocol",
-      "symbol": "EML",
+      "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+      "name": "Synthetix Network",
+      "symbol": "SNX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30950/large/EML_LOGO.png?1696529788"
+      "logoURI": "https://assets.coingecko.com/coins/images/3406/large/SNX.png?1696504103"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+      "name": "Across Protocol",
+      "symbol": "ACX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4d1c297d39c5c1277964d0e3f8aa901493664530",
+      "name": "Puffer",
+      "symbol": "PUFFER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50630/large/PUFFER_token_Logo.png?1729574024"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+      "name": "Dai",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9956/large/Badge_Dai.png?1696509996"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
+      "name": "Quant",
+      "symbol": "QNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3370/large/5ZOu7brX_400x400.jpg?1696504070"
+    },
+    {
+      "chainId": 1,
+      "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
+      "name": "Status",
+      "symbol": "SNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/779/large/status.png?1696501931"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1f57da732a77636d913c9a75d685b26cc85dcc3a",
+      "name": "OPENLOOT",
+      "symbol": "OL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51801/large/_OPENLOOT_token-icon_black_%282%29.png?1731989426"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
+      "name": "Ethena USDe",
+      "symbol": "USDE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33613/large/usde.png?1733810059"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe0ed4138121ecfc5c0e56b40517da27e6c5226b",
+      "name": "Aethir",
+      "symbol": "ATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
+    },
+    {
+      "chainId": 1,
+      "address": "0x58d97b57bb95320f9a05dc918aef65434969c2b2",
+      "name": "Morpho",
+      "symbol": "MORPHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8457ca5040ad67fdebbcc8edce889a335bc0fbfb",
+      "name": "AltLayer",
+      "symbol": "ALT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34608/large/Logomark_200x200.png?1715107868"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2dff88a56767223a5529ea5960da7a3f5f766406",
+      "name": "SPACE ID",
+      "symbol": "ID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29468/large/sid_token_logo_%28green2%29.png?1696528413"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe3c408bd53c31c085a1746af401a4042954ff740",
+      "name": "GMT",
+      "symbol": "GMT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/23597/large/token-gmt-200x200.png?1703153841"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+      "name": "Wrapped stETH",
+      "symbol": "WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf091867ec603a6628ed83d274e835539d82e9cc8",
+      "name": "ZetaChain",
+      "symbol": "ZETA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26718/large/Twitter_icon.png?1696525788"
     },
     {
       "chainId": 1,
@@ -1084,123 +708,275 @@
     },
     {
       "chainId": 1,
-      "address": "0xcc8fa225d80b9c7d42f96e9570156c65d6caaa25",
-      "name": "Smooth Love Potion",
-      "symbol": "SLP",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/10366/large/SLP.png?1696510368"
-    },
-    {
-      "chainId": 1,
-      "address": "0x467719ad09025fcc6cf6f8311755809d45a5e5f3",
-      "name": "Axelar",
-      "symbol": "AXL",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg?1696526329"
-    },
-    {
-      "chainId": 1,
-      "address": "0x198d14f2ad9ce69e76ea330b374de4957c3f850a",
-      "name": "APENFT",
-      "symbol": "NFT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/15687/large/apenft.jpg?1696515316"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf4fb9bf10e489ea3edb03e094939341399587b0c",
-      "name": "AirDAO",
-      "symbol": "AMB",
+      "address": "0xc669928185dbce49d2230cc9b0979be6dc797957",
+      "name": "BitTorrent",
+      "symbol": "BTT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1041/large/amb.png?1696502148"
+      "logoURI": "https://assets.coingecko.com/coins/images/22457/large/btt_logo.png?1696521780"
     },
     {
       "chainId": 1,
-      "address": "0x2a79324c19ef2b89ea98b23bc669b7e7c9f8a517",
-      "name": "WAX",
-      "symbol": "WAXP",
+      "address": "0x9d65ff81a3c488d585bbfb0bfe3c7707c7917f54",
+      "name": "SSV Network",
+      "symbol": "SSV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19155/large/ssv.png?1696518606"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe53ec727dbdeb9e2d5456c3be40cff031ab40a55",
+      "name": "SuperVerse",
+      "symbol": "SUPER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14040/large/SV-Logo-200x200.png?1706880312"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3429d03c6f7521aec737a0bbf2e5ddcef2c3ae31",
+      "name": "Pixels",
+      "symbol": "PIXEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35100/large/pixel-icon.png?1708339519"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfee293840d23b0b2de8c55e1cf7a9f01c157767c",
+      "name": "Degen  Base ",
+      "symbol": "DEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaedf386b755465871ff874e3e37af5976e247064",
+      "name": "Fasttoken",
+      "symbol": "FTN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28478/large/lightenicon_200x200.png?1696527472"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaaee1a9723aadb7afa2810263653a34ba2c21c7a",
+      "name": "Mog Coin",
+      "symbol": "MOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png?1696529893"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfd418e42783382e86ae91e445406600ba144d162",
+      "name": "Zircuit",
+      "symbol": "ZRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35960/large/zircuit_token_icon_2.png?1732502352"
+    },
+    {
+      "chainId": 1,
+      "address": "0x767fe9edc9e0df98e07454847909b5e959d7ca0e",
+      "name": "Illuvium",
+      "symbol": "ILV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14468/large/logo-200x200.png?1696514154"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e15a54b5ecac17e58dadeddbe8506a7560252f9",
+      "name": "SynFutures",
+      "symbol": "F",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52186/large/synfutures_f_token_light_200.png?1732722899"
+    },
+    {
+      "chainId": 1,
+      "address": "0xae12c5930881c53715b369cec7606b70d8eb229f",
+      "name": "Coin98",
+      "symbol": "C98",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17117/large/logo.png?1696516677"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
+      "name": "Convex Finance",
+      "symbol": "CVX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15585/large/convex.png?1696515221"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
+      "name": "Enjin Coin",
+      "symbol": "ENJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1102/large/Symbol_Only_-_Purple.png?1709725966"
+    },
+    {
+      "chainId": 1,
+      "address": "0x11eef04c884e24d9b7b4760e7476d06ddf797f36",
+      "name": "MX",
+      "symbol": "MX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8545/large/MEXC_GLOBAL_LOGO.jpeg?1696508719"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb0c7a3ba49c7a6eaba6cd4a96c55a1391070ac9a",
+      "name": "Treasure",
+      "symbol": "MAGIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18623/large/magic.png?1696518095"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1bbe973bef3a977fc51cbed703e8ffdefe001fed",
+      "name": "Portal",
+      "symbol": "PORTAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35436/large/portal.jpeg?1708590254"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b",
+      "name": "Cronos",
+      "symbol": "CRO",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/1372/large/WAX_Coin_Tickers_P_512px.png?1696502430"
+      "logoURI": "https://assets.coingecko.com/coins/images/7310/large/cro_token_logo.png?1696507599"
     },
     {
       "chainId": 1,
-      "address": "0x8de5b80a0c1b02fe4976851d030b36122dbb8624",
-      "name": "Vanar Chain",
-      "symbol": "VANRY",
+      "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
+      "name": "Stargate Finance",
+      "symbol": "STG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
     },
     {
       "chainId": 1,
-      "address": "0x14778860e937f509e651192a90589de711fb88a9",
-      "name": "CYBER",
-      "symbol": "CYBER",
+      "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
+      "name": "WOO",
+      "symbol": "WOO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31274/large/token.png?1715826754"
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
     },
     {
       "chainId": 1,
-      "address": "0x4be10da47a07716af28ad199fbe020501bddd7af",
-      "name": "XT com",
-      "symbol": "XT",
+      "address": "0xff20817765cb7f73d4bde2e66e067e58d11095c2",
+      "name": "Amp",
+      "symbol": "AMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8391/large/20240701-155217.jpeg?1719895785"
+      "logoURI": "https://assets.coingecko.com/coins/images/12409/large/amp-200x200.png?1696512231"
     },
     {
       "chainId": 1,
-      "address": "0x888888848b652b3e3a0f34c96e00eec0f3a23f72",
-      "name": "Alien Worlds",
-      "symbol": "TLM",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/14676/large/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1696514350"
+      "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+      "name": "Loopring",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/913/large/LRC.png?1696502034"
     },
     {
       "chainId": 1,
-      "address": "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
-      "name": "PayPal USD",
-      "symbol": "PYUSD",
+      "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
+      "name": "Holo",
+      "symbol": "HOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3348/large/Holologo_Profile.png?1696504052"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5afe3855358e112b5647b952709e6165e1c1eeee",
+      "name": "Safe",
+      "symbol": "SAFE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27032/large/Artboard_1_copy_8circle-1.png?1696526084"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
+      "name": "USDS",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
+    },
+    {
+      "chainId": 1,
+      "address": "0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7",
+      "name": "SKALE",
+      "symbol": "SKL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13245/large/SKALE_token_300x300.png?1696513021"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
+      "name": "TrueFi",
+      "symbol": "TRU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13180/large/truefi_glyph_color.png?1696512963"
+    },
+    {
+      "chainId": 1,
+      "address": "0xed04915c23f00a313a544955524eb7dbd823143d",
+      "name": "Alchemy Pay",
+      "symbol": "ACH",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12390/large/ACH_%281%29.png?1696512213"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+      "name": "Basic Attention",
+      "symbol": "BAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/677/large/basic-attention-token.png?1696501867"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8290333cef9e6d528dd5618fb97a76f268f3edd4",
+      "name": "Ankr Network",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1696504928"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6fb3e0a217407efff7ca062d46c26e5d60a14d69",
+      "name": "IoTeX",
+      "symbol": "IOTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3334/large/Token_Icon_Token_Icon.png?1727899869"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
+      "name": "IDEX",
+      "symbol": "IDEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2565/large/idexlogo.png?1696503371"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8a2279d4a90b6fe1c4b30fa660cc9f926797baa2",
+      "name": "Chromia",
+      "symbol": "CHR",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1696530039"
+      "logoURI": "https://assets.coingecko.com/coins/images/5000/large/Chromia.png?1696505533"
     },
     {
       "chainId": 1,
-      "address": "0x38e68a37e401f7271568cecaac63c6b1e19130b4",
-      "name": "Banana Gun",
-      "symbol": "BANANA",
+      "address": "0xddb3422497e61e13543bea06989c0789117555c5",
+      "name": "COTI",
+      "symbol": "COTI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31744/large/bg-logo-coingecko-200.png?1716971024"
+      "logoURI": "https://assets.coingecko.com/coins/images/2962/large/Coti.png?1696503705"
     },
     {
       "chainId": 1,
-      "address": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
-      "name": "EURC",
-      "symbol": "EURC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/26045/large/euro.png?1696525125"
-    },
-    {
-      "chainId": 1,
-      "address": "0x626e8036deb333b408be468f951bdb42433cbf18",
-      "name": "AIOZ Network",
-      "symbol": "AIOZ",
+      "address": "0x55296f69f40ea6d20e478533c15a6b08b654e758",
+      "name": "XYO Network",
+      "symbol": "XYO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14631/large/aioz-logo-200.png?1696514309"
-    },
-    {
-      "chainId": 1,
-      "address": "0x52a8845df664d76c69d2eea607cd793565af42b8",
-      "name": "ApeX",
-      "symbol": "APEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25266/large/CxpMECpk_400x400_%281%29.png?1696524406"
-    },
-    {
-      "chainId": 1,
-      "address": "0x57b946008913b82e4df85f501cbaed910e58d26c",
-      "name": "Marlin",
-      "symbol": "POND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8903/large/200x200.png?1706115827"
+      "logoURI": "https://assets.coingecko.com/coins/images/4519/large/XYO_Network-logo.png?1696505103"
     },
     {
       "chainId": 1,
@@ -1212,11 +988,67 @@
     },
     {
       "chainId": 1,
-      "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
-      "name": "Numeraire",
-      "symbol": "NMR",
+      "address": "0x9c7beba8f6ef6643abd725e45a4e8387ef260649",
+      "name": "Gravity",
+      "symbol": "G",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/752/large/numeraire.png?1696501906"
+      "logoURI": "https://assets.coingecko.com/coins/images/39200/large/gravity.jpg?1721020647"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcc8fa225d80b9c7d42f96e9570156c65d6caaa25",
+      "name": "Smooth Love Potion",
+      "symbol": "SLP",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/10366/large/SLP.png?1696510368"
+    },
+    {
+      "chainId": 1,
+      "address": "0x137ddb47ee24eaa998a535ab00378d6bfa84f893",
+      "name": "Radiant Capital",
+      "symbol": "RDNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa9b1eb5908cfc3cdf91f9b8b3a74108598009096",
+      "name": "Bounce",
+      "symbol": "AUCTION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13860/large/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1696513606"
+    },
+    {
+      "chainId": 1,
+      "address": "0x888888848b652b3e3a0f34c96e00eec0f3a23f72",
+      "name": "Alien Worlds",
+      "symbol": "TLM",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/14676/large/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1696514350"
+    },
+    {
+      "chainId": 1,
+      "address": "0x38e68a37e401f7271568cecaac63c6b1e19130b4",
+      "name": "Banana Gun",
+      "symbol": "BANANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31744/large/bg-logo-coingecko-200.png?1716971024"
+    },
+    {
+      "chainId": 1,
+      "address": "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9",
+      "name": "FTX",
+      "symbol": "FTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9026/large/F.png?1696509161"
+    },
+    {
+      "chainId": 1,
+      "address": "0x32353a6c91143bfd6c7d363b546e62a9a2489a20",
+      "name": "Adventure Gold",
+      "symbol": "AGLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18125/large/lpgblc4h_400x400.jpg?1696517628"
     },
     {
       "chainId": 1,
@@ -1236,579 +1068,27 @@
     },
     {
       "chainId": 1,
-      "address": "0x9e32b13ce7f2e80a01932b42553652e053d6ed8e",
-      "name": "Metis",
-      "symbol": "METIS",
+      "address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+      "name": "Frax Share",
+      "symbol": "FXS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15595/large/Metis_Black_Bg.png?1702968192"
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1696513183"
     },
     {
       "chainId": 1,
-      "address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
-      "name": "CoW Protocol",
-      "symbol": "COW",
+      "address": "0x7dd9c5cba05e151c895fde1cf355c9a1d5da6429",
+      "name": "Golem",
+      "symbol": "GLM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+      "logoURI": "https://assets.coingecko.com/coins/images/542/large/Golem_Submark_Positive_RGB.png?1696501761"
     },
     {
       "chainId": 1,
-      "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
-      "name": "Storj",
-      "symbol": "STORJ",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/949/large/storj.png?1696502065"
-    },
-    {
-      "chainId": 1,
-      "address": "0x137ddb47ee24eaa998a535ab00378d6bfa84f893",
-      "name": "Radiant Capital",
-      "symbol": "RDNT",
+      "address": "0x10dea67478c5f8c5e2d90e5e9b26dbe60c54d800",
+      "name": "Taiko",
+      "symbol": "TAIKO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
-      "name": "Wrapped eETH",
-      "symbol": "WEETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
-      "name": "Ethena Staked USDe",
-      "symbol": "SUSDE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33669/large/sUSDe-Symbol-Color.png?1716307680"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
-      "name": "Perpetual Protocol",
-      "symbol": "PERP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
-      "name": "API3",
-      "symbol": "API3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13256/large/api3.jpg?1696513031"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa62cc35625b0c8dc1faea39d33625bb4c15bd71c",
-      "name": "StormX",
-      "symbol": "STMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1369/large/StormX.png?1696502427"
-    },
-    {
-      "chainId": 1,
-      "address": "0x090185f2135308bad17527004364ebcc2d37e5f6",
-      "name": "Spell",
-      "symbol": "SPELL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15861/large/abracadabra-3.png?1696515477"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
-      "name": "Biconomy",
-      "symbol": "BICO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21061/large/biconomy_logo.jpg?1696520444"
-    },
-    {
-      "chainId": 1,
-      "address": "0xac51066d7bec65dc4589368da368b212745d63e8",
-      "name": "My Neighbor Alice",
-      "symbol": "ALICE",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/14375/large/alice_logo.jpg?1696514067"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
-      "name": "Badger",
-      "symbol": "BADGER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1696513059"
-    },
-    {
-      "chainId": 1,
-      "address": "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
-      "name": "Civic",
-      "symbol": "CVC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/788/large/civic-orange.png?1696501939"
-    },
-    {
-      "chainId": 1,
-      "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
-      "name": "Audius",
-      "symbol": "AUDIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12913/large/AudiusCoinLogo_2x.png?1696512701"
-    },
-    {
-      "chainId": 1,
-      "address": "0xadf7c35560035944e805d98ff17d58cde2449389",
-      "name": "Spectral",
-      "symbol": "SPEC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36138/large/ls7wS7vf_400x400.jpg?1724975224"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
-      "name": "Celer Network",
-      "symbol": "CELR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4379/large/Celr.png?1696504978"
-    },
-    {
-      "chainId": 1,
-      "address": "0x83f20f44975d03b1b09e64809b757c47f942beea",
-      "name": "Savings Dai",
-      "symbol": "SDAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32254/large/sdai.png?1697015278"
-    },
-    {
-      "chainId": 1,
-      "address": "0x430ef9263e76dae63c84292c3409d61c598e9682",
-      "name": "Vulcan Forged",
-      "symbol": "PYR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14770/large/1617088937196.png?1696514439"
-    },
-    {
-      "chainId": 1,
-      "address": "0x24fcfc492c1393274b6bcd568ac9e225bec93584",
-      "name": "Heroes of Mavia",
-      "symbol": "MAVIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33895/large/2023-12-20_21.21.41_%281%29.jpg?1703230771"
-    },
-    {
-      "chainId": 1,
-      "address": "0x940a2db1b7008b6c776d4faaca729d6d4a4aa551",
-      "name": "Dusk",
-      "symbol": "DUSK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5217/large/image_widget_biddfvxd454b1.png?1696505726"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba11d00c5f74255f56a5e366f4f77f5a186d7f55",
-      "name": "Band Protocol",
-      "symbol": "BAND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9545/large/Band_token_blue_violet_token.png?1696509627"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
-      "name": "Solar",
-      "symbol": "SXP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9368/large/swipe.png?1696509466"
-    },
-    {
-      "chainId": 1,
-      "address": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd",
-      "name": "DODO",
-      "symbol": "DODO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12651/large/dodo_logo.png?1696512458"
-    },
-    {
-      "chainId": 1,
-      "address": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
-      "name": "AUSD",
-      "symbol": "AUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39284/large/Circle_Agora_White_on_Olive_1080px.png?1722961274"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdefa4e8a7bcba345f687a2f1456f5edd9ce97202",
-      "name": "Kyber Network Crystal",
-      "symbol": "KNC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14899/large/RwdVsGcw_400x400.jpg?1696514562"
-    },
-    {
-      "chainId": 1,
-      "address": "0x595832f8fc6bf59c85c527fec3740a1b7a361269",
-      "name": "Powerledger",
-      "symbol": "POWR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/1104/large/Powerledger_Northstar_colour_digital_%282%29.png?1706702222"
-    },
-    {
-      "chainId": 1,
-      "address": "0x925206b8a707096ed26ae47c84747fe0bb734f59",
-      "name": "WhiteBIT Coin",
-      "symbol": "WBT",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/27045/large/wbt_token.png?1696526096"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa1faa113cbe53436df28ff0aee54275c13b40975",
-      "name": "Stella",
-      "symbol": "ALPHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12738/large/Stella200x200-06.png?1696512537"
-    },
-    {
-      "chainId": 1,
-      "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
-      "name": "Radworks",
-      "symbol": "RAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14013/large/radicle.png?1696513741"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
-      "name": "Threshold Network",
-      "symbol": "T",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22228/large/nFPNiSbL_400x400.jpg?1696521570"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
-      "name": "Origin Token",
-      "symbol": "OGN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3296/large/op.jpg?1696504006"
-    },
-    {
-      "chainId": 1,
-      "address": "0x491604c0fdf08347dd1fa4ee062a822a5dd06b5d",
-      "name": "Cartesi",
-      "symbol": "CTSI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
-    },
-    {
-      "chainId": 1,
-      "address": "0x14fee680690900ba0cccfc76ad70fd1b95d10e16",
-      "name": "PAAL AI",
-      "symbol": "PAAL",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/30815/large/Paal_New_Logo_%281%29.png?1718160584"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
-      "name": "USDS",
-      "symbol": "USDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb3999f658c0391d94a37f7ff328f3fec942bcadc",
-      "name": "Hashflow",
-      "symbol": "HFT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26136/large/200x200_360.png?1728551257"
-    },
-    {
-      "chainId": 1,
-      "address": "0x71ab77b7dbb4fa7e017bc15090b2163221420282",
-      "name": "Highstreet",
-      "symbol": "HIGH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18973/large/logosq200200Coingecko.png?1696518427"
-    },
-    {
-      "chainId": 1,
-      "address": "0x45804880de22913dafe09f4980848ece6ecbaf78",
-      "name": "PAX Gold",
-      "symbol": "PAXG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9519/large/paxgold.png?1696509604"
-    },
-    {
-      "chainId": 1,
-      "address": "0xabd4c63d2616a5201454168269031355f4764337",
-      "name": "Orderly Network",
-      "symbol": "ORDER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38501/large/Orderly_Network_Coingecko_200*200.png?1717751359"
-    },
-    {
-      "chainId": 1,
-      "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
-      "name": "iExec RLC",
-      "symbol": "RLC",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/646/large/pL1VuXm.png?1696501840"
-    },
-    {
-      "chainId": 1,
-      "address": "0x26aad156ba8efa501b32b42ffcdc8413f90e9c99",
-      "name": "Open Campus",
-      "symbol": "EDU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29948/large/EDU_Logo.png?1696528874"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd5f7838f5c461feff7fe49ea5ebaf7728bb0adfa",
-      "name": "Mantle Staked Ether",
-      "symbol": "METH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33345/large/symbol_transparent_bg.png?1701697066"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba50933c268f567bdc86e1ac131be072c6b0b71a",
-      "name": "ARPA",
-      "symbol": "ARPA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8506/large/9u0a23XY_400x400.jpg?1696508685"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa2e3356610840701bdf5611a53974510ae27e2e1",
-      "name": "Wrapped Beacon ETH",
-      "symbol": "WBETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30061/large/wbeth-icon.png?1696528983"
-    },
-    {
-      "chainId": 1,
-      "address": "0x55296f69f40ea6d20e478533c15a6b08b654e758",
-      "name": "XYO Network",
-      "symbol": "XYO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4519/large/XYO_Network-logo.png?1696505103"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0f3a12b78fee11ee088e454a0547bdbc5a253a6d",
-      "name": "Merlin Chain",
-      "symbol": "MERL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37118/large/merlin.jpeg?1713352230"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5cf04716ba20127f1e2297addcf4b5035000c9eb",
-      "name": "NKN",
-      "symbol": "NKN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3375/large/nkn.png?1696504074"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
-      "name": "Aavegotchi",
-      "symbol": "GHST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12467/large/GHST.png?1696512286"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
-      "name": "Dent",
-      "symbol": "DENT",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/1152/large/DENT_Token.png?1718837065"
-    },
-    {
-      "chainId": 1,
-      "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
-      "name": "tBTC",
-      "symbol": "TBTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4575f41308ec1483f3d399aa9a2826d74da13deb",
-      "name": "Orchid Protocol",
-      "symbol": "OXT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3916/large/download_%285%29.png?1696504574"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba100000625a3754423978a60c9317c58a424e3d",
-      "name": "Balancer",
-      "symbol": "BAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
-    },
-    {
-      "chainId": 1,
-      "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
-      "name": "OKB",
-      "symbol": "OKB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4463/large/WeChat_Image_20220118095654.png?1696505053"
-    },
-    {
-      "chainId": 1,
-      "address": "0xac57de9c1a09fec648e93eb98875b212db0d460b",
-      "name": "Baby Doge Coin",
-      "symbol": "BABYDOGE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/16125/large/babydoge.jpg?1696515731"
-    },
-    {
-      "chainId": 1,
-      "address": "0x081131434f93063751813c619ecca9c4dc7862a3",
-      "name": "Mines of Dalarnia",
-      "symbol": "DAR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/19837/large/dar.png?1696519259"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
-      "name": "Synapse",
-      "symbol": "SYN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18024/large/synapse_social_icon.png?1696517540"
-    },
-    {
-      "chainId": 1,
-      "address": "0x12e2b8033420270db2f3b328e32370cb5b2ca134",
-      "name": "SafePal",
-      "symbol": "SFP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13905/large/sfp.png?1696513647"
-    },
-    {
-      "chainId": 1,
-      "address": "0x12bb890508c125661e03b09ec06e404bc9289040",
-      "name": "Radio Caca",
-      "symbol": "RACA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17841/large/ez44_BSs_400x400.jpg?1696517365"
-    },
-    {
-      "chainId": 1,
-      "address": "0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419",
-      "name": "DIA",
-      "symbol": "DIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11955/large/Token_Logo.png?1696511815"
-    },
-    {
-      "chainId": 1,
-      "address": "0x408e41876cccdc0f92210600ef50372656052a38",
-      "name": "Ren",
-      "symbol": "REN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3139/large/REN.png?1696503862"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
-      "name": "Polygon",
-      "symbol": "MATIC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4713/large/polygon.png?1698233745"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb7109df1a93f8fe2b8162c6207c9b846c1c68090",
-      "name": "Matr1x",
-      "symbol": "MAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39481/large/t05.png?1722465175"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3da932456d082cba208feb0b096d49b202bf89c8",
-      "name": "Dego Finance",
-      "symbol": "DEGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12503/large/Token.png?1733381203"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7448c7456a97769f6cd04f1e83a4a23ccdc46abd",
-      "name": "Maverick Protocol",
-      "symbol": "MAV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30850/large/MAV_Logo.png?1696529701"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf2b2f7b47715256ce4ea43363a867fdce9353e3a",
-      "name": "Bitgert",
-      "symbol": "BRISE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/17388/large/200x200.png?1696516937"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
-      "name": "Rocket Pool",
-      "symbol": "RPL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
-    },
-    {
-      "chainId": 1,
-      "address": "0x853d955acef822db058eb8505911ed77f175b99e",
-      "name": "Frax",
-      "symbol": "FRAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1696513182"
-    },
-    {
-      "chainId": 1,
-      "address": "0xade00c28244d5ce17d72e40330b1c318cd12b7c3",
-      "name": "AdEx",
-      "symbol": "ADX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/847/large/adex.jpeg?1696501984"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbf2179859fc6d5bee9bf9158632dc51678a4100e",
-      "name": "aelf",
-      "symbol": "ELF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1371/large/aelf-logo.png?1696502429"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
-      "name": "Linear",
-      "symbol": "LINA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12509/large/1649227343-linalogo200px.png?1696512324"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1cf4592ebffd730c7dc92c1bdffdfc3b9efcf29a",
-      "name": "Waves",
-      "symbol": "WAVES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/425/large/waves.png?1696501700"
-    },
-    {
-      "chainId": 1,
-      "address": "0xff56cc6b1e6ded347aa0b7676c85ab0b3d08b0fa",
-      "name": "Orbs",
-      "symbol": "ORBS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4630/large/Orbs.jpg?1696505200"
+      "logoURI": "https://assets.coingecko.com/coins/images/38058/large/icon.png?1717626867"
     },
     {
       "chainId": 1,
@@ -1820,123 +1100,203 @@
     },
     {
       "chainId": 1,
-      "address": "0xf411903cbc70a74d22900a5de66a2dda66507255",
-      "name": "Verasity",
-      "symbol": "VRA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14025/large/logo_%281%29.png?1716968890"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4385328cc4d643ca98dfea734360c0f596c83449",
-      "name": "tomiNet",
-      "symbol": "TOMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28730/large/logo_for_token.png?1696527710"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd3cc9d8f3689b83c91b7b59cab4946b063eb894a",
-      "name": "Venus",
-      "symbol": "XVS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
-    },
-    {
-      "chainId": 1,
-      "address": "0x168e209d7b2f58f1f24b8ae7b7d35e662bbf11cc",
-      "name": "LayerAI",
-      "symbol": "LAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29223/large/Favicon_200x200px.png?1696528181"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8971f9fd7196e5cee2c1032b50f656855af7dd26",
-      "name": "Lambda",
-      "symbol": "LAMB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4703/large/lambda_200.png?1696505268"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
-      "name": "NEXO",
-      "symbol": "NEXO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3695/large/CG-nexo-token-200x200_2x.png?1730414360"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6c5ba91642f10282b576d91922ae6448c9d52f4e",
-      "name": "PHALA",
-      "symbol": "PHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12451/large/phala.png?1696512270"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcf3c8be2e2c42331da80ef210e9b1b307c03d36a",
-      "name": "Bepro",
-      "symbol": "BEPRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10251/large/bepro_logo_200x200.png?1718012232"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0bb217e40f8a5cb79adf04e1aab60e5abd0dfc1e",
-      "name": "SWFTCOIN",
-      "symbol": "SWFTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/2346/large/SWFTCoin.jpg?1696503223"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4507cef57c46789ef8d1a19ea45f4216bae2b528",
-      "name": "TokenFi",
-      "symbol": "TOKEN",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/32507/large/MAIN_TokenFi_logo_icon.png?1698918427"
-    },
-    {
-      "chainId": 1,
-      "address": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
-      "name": "Stader",
-      "symbol": "SD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20658/large/SD_Token_Logo.png?1696520060"
-    },
-    {
-      "chainId": 1,
-      "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
-      "name": "XSGD",
-      "symbol": "XSGD",
+      "address": "0x50327c6c5a14dcade707abad2e27eb517df87ab5",
+      "name": "Wrapped Tron",
+      "symbol": "WTRX",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/12832/large/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623"
+      "logoURI": "https://assets.coingecko.com/coins/images/22471/large/xOesRfpN_400x400.jpg?1696521795"
     },
     {
       "chainId": 1,
-      "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
-      "name": "Bluzelle",
-      "symbol": "BLZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2848/large/ColorIcon_3x.png?1696503607"
+      "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
+      "name": "Storj",
+      "symbol": "STORJ",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/949/large/storj.png?1696502065"
     },
     {
       "chainId": 1,
-      "address": "0xba41ddf06b7ffd89d1267b5a93bfef2424eb2003",
-      "name": "Mythos",
-      "symbol": "MYTH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28045/large/Mythos_Logos_200x200.png?1696527059"
+      "address": "0x198d14f2ad9ce69e76ea330b374de4957c3f850a",
+      "name": "APENFT",
+      "symbol": "NFT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/15687/large/apenft.jpg?1696515316"
     },
     {
       "chainId": 1,
-      "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
-      "name": "Gnosis",
-      "symbol": "GNO",
+      "address": "0x14778860e937f509e651192a90589de711fb88a9",
+      "name": "CYBER",
+      "symbol": "CYBER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/662/large/logo_square_simple_300px.png?1696501854"
+      "logoURI": "https://assets.coingecko.com/coins/images/31274/large/token.png?1715826754"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe1bad922f84b198a08292fb600319300ae32471b",
+      "name": "Firmachain",
+      "symbol": "FCT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9892/large/6mHcLurm_400x400.jpg?1696509941"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
+      "name": "TrueUSD",
+      "symbol": "TUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3449/large/tusd.png?1696504140"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+      "name": "CoW Protocol",
+      "symbol": "COW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8de5b80a0c1b02fe4976851d030b36122dbb8624",
+      "name": "Vanar Chain",
+      "symbol": "VANRY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0a6e7ba5042b38349e437ec6db6214aec7b35676",
+      "name": "Swell",
+      "symbol": "SWELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28777/large/swell1.png?1727899715"
+    },
+    {
+      "chainId": 1,
+      "address": "0x03dde9e5bb31ee40a471476e2fccf75c67921062",
+      "name": "EML Protocol",
+      "symbol": "EML",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30950/large/EML_LOGO.png?1696529788"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4be10da47a07716af28ad199fbe020501bddd7af",
+      "name": "XT com",
+      "symbol": "XT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8391/large/20240701-155217.jpeg?1719895785"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9e32b13ce7f2e80a01932b42553652e053d6ed8e",
+      "name": "Metis",
+      "symbol": "METIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15595/large/Metis_Black_Bg.png?1702968192"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1cf4592ebffd730c7dc92c1bdffdfc3b9efcf29a",
+      "name": "Waves",
+      "symbol": "WAVES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/425/large/waves.png?1696501700"
+    },
+    {
+      "chainId": 1,
+      "address": "0x467719ad09025fcc6cf6f8311755809d45a5e5f3",
+      "name": "Axelar",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg?1696526329"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f3a12b78fee11ee088e454a0547bdbc5a253a6d",
+      "name": "Merlin Chain",
+      "symbol": "MERL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37118/large/merlin.jpeg?1713352230"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
+      "name": "Biconomy",
+      "symbol": "BICO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/large/biconomy_logo.jpg?1696520444"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
+      "name": "Solar",
+      "symbol": "SXP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9368/large/swipe.png?1696509466"
+    },
+    {
+      "chainId": 1,
+      "address": "0x45804880de22913dafe09f4980848ece6ecbaf78",
+      "name": "PAX Gold",
+      "symbol": "PAXG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9519/large/paxgold.png?1696509604"
+    },
+    {
+      "chainId": 1,
+      "address": "0x595832f8fc6bf59c85c527fec3740a1b7a361269",
+      "name": "Powerledger",
+      "symbol": "POWR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/1104/large/Powerledger_Northstar_colour_digital_%282%29.png?1706702222"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
+      "name": "EURC",
+      "symbol": "EURC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/large/euro.png?1696525125"
+    },
+    {
+      "chainId": 1,
+      "address": "0xac51066d7bec65dc4589368da368b212745d63e8",
+      "name": "My Neighbor Alice",
+      "symbol": "ALICE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14375/large/alice_logo.jpg?1696514067"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a79324c19ef2b89ea98b23bc669b7e7c9f8a517",
+      "name": "WAX",
+      "symbol": "WAXP",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/1372/large/WAX_Coin_Tickers_P_512px.png?1696502430"
+    },
+    {
+      "chainId": 1,
+      "address": "0x80c62fe4487e1351b47ba49809ebd60ed085bf52",
+      "name": "Clover Finance",
+      "symbol": "CLV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15278/large/photo_2022-03-24_10-22-33.jpg?1696514930"
+    },
+    {
+      "chainId": 1,
+      "address": "0x925206b8a707096ed26ae47c84747fe0bb734f59",
+      "name": "WhiteBIT Coin",
+      "symbol": "WBT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/27045/large/wbt_token.png?1696526096"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
+      "name": "Threshold Network",
+      "symbol": "T",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22228/large/nFPNiSbL_400x400.jpg?1696521570"
     },
     {
       "chainId": 1,
@@ -1948,123 +1308,75 @@
     },
     {
       "chainId": 1,
-      "address": "0xf4d2888d29d722226fafa5d9b24f9164c092421e",
-      "name": "LooksRare",
-      "symbol": "LOOKS",
+      "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
+      "name": "API3",
+      "symbol": "API3",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22173/large/circle-black-256.png?1696521517"
+      "logoURI": "https://assets.coingecko.com/coins/images/13256/large/api3.jpg?1696513031"
     },
     {
       "chainId": 1,
-      "address": "0x3be7bf1a5f23bd8336787d0289b70602f1940875",
-      "name": "VIDT DAO",
-      "symbol": "VIDT",
+      "address": "0x61ec85ab89377db65762e234c946b5c25a56e99e",
+      "name": "HTX DAO",
+      "symbol": "HTX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27552/large/VIDTDAO_logo.png?1696526588"
+      "logoURI": "https://assets.coingecko.com/coins/images/35491/large/Frame_1321318576.png?1708908626"
     },
     {
       "chainId": 1,
-      "address": "0xf944e35f95e819e752f3ccb5faf40957d311e8c5",
-      "name": "Moca Coin",
-      "symbol": "MOCA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37812/large/moca.jpg?1720693068"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
-      "name": "Kaon",
-      "symbol": "AKRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3328/large/kaon.jpg?1730712283"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4b9278b94a1112cad404048903b8d343a810b07e",
-      "name": "Hifi Finance",
-      "symbol": "HIFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28712/large/hft.png?1696527693"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd26114cd6ee289accf82350c8d8487fedb8a0c07",
-      "name": "OMG Network",
-      "symbol": "OMG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/776/large/OMG_Network.jpg?1696501928"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba5bde662c17e2adff1075610382b9b691296350",
-      "name": "SuperRare",
-      "symbol": "RARE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17753/large/RARE.png?1709598473"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0d3cbed3f69ee050668adf3d9ea57241cba33a2b",
-      "name": "PlayDapp",
-      "symbol": "PDA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14316/large/PDA-symbol.png?1710234068"
-    },
-    {
-      "chainId": 1,
-      "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
-      "name": "FUNToken",
-      "symbol": "FUN",
+      "address": "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
+      "name": "Civic",
+      "symbol": "CVC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/761/large/FUN.png?1696501914"
+      "logoURI": "https://assets.coingecko.com/coins/images/788/large/civic-orange.png?1696501939"
     },
     {
       "chainId": 1,
-      "address": "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e",
-      "name": "crvUSD",
-      "symbol": "CRVUSD",
+      "address": "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
+      "name": "PayPal USD",
+      "symbol": "PYUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1696530039"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb7109df1a93f8fe2b8162c6207c9b846c1c68090",
+      "name": "Matr1x",
+      "symbol": "MAX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30118/large/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
+      "logoURI": "https://assets.coingecko.com/coins/images/39481/large/t05.png?1722465175"
     },
     {
       "chainId": 1,
-      "address": "0x1a4b46696b2bb4794eb3d4c26f1c55f9170fa4c5",
-      "name": "BitDAO",
-      "symbol": "BIT",
+      "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+      "name": "Badger",
+      "symbol": "BADGER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17627/large/rI_YptK8.png?1696517158"
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1696513059"
     },
     {
       "chainId": 1,
-      "address": "0x4b5f49487ea7b3609b1ad05459be420548789f1f",
-      "name": "LeverFi",
-      "symbol": "LEVER",
+      "address": "0xa62cc35625b0c8dc1faea39d33625bb4c15bd71c",
+      "name": "StormX",
+      "symbol": "STMX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26205/large/WI72SpBl_400x400.jpeg?1696525291"
+      "logoURI": "https://assets.coingecko.com/coins/images/1369/large/StormX.png?1696502427"
     },
     {
       "chainId": 1,
-      "address": "0x1121acc14c63f3c872bfca497d10926a6098aac5",
-      "name": "Department Of Government Efficiency",
-      "symbol": "DOGE",
+      "address": "0x52a8845df664d76c69d2eea607cd793565af42b8",
+      "name": "ApeX",
+      "symbol": "APEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39841/large/IMG_9775.PNG?1729771739"
+      "logoURI": "https://assets.coingecko.com/coins/images/25266/large/CxpMECpk_400x400_%281%29.png?1696524406"
     },
     {
       "chainId": 1,
-      "address": "0xc03fbf20a586fa89c2a5f6f941458e1fbc40c661",
-      "name": "COMBO",
-      "symbol": "COMBO",
+      "address": "0xd5f7838f5c461feff7fe49ea5ebaf7728bb0adfa",
+      "name": "Mantle Staked Ether",
+      "symbol": "METH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4932/large/COMBO.jpg?1696505472"
-    },
-    {
-      "chainId": 1,
-      "address": "0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44",
-      "name": "Wrapped TAO",
-      "symbol": "WTAO",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/29087/large/wtao.png?1696528051"
+      "logoURI": "https://assets.coingecko.com/coins/images/33345/large/symbol_transparent_bg.png?1701697066"
     },
     {
       "chainId": 1,
@@ -2076,51 +1388,283 @@
     },
     {
       "chainId": 1,
-      "address": "0xa849eaae994fb86afa73382e9bd88c2b6b18dc71",
-      "name": "MVL",
-      "symbol": "MVL",
+      "address": "0x24fcfc492c1393274b6bcd568ac9e225bec93584",
+      "name": "Heroes of Mavia",
+      "symbol": "MAVIA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3476/large/CoinGecko.png?1711620384"
+      "logoURI": "https://assets.coingecko.com/coins/images/33895/large/2023-12-20_21.21.41_%281%29.jpg?1703230771"
     },
     {
       "chainId": 1,
-      "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
-      "name": "Coinbase Wrapped Staked ETH",
-      "symbol": "CBETH",
+      "address": "0x4b9278b94a1112cad404048903b8d343a810b07e",
+      "name": "Hifi Finance",
+      "symbol": "HIFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1709186989"
+      "logoURI": "https://assets.coingecko.com/coins/images/28712/large/hft.png?1696527693"
     },
     {
       "chainId": 1,
-      "address": "0xec12ba5ac0f259e9ac6fc9a3bc23a76ad2fde5d9",
-      "name": "HugeWin",
-      "symbol": "HUGE",
+      "address": "0xba11d00c5f74255f56a5e366f4f77f5a186d7f55",
+      "name": "Band Protocol",
+      "symbol": "BAND",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35923/large/2024-03-01_17.49.27_%281%29.png?1710221459"
+      "logoURI": "https://assets.coingecko.com/coins/images/9545/large/Band_token_blue_violet_token.png?1696509627"
     },
     {
       "chainId": 1,
-      "address": "0x572975ff6d5136c81c8d7448b6361ef9eefe1ab0",
-      "name": "Wrapped Staked USDT",
-      "symbol": "WSTUSDT",
+      "address": "0x71ab77b7dbb4fa7e017bc15090b2163221420282",
+      "name": "Highstreet",
+      "symbol": "HIGH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31160/large/wstusdt.jpeg?1696529988"
+      "logoURI": "https://assets.coingecko.com/coins/images/18973/large/logosq200200Coingecko.png?1696518427"
     },
     {
       "chainId": 1,
-      "address": "0x61e90a50137e1f645c9ef4a0d3a4f01477738406",
-      "name": "League of Kingdoms",
-      "symbol": "LOKA",
+      "address": "0xabd4c63d2616a5201454168269031355f4764337",
+      "name": "Orderly Network",
+      "symbol": "ORDER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22572/large/loka_64pix.png?1696521891"
+      "logoURI": "https://assets.coingecko.com/coins/images/38501/large/Orderly_Network_Coingecko_200*200.png?1717751359"
     },
     {
       "chainId": 1,
-      "address": "0x814e0908b12a99fecf5bc101bb5d0b8b5cdf7d26",
-      "name": "Measurable Data",
-      "symbol": "MDT",
+      "address": "0x7da2641000cbb407c329310c461b2cb9c70c3046",
+      "name": "Delysium",
+      "symbol": "AGI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2441/large/mdt_icon_120x120.png?1711452723"
+      "logoURI": "https://assets.coingecko.com/coins/images/29299/large/AGI_logo_200.png?1696528251"
+    },
+    {
+      "chainId": 1,
+      "address": "0x626e8036deb333b408be468f951bdb42433cbf18",
+      "name": "AIOZ Network",
+      "symbol": "AIOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14631/large/aioz-logo-200.png?1696514309"
+    },
+    {
+      "chainId": 1,
+      "address": "0x491604c0fdf08347dd1fa4ee062a822a5dd06b5d",
+      "name": "Cartesi",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
+    },
+    {
+      "chainId": 1,
+      "address": "0x579cea1889991f68acc35ff5c3dd0621ff29b0c9",
+      "name": "IQ",
+      "symbol": "IQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5010/large/YAIS3fUh.png?1696505542"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb23d80f5fefcddaa212212f028021b41ded428cf",
+      "name": "Echelon Prime",
+      "symbol": "PRIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/prime-logo-small-border_%282%29.png?1696528020"
+    },
+    {
+      "chainId": 1,
+      "address": "0x081131434f93063751813c619ecca9c4dc7862a3",
+      "name": "Mines of Dalarnia",
+      "symbol": "DAR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/19837/large/dar.png?1696519259"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc52c326331e9ce41f04484d3b5e5648158028804",
+      "name": "Unizen",
+      "symbol": "ZCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14830/large/logo128px.png?1700169101"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf411903cbc70a74d22900a5de66a2dda66507255",
+      "name": "Verasity",
+      "symbol": "VRA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14025/large/logo_%281%29.png?1716968890"
+    },
+    {
+      "chainId": 1,
+      "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
+      "name": "Radworks",
+      "symbol": "RAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14013/large/radicle.png?1696513741"
+    },
+    {
+      "chainId": 1,
+      "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
+      "name": "XSGD",
+      "symbol": "XSGD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/12832/large/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623"
+    },
+    {
+      "chainId": 1,
+      "address": "0x430ef9263e76dae63c84292c3409d61c598e9682",
+      "name": "Vulcan Forged",
+      "symbol": "PYR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14770/large/1617088937196.png?1696514439"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+      "name": "CARV",
+      "symbol": "CARV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba50933c268f567bdc86e1ac131be072c6b0b71a",
+      "name": "ARPA",
+      "symbol": "ARPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8506/large/9u0a23XY_400x400.jpg?1696508685"
+    },
+    {
+      "chainId": 1,
+      "address": "0x031b8d752d73d7fe9678acef26e818280d0646b4",
+      "name": "Sovrun",
+      "symbol": "SOVRN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52312/large/IMG_20241202_183145_081.jpg?1733135740"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba5bde662c17e2adff1075610382b9b691296350",
+      "name": "SuperRare",
+      "symbol": "RARE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17753/large/RARE.png?1709598473"
+    },
+    {
+      "chainId": 1,
+      "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+      "name": "Audius",
+      "symbol": "AUDIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12913/large/AudiusCoinLogo_2x.png?1696512701"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdefa4e8a7bcba345f687a2f1456f5edd9ce97202",
+      "name": "Kyber Network Crystal",
+      "symbol": "KNC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14899/large/RwdVsGcw_400x400.jpg?1696514562"
+    },
+    {
+      "chainId": 1,
+      "address": "0x56072c95faa701256059aa122697b133aded9279",
+      "name": "Sky",
+      "symbol": "SKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39925/large/sky.jpg?1724827980"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+      "name": "Balancer",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
+      "name": "Celer Network",
+      "symbol": "CELR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/large/Celr.png?1696504978"
+    },
+    {
+      "chainId": 1,
+      "address": "0x940a2db1b7008b6c776d4faaca729d6d4a4aa551",
+      "name": "Dusk",
+      "symbol": "DUSK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5217/large/image_widget_biddfvxd454b1.png?1696505726"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4507cef57c46789ef8d1a19ea45f4216bae2b528",
+      "name": "TokenFi",
+      "symbol": "TOKEN",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32507/large/MAIN_TokenFi_logo_icon.png?1698918427"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3e5a19c91266ad8ce2477b91585d1856b84062df",
+      "name": "Ancient8",
+      "symbol": "A8",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39170/large/A8_Token-04_200x200.png?1720798300"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec67005c4e498ec7f55e092bd1d35cbc47c91892",
+      "name": "Enzyme",
+      "symbol": "MLN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/605/large/Enzyme_Icon_Secondary.png?1696501803"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+      "name": "Perpetual Protocol",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbf5495efe5db9ce00f80364c8b423567e58d2110",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+      "name": "Ethena Staked USDe",
+      "symbol": "SUSDE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33669/large/sUSDe-Symbol-Color.png?1716307680"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+      "name": "Polygon",
+      "symbol": "MATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/large/polygon.png?1698233745"
+    },
+    {
+      "chainId": 1,
+      "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
+      "name": "iExec RLC",
+      "symbol": "RLC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/646/large/pL1VuXm.png?1696501840"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb3999f658c0391d94a37f7ff328f3fec942bcadc",
+      "name": "Hashflow",
+      "symbol": "HFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26136/large/200x200_360.png?1728551257"
     },
     {
       "chainId": 1,
@@ -2132,6 +1676,134 @@
     },
     {
       "chainId": 1,
+      "address": "0xa1faa113cbe53436df28ff0aee54275c13b40975",
+      "name": "Stella",
+      "symbol": "ALPHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12738/large/Stella200x200-06.png?1696512537"
+    },
+    {
+      "chainId": 1,
+      "address": "0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419",
+      "name": "DIA",
+      "symbol": "DIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11955/large/Token_Logo.png?1696511815"
+    },
+    {
+      "chainId": 1,
+      "address": "0x91af0fbb28aba7e31403cb457106ce79397fd4e6",
+      "name": "Aergo",
+      "symbol": "AERGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4490/large/aergo.png?1696505079"
+    },
+    {
+      "chainId": 1,
+      "address": "0xadf7c35560035944e805d98ff17d58cde2449389",
+      "name": "Spectral",
+      "symbol": "SPEC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36138/large/ls7wS7vf_400x400.jpg?1724975224"
+    },
+    {
+      "chainId": 1,
+      "address": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd",
+      "name": "DODO",
+      "symbol": "DODO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12651/large/dodo_logo.png?1696512458"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
+      "name": "Linear",
+      "symbol": "LINA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12509/large/1649227343-linalogo200px.png?1696512324"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
+      "name": "Numeraire",
+      "symbol": "NMR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/752/large/numeraire.png?1696501906"
+    },
+    {
+      "chainId": 1,
+      "address": "0x26aad156ba8efa501b32b42ffcdc8413f90e9c99",
+      "name": "Open Campus",
+      "symbol": "EDU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29948/large/EDU_Logo.png?1696528874"
+    },
+    {
+      "chainId": 1,
+      "address": "0xade00c28244d5ce17d72e40330b1c318cd12b7c3",
+      "name": "AdEx",
+      "symbol": "ADX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/847/large/adex.jpeg?1696501984"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
+      "name": "Dent",
+      "symbol": "DENT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/1152/large/DENT_Token.png?1718837065"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbf2179859fc6d5bee9bf9158632dc51678a4100e",
+      "name": "aelf",
+      "symbol": "ELF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1371/large/aelf-logo.png?1696502429"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
+      "name": "Synapse",
+      "symbol": "SYN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/large/synapse_social_icon.png?1696517540"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7448c7456a97769f6cd04f1e83a4a23ccdc46abd",
+      "name": "Maverick Protocol",
+      "symbol": "MAV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30850/large/MAV_Logo.png?1696529701"
+    },
+    {
+      "chainId": 1,
+      "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
+      "name": "OKB",
+      "symbol": "OKB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4463/large/WeChat_Image_20220118095654.png?1696505053"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
+      "name": "Bluzelle",
+      "symbol": "BLZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2848/large/ColorIcon_3x.png?1696503607"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
+      "name": "Origin Token",
+      "symbol": "OGN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3296/large/op.jpg?1696504006"
+    },
+    {
+      "chainId": 1,
       "address": "0x66761fa41377003622aee3c7675fc7b5c1c2fac5",
       "name": "Clearpool",
       "symbol": "CPOOL",
@@ -2140,19 +1812,107 @@
     },
     {
       "chainId": 1,
-      "address": "0xd29da236dd4aac627346e1bba06a619e8c22d7c5",
-      "name": "MAGA Hat",
-      "symbol": "MAGA",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37988/large/MAGA200.jpg?1716223291"
+      "address": "0x83f20f44975d03b1b09e64809b757c47f942beea",
+      "name": "Savings Dai",
+      "symbol": "SDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32254/large/sdai.png?1697015278"
     },
     {
       "chainId": 1,
-      "address": "0x4cc19356f2d37338b9802aa8e8fc58b0373296e7",
-      "name": "SelfKey",
-      "symbol": "KEY",
+      "address": "0x090185f2135308bad17527004364ebcc2d37e5f6",
+      "name": "Spell",
+      "symbol": "SPELL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2034/large/selfkey.png?1696503004"
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/large/abracadabra-3.png?1696515477"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd3cc9d8f3689b83c91b7b59cab4946b063eb894a",
+      "name": "Venus",
+      "symbol": "XVS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf944e35f95e819e752f3ccb5faf40957d311e8c5",
+      "name": "Moca Coin",
+      "symbol": "MOCA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37812/large/moca.jpg?1720693068"
+    },
+    {
+      "chainId": 1,
+      "address": "0x12e2b8033420270db2f3b328e32370cb5b2ca134",
+      "name": "SafePal",
+      "symbol": "SFP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13905/large/sfp.png?1696513647"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2e3356610840701bdf5611a53974510ae27e2e1",
+      "name": "Wrapped Beacon ETH",
+      "symbol": "WBETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30061/large/wbeth-icon.png?1696528983"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4575f41308ec1483f3d399aa9a2826d74da13deb",
+      "name": "Orchid Protocol",
+      "symbol": "OXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3916/large/download_%285%29.png?1696504574"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf2b2f7b47715256ce4ea43363a867fdce9353e3a",
+      "name": "Bitgert",
+      "symbol": "BRISE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17388/large/200x200.png?1696516937"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c5ba91642f10282b576d91922ae6448c9d52f4e",
+      "name": "PHALA",
+      "symbol": "PHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12451/large/phala.png?1696512270"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5cf04716ba20127f1e2297addcf4b5035000c9eb",
+      "name": "NKN",
+      "symbol": "NKN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3375/large/nkn.png?1696504074"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+      "name": "Rocket Pool",
+      "symbol": "RPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
+    },
+    {
+      "chainId": 1,
+      "address": "0xff56cc6b1e6ded347aa0b7676c85ab0b3d08b0fa",
+      "name": "Orbs",
+      "symbol": "ORBS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4630/large/Orbs.jpg?1696505200"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf4d2888d29d722226fafa5d9b24f9164c092421e",
+      "name": "LooksRare",
+      "symbol": "LOOKS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22173/large/circle-black-256.png?1696521517"
     },
     {
       "chainId": 1,
@@ -2161,6 +1921,198 @@
       "symbol": "GTC",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/15810/large/gitcoin.png?1696515429"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4b5f49487ea7b3609b1ad05459be420548789f1f",
+      "name": "LeverFi",
+      "symbol": "LEVER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26205/large/WI72SpBl_400x400.jpeg?1696525291"
+    },
+    {
+      "chainId": 1,
+      "address": "0x761d38e5ddf6ccf6cf7c55759d5210750b5d60f3",
+      "name": "Dogelon Mars",
+      "symbol": "ELON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14962/large/6GxcPRo3_400x400.jpg?1696514622"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+      "name": "Gnosis",
+      "symbol": "GNO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/662/large/logo_square_simple_300px.png?1696501854"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
+      "name": "NEXO",
+      "symbol": "NEXO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3695/large/CG-nexo-token-200x200_2x.png?1730414360"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
+      "name": "Wrapped Fantom",
+      "symbol": "WFTM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16036/large/Fantom.png?1696515646"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0d3cbed3f69ee050668adf3d9ea57241cba33a2b",
+      "name": "PlayDapp",
+      "symbol": "PDA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14316/large/PDA-symbol.png?1710234068"
+    },
+    {
+      "chainId": 1,
+      "address": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
+      "name": "AUSD",
+      "symbol": "AUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39284/large/Circle_Agora_White_on_Olive_1080px.png?1722961274"
+    },
+    {
+      "chainId": 1,
+      "address": "0x14fee680690900ba0cccfc76ad70fd1b95d10e16",
+      "name": "PAAL AI",
+      "symbol": "PAAL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/30815/large/Paal_New_Logo_%281%29.png?1718160584"
+    },
+    {
+      "chainId": 1,
+      "address": "0x408e41876cccdc0f92210600ef50372656052a38",
+      "name": "Ren",
+      "symbol": "REN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3139/large/REN.png?1696503862"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfc385a1df85660a7e041423db512f779070fcede",
+      "name": "zkLink",
+      "symbol": "ZKL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34982/large/Logo1.png?1714980729"
+    },
+    {
+      "chainId": 1,
+      "address": "0x12bb890508c125661e03b09ec06e404bc9289040",
+      "name": "Radio Caca",
+      "symbol": "RACA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17841/large/ez44_BSs_400x400.jpg?1696517365"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8390a1da07e376ef7add4be859ba74fb83aa02d5",
+      "name": "Grok",
+      "symbol": "GROK",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32788/large/GROK.png?1707579427"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfe3e6a25e6b192a42a44ecddcd13796471735acf",
+      "name": "Reef",
+      "symbol": "REEF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13504/large/Group_10572.png?1696513266"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7a56e1c57c7475ccf742a1832b028f0456652f97",
+      "name": "Solv Protocol SolvBTC",
+      "symbol": "SOLVBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36800/large/solvBTC.png?1719810684"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9aab071b4129b083b01cb5a0cb513ce7eca26fa5",
+      "name": "Hunt",
+      "symbol": "HUNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7989/large/HUNT.png?1696508215"
+    },
+    {
+      "chainId": 1,
+      "address": "0x572975ff6d5136c81c8d7448b6361ef9eefe1ab0",
+      "name": "Wrapped Staked USDT",
+      "symbol": "WSTUSDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31160/large/wstusdt.jpeg?1696529988"
+    },
+    {
+      "chainId": 1,
+      "address": "0x57b946008913b82e4df85f501cbaed910e58d26c",
+      "name": "Marlin",
+      "symbol": "POND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8903/large/200x200.png?1706115827"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
+      "name": "Aavegotchi",
+      "symbol": "GHST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12467/large/GHST.png?1696512286"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e",
+      "name": "crvUSD",
+      "symbol": "CRVUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/large/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
+    },
+    {
+      "chainId": 1,
+      "address": "0x853d955acef822db058eb8505911ed77f175b99e",
+      "name": "Frax",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1696513182"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc03fbf20a586fa89c2a5f6f941458e1fbc40c661",
+      "name": "COMBO",
+      "symbol": "COMBO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4932/large/COMBO.jpg?1696505472"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4385328cc4d643ca98dfea734360c0f596c83449",
+      "name": "tomiNet",
+      "symbol": "TOMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28730/large/logo_for_token.png?1696527710"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde7d85157d9714eadf595045cc12ca4a5f3e2adb",
+      "name": "STP",
+      "symbol": "STPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8713/large/STP.png?1696508875"
+    },
+    {
+      "chainId": 1,
+      "address": "0x168e209d7b2f58f1f24b8ae7b7d35e662bbf11cc",
+      "name": "LayerAI",
+      "symbol": "LAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29223/large/Favicon_200x200px.png?1696528181"
     },
     {
       "chainId": 1,
@@ -2180,635 +2132,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xd433138d12beb9929ff6fd583dc83663eea6aaa5",
-      "name": "Bitrue Coin",
-      "symbol": "BTR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8873/large/Bittrue_logo.png?1696509025"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd31a59c85ae9d8edefec411d448f90841571b89c",
-      "name": "SOL  Wormhole ",
-      "symbol": "SOL",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/22876/large/SOL_wh_small.png?1696522175"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbbc2ae13b23d715c30720f079fcd9b4a74093505",
-      "name": "Ethernity Chain",
-      "symbol": "ERN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14238/large/logo_black.png?1715198164"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3010ccb5419f1ef26d40a7cd3f0d707a0fa127dc",
-      "name": "Gems VIP",
-      "symbol": "GEMS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38725/large/200x200.png?1718478016"
-    },
-    {
-      "chainId": 1,
-      "address": "0x944824290cc12f31ae18ef51216a223ba4063092",
-      "name": "Masa",
-      "symbol": "MASA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35538/large/masa.png?1712635899"
-    },
-    {
-      "chainId": 1,
-      "address": "0xef3a930e1ffffacd2fc13434ac81bd278b0ecc8d",
-      "name": "Stafi",
-      "symbol": "FIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12423/large/FIS.png?1696512244"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
-      "name": "Alchemix",
-      "symbol": "ALCX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14113/large/Alchemix.png?1696513834"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2a9bdcff37ab68b95a53435adfd8892e86084f93",
-      "name": "Alpha Quark",
-      "symbol": "AQT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12872/large/alpha_quark_logo.png?1696512660"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfe3e6a25e6b192a42a44ecddcd13796471735acf",
-      "name": "Reef",
-      "symbol": "REEF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13504/large/Group_10572.png?1696513266"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe66747a101bff2dba3697199dcce5b743b454759",
-      "name": "Gate",
-      "symbol": "GT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8183/large/gate.png?1696508395"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb056c38f6b7dc4064367403e26424cd2c60655e1",
-      "name": "CEEK Smart VR",
-      "symbol": "CEEK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2581/large/ceek-smart-vr-token-logo.png?1696503385"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8ed97a637a790be1feff5e888d43629dc05408f6",
-      "name": "Non Playable Coin",
-      "symbol": "NPC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31193/large/NPC_200x200.png?1696530021"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd2ba23de8a19316a638dc1e7a9adda1d74233368",
-      "name": "Quickswap",
-      "symbol": "QUICK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25393/large/quickswap.png?1696524525"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa2cd3d43c775978a96bdbf12d733d5a1ed94fb18",
-      "name": "Onyxcoin",
-      "symbol": "XCN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24210/large/onyxlogo.jpg?1696523397"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb59490ab09a0f526cc7305822ac65f2ab12f9723",
-      "name": "Litentry",
-      "symbol": "LIT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13825/large/logo_200x200.png?1696513568"
-    },
-    {
-      "chainId": 1,
-      "address": "0x77777feddddffc19ff86db637967013e6c6a116c",
-      "name": "Tornado Cash",
-      "symbol": "TORN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13496/large/ZINt8NSB_400x400.jpg?1696513257"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
-      "name": "Wrapped Fantom",
-      "symbol": "WFTM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16036/large/Fantom.png?1696515646"
-    },
-    {
-      "chainId": 1,
-      "address": "0x56072c95faa701256059aa122697b133aded9279",
-      "name": "Sky",
-      "symbol": "SKY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39925/large/sky.jpg?1724827980"
-    },
-    {
-      "chainId": 1,
-      "address": "0xec67005c4e498ec7f55e092bd1d35cbc47c91892",
-      "name": "Enzyme",
-      "symbol": "MLN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/605/large/Enzyme_Icon_Secondary.png?1696501803"
-    },
-    {
-      "chainId": 1,
-      "address": "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
-      "name": "Boba Network",
-      "symbol": "BOBA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20285/large/Boba-200x200---white.png?1696519690"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9d1a7a3191102e9f900faa10540837ba84dcbae7",
-      "name": "Eurite",
-      "symbol": "EURI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39952/large/EURI.jpg?1724902829"
-    },
-    {
-      "chainId": 1,
-      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
-      "name": "Telos",
-      "symbol": "TLOS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7588/large/tlos_png.png?1722391289"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbe1a001fe942f96eea22ba08783140b9dcc09d28",
-      "name": "Beta Finance",
-      "symbol": "BETA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18715/large/beta_finance.jpg?1696518183"
-    },
-    {
-      "chainId": 1,
-      "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
-      "name": "Telcoin",
-      "symbol": "TEL",
-      "decimals": 2,
-      "logoURI": "https://assets.coingecko.com/coins/images/1899/large/tel.png?1696502892"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
-      "name": "Bone ShibaSwap",
-      "symbol": "BONE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16916/large/bone_icon.png?1696516487"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfc385a1df85660a7e041423db512f779070fcede",
-      "name": "zkLink",
-      "symbol": "ZKL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34982/large/Logo1.png?1714980729"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf94e7d0710709388bce3161c32b4eea56d3f91cc",
-      "name": "Destra Network",
-      "symbol": "DSYNC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35996/large/Destra_Network.png?1710316001"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbf5495efe5db9ce00f80364c8b423567e58d2110",
-      "name": "Renzo Restaked ETH",
-      "symbol": "EZETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc98d64da73a6616c42117b582e832812e7b8d57f",
-      "name": "RSS3",
-      "symbol": "RSS3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23575/large/rss3.jpeg?1718351333"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa2120b9e674d3fc3875f415a7df52e382f141225",
-      "name": "Automata",
-      "symbol": "ATA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15985/large/ATA_Icon_%28Profile_2%29.png?1720487988"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8642a849d0dcb7a15a974794668adcfbe4794b56",
-      "name": "Prosper",
-      "symbol": "PROS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13668/large/PFP_Visual_CG.png?1727714135"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd01409314acb3b245cea9500ece3f6fd4d70ea30",
-      "name": "LTO Network",
-      "symbol": "LTO",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/6068/large/lto.png?1696506473"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
-      "name": "IDEX",
-      "symbol": "IDEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2565/large/idexlogo.png?1696503371"
-    },
-    {
-      "chainId": 1,
-      "address": "0x594daad7d77592a2b97b725a7ad59d7e188b5bfa",
-      "name": "Apu Apustaja",
-      "symbol": "APU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35986/large/200x200.png?1710308147"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1495bc9e44af1f8bcb62278d2bec4540cf0c05ea",
-      "name": "Zero1 Labs",
-      "symbol": "DEAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36315/large/512x512-xion-ava03.png?1711092111"
-    },
-    {
-      "chainId": 1,
-      "address": "0x667102bd3413bfeaa3dffb48fa8288819e480a88",
-      "name": "Tokenize Xchange",
-      "symbol": "TKX",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/4984/large/TKX_-_Logo_-_RGB-15.png?1696505519"
-    },
-    {
-      "chainId": 1,
-      "address": "0x38e382f74dfb84608f3c1f10187f6bef5951de93",
-      "name": "Multibit",
-      "symbol": "MUBI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33051/large/multi.jpg?1700473994"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7ddc52c4de30e94be3a6a0a2b259b2850f421989",
-      "name": "Gomining Token",
-      "symbol": "GOMINING",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15662/large/GoMining_Logo.png?1714757256"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdc9ac3c20d1ed0b540df9b1fedc10039df13f99c",
-      "name": "xMoney",
-      "symbol": "UTK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1824/large/200x200.png?1696723239"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
-      "name": "OriginTrail",
-      "symbol": "TRAC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1877/large/TRAC.jpg?1696502873"
-    },
-    {
-      "chainId": 1,
-      "address": "0x67466be17df832165f8c80a5a120ccc652bd7e69",
-      "name": "LandWolf",
-      "symbol": "WOLF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37403/large/wolf_200x200.png?1715222165"
-    },
-    {
-      "chainId": 1,
-      "address": "0xadd5e881984783dd432f80381fb52f45b53f3e70",
-      "name": "Vite",
-      "symbol": "VITE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4513/large/VITE_new_logo_200px.png?1709175957"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7abc8a5768e6be61a6c693a6e4eacb5b60602c4d",
-      "name": "Covalent X Token",
-      "symbol": "CXT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39177/large/CXT_Ticker.png?1720829918"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa91ac63d040deb1b7a5e4d4134ad23eb0ba07e14",
-      "name": "Bella Protocol",
-      "symbol": "BEL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12478/large/Bella.png?1696512296"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfc82bb4ba86045af6f327323a46e80412b91b27d",
-      "name": "Prom",
-      "symbol": "PROM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8825/large/Ticker.png?1696508978"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9e9fbde7c7a83c43913bddc8779158f1368f0413",
-      "name": "Pandora",
-      "symbol": "PANDORA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34996/large/PandoraToken.png?1706954340"
-    },
-    {
-      "chainId": 1,
-      "address": "0x826180541412d574cf1336d22c0c0a287822678a",
-      "name": "Chainflip",
-      "symbol": "FLIP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25576/large/kdt_AgmT_400x400.png?1696524709"
-    },
-    {
-      "chainId": 1,
-      "address": "0x25931894a86d47441213199621f1f2994e1c39aa",
-      "name": "ChainGPT",
-      "symbol": "CGPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29306/large/200x200.png?1696528257"
-    },
-    {
-      "chainId": 1,
-      "address": "0x68749665ff8d2d112fa859aa293f07a622782f38",
-      "name": "Tether Gold",
-      "symbol": "XAUT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/10481/large/Tether_Gold.png?1696510471"
-    },
-    {
-      "chainId": 1,
-      "address": "0x28561b8a2360f463011c16b6cc0b0cbef8dbbcad",
-      "name": "MOO DENG",
-      "symbol": "MOODENG",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/50348/large/1000000612.jpg?1727248974"
-    },
-    {
-      "chainId": 1,
-      "address": "0x79f05c263055ba20ee0e814acd117c20caa10e0c",
-      "name": "Ice Open Network",
-      "symbol": "ICE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34674/large/ion-coingecko-200w.png?1714009819"
-    },
-    {
-      "chainId": 1,
-      "address": "0x97a9a15168c22b3c137e6381037e1499c8ad0978",
-      "name": "Data Ownership Protocol",
-      "symbol": "DOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36706/large/DOP-Round-200x200.png?1720836160"
-    },
-    {
-      "chainId": 1,
       "address": "0x12970e6868f88f6557b76120662c1b3e50a646bf",
       "name": "Milady Meme Coin",
       "symbol": "LADYS",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/30194/large/LADYS_Clean.png?1725897475"
-    },
-    {
-      "chainId": 1,
-      "address": "0x761d38e5ddf6ccf6cf7c55759d5210750b5d60f3",
-      "name": "Dogelon Mars",
-      "symbol": "ELON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14962/large/6GxcPRo3_400x400.jpg?1696514622"
-    },
-    {
-      "chainId": 1,
-      "address": "0xeeb4d8400aeefafc1b2953e0094134a887c76bd8",
-      "name": "Avail",
-      "symbol": "AVAIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37372/large/avail-logo.png?1714145201"
-    },
-    {
-      "chainId": 1,
-      "address": "0xde7d85157d9714eadf595045cc12ca4a5f3e2adb",
-      "name": "STP",
-      "symbol": "STPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8713/large/STP.png?1696508875"
-    },
-    {
-      "chainId": 1,
-      "address": "0x48b847cf774a5710f36f594b11fc10e2e59bba72",
-      "name": "Unit0",
-      "symbol": "UNIT0",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51237/large/200%D1%85200.png?1730448085"
-    },
-    {
-      "chainId": 1,
-      "address": "0xde4ee8057785a7e8e800db58f9784845a5c2cbd6",
-      "name": "DeXe",
-      "symbol": "DEXE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12713/large/DEXE_token_logo.png?1696512514"
-    },
-    {
-      "chainId": 1,
-      "address": "0x508e00d5cef397b02d260d035e5ee80775e4c821",
-      "name": "Bitcoin Cats",
-      "symbol": "1CAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34059/large/779e5404024bcd3cec3db54370ea66c.jpg?1703752231"
-    },
-    {
-      "chainId": 1,
-      "address": "0xea26c4ac16d4a5a106820bc8aee85fd0b7b2b664",
-      "name": "QuarkChain",
-      "symbol": "QKC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3849/large/QuarkChain.jpg?1730964236"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4c11249814f11b9346808179cf06e71ac328c1b5",
-      "name": "Oraichain",
-      "symbol": "ORAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12931/large/orai.png?1696512718"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7613c48e0cd50e42dd9bf0f6c235063145f6f8dc",
-      "name": "Pirate Nation Token",
-      "symbol": "PIRATE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38524/large/_Pirate_Transparent_200x200.png?1717947813"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7a56e1c57c7475ccf742a1832b028f0456652f97",
-      "name": "Solv Protocol SolvBTC",
-      "symbol": "SOLVBTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36800/large/solvBTC.png?1719810684"
-    },
-    {
-      "chainId": 1,
-      "address": "0x96f6ef951840721adbf46ac996b59e0235cb985c",
-      "name": "Ondo US Dollar Yield",
-      "symbol": "USDY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31700/large/usdy_%281%29.png?1696530524"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3ffeea07a27fab7ad1df5297fa75e77a43cb5790",
-      "name": "PeiPei",
-      "symbol": "PEIPEI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38512/large/PeiPei.png?1718315778"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1e053d89e08c24aa2ce5c5b4206744dc2d7bd8f5",
-      "name": "ThunderCore",
-      "symbol": "TT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4375/large/ThunderCore_Logo_Mark_Gradient_%283%29.png?1696504974"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0f51bb10119727a7e5ea3538074fb341f56b09ad",
-      "name": "DAO Maker",
-      "symbol": "DAO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13915/large/4.jpg?1727532864"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0c7d5ae016f806603cb1782bea29ac69471cab9c",
-      "name": "Bifrost",
-      "symbol": "BFC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4639/large/BFC_Symbol.png?1696505208"
-    },
-    {
-      "chainId": 1,
-      "address": "0x06450dee7fd2fb8e39061434babcfc05599a6fb8",
-      "name": "XEN Crypto",
-      "symbol": "XEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27713/large/Xen.jpeg?1696526739"
-    },
-    {
-      "chainId": 1,
-      "address": "0x628a3b2e302c7e896acc432d2d0dd22b6cb9bc88",
-      "name": "LimeWire",
-      "symbol": "LMWR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30356/large/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8f693ca8d21b157107184d29d398a8d082b38b76",
-      "name": "Streamr",
-      "symbol": "DATA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17869/large/DATA_new_symbol_3x.png?1696517392"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8236a87084f8b84306f72007f36f2618a5634494",
-      "name": "Lombard Staked BTC",
-      "symbol": "LBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39969/large/LBTC_Logo.png?1724959872"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaaaaaa20d9e0e2461697782ef11675f668207961",
-      "name": "Aurora",
-      "symbol": "AURORA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20582/large/aurora.jpeg?1696519989"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
-      "name": "Request",
-      "symbol": "REQ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1031/large/Request_icon_green.png?1696502140"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2be5e8c109e2197d077d13a82daead6a9b3433c5",
-      "name": "Tokamak Network",
-      "symbol": "TON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12260/large/D919x5-s_400x400.png?1696512091"
-    },
-    {
-      "chainId": 1,
-      "address": "0x72e4f9f808c49a2a61de9c5896298920dc4eeea9",
-      "name": "HarryPotterObamaSonic10Inu  ETH ",
-      "symbol": "BITCOIN",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
-    },
-    {
-      "chainId": 1,
-      "address": "0x77fba179c79de5b7653f68b5039af940ada60ce0",
-      "name": "Ampleforth Governance",
-      "symbol": "FORTH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14917/large/photo_2021-04-22_00.00.03.jpeg?1696514579"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3e5a19c91266ad8ce2477b91585d1856b84062df",
-      "name": "Ancient8",
-      "symbol": "A8",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39170/large/A8_Token-04_200x200.png?1720798300"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf8ebf4849f1fa4faf0dff2106a173d3a6cb2eb3a",
-      "name": "Troll",
-      "symbol": "TROLL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29897/large/TROLL.jpeg?1696528821"
     },
     {
       "chainId": 1,
@@ -2820,123 +2148,115 @@
     },
     {
       "chainId": 1,
-      "address": "0x4527a3b4a8a150403090a99b87effc96f2195047",
-      "name": "P2P solutions foundation",
-      "symbol": "P2PS",
+      "address": "0x61e90a50137e1f645c9ef4a0d3a4f01477738406",
+      "name": "League of Kingdoms",
+      "symbol": "LOKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22572/large/loka_64pix.png?1696521891"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb59490ab09a0f526cc7305822ac65f2ab12f9723",
+      "name": "Litentry",
+      "symbol": "LIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13825/large/logo_200x200.png?1696513568"
+    },
+    {
+      "chainId": 1,
+      "address": "0xeeb4d8400aeefafc1b2953e0094134a887c76bd8",
+      "name": "Avail",
+      "symbol": "AVAIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37372/large/avail-logo.png?1714145201"
+    },
+    {
+      "chainId": 1,
+      "address": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
+      "name": "Stader",
+      "symbol": "SD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20658/large/SD_Token_Logo.png?1696520060"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3ffeea07a27fab7ad1df5297fa75e77a43cb5790",
+      "name": "PeiPei",
+      "symbol": "PEIPEI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38512/large/PeiPei.png?1718315778"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd433138d12beb9929ff6fd583dc83663eea6aaa5",
+      "name": "Bitrue Coin",
+      "symbol": "BTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8873/large/Bittrue_logo.png?1696509025"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd26114cd6ee289accf82350c8d8487fedb8a0c07",
+      "name": "OMG Network",
+      "symbol": "OMG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/776/large/OMG_Network.jpg?1696501928"
+    },
+    {
+      "chainId": 1,
+      "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
+      "name": "FUNToken",
+      "symbol": "FUN",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/2798/large/p2ps.png?1696503565"
+      "logoURI": "https://assets.coingecko.com/coins/images/761/large/FUN.png?1696501914"
     },
     {
       "chainId": 1,
-      "address": "0x91af0fbb28aba7e31403cb457106ce79397fd4e6",
-      "name": "Aergo",
-      "symbol": "AERGO",
+      "address": "0x7ddc52c4de30e94be3a6a0a2b259b2850f421989",
+      "name": "Gomining Token",
+      "symbol": "GOMINING",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4490/large/aergo.png?1696505079"
+      "logoURI": "https://assets.coingecko.com/coins/images/15662/large/GoMining_Logo.png?1714757256"
     },
     {
       "chainId": 1,
-      "address": "0x6e79b51959cf968d87826592f46f819f92466615",
-      "name": "Hoppy",
-      "symbol": "HOPPY",
+      "address": "0xf4fb9bf10e489ea3edb03e094939341399587b0c",
+      "name": "AirDAO",
+      "symbol": "AMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1041/large/amb.png?1696502148"
+    },
+    {
+      "chainId": 1,
+      "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
+      "name": "tBTC",
+      "symbol": "TBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd29da236dd4aac627346e1bba06a619e8c22d7c5",
+      "name": "MAGA Hat",
+      "symbol": "MAGA",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37197/large/Hoppy_200x200_.png?1724175711"
+      "logoURI": "https://assets.coingecko.com/coins/images/37988/large/MAGA200.jpg?1716223291"
     },
     {
       "chainId": 1,
-      "address": "0xed35af169af46a02ee13b9d79eb57d6d68c1749e",
-      "name": "ECOMI",
-      "symbol": "OMI",
+      "address": "0xa91ac63d040deb1b7a5e4d4134ad23eb0ba07e14",
+      "name": "Bella Protocol",
+      "symbol": "BEL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4428/large/ECOMI.png?1696505023"
+      "logoURI": "https://assets.coingecko.com/coins/images/12478/large/Bella.png?1696512296"
     },
     {
       "chainId": 1,
-      "address": "0xbef26bd568e421d6708cca55ad6e35f8bfa0c406",
-      "name": "bitsCrunch Token",
-      "symbol": "BCUT",
+      "address": "0xe66747a101bff2dba3697199dcce5b743b454759",
+      "name": "Gate",
+      "symbol": "GT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34832/large/logo-256_%281%29.png?1710244462"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8390a1da07e376ef7add4be859ba74fb83aa02d5",
-      "name": "Grok",
-      "symbol": "GROK",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/32788/large/GROK.png?1707579427"
-    },
-    {
-      "chainId": 1,
-      "address": "0x52284158e02425290f6b627aeb5fff65edf058ad",
-      "name": "FlappyMoonbird",
-      "symbol": "FMB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30659/large/200_%282%29.jpg?1696529529"
-    },
-    {
-      "chainId": 1,
-      "address": "0x701c244b988a513c945973defa05de933b23fe1d",
-      "name": "OAX",
-      "symbol": "OAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/853/large/OAXlogo.png?1696501987"
-    },
-    {
-      "chainId": 1,
-      "address": "0x554fb3b6c1cf4a3cef49779ced321ca51c667d7d",
-      "name": "Arata AGI",
-      "symbol": "ARATA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51555/large/500px.png?1731517839"
-    },
-    {
-      "chainId": 1,
-      "address": "0x94a8b4ee5cd64c79d0ee816f467ea73009f51aa0",
-      "name": "Realio Network Token",
-      "symbol": "RIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12206/large/Rio.png?1696512042"
-    },
-    {
-      "chainId": 1,
-      "address": "0x44971abf0251958492fee97da3e5c5ada88b9185",
-      "name": "BasedAI",
-      "symbol": "BASEDAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36607/large/1000004475.png?1711964332"
-    },
-    {
-      "chainId": 1,
-      "address": "0x825459139c897d769339f295e962396c4f9e4a4d",
-      "name": "GameBuild",
-      "symbol": "GAME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37789/large/Gamebuild-logo-200.png?1715586834"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc328a59e7321747aebbc49fd28d1b32c1af8d3b2",
-      "name": "Phil",
-      "symbol": "PHIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39975/large/yr0kMUrz_400x400.jpg?1724971221"
-    },
-    {
-      "chainId": 1,
-      "address": "0x678e840c640f619e17848045d23072844224dd37",
-      "name": "Cratos",
-      "symbol": "CRTS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17322/large/cratos.png?1696516876"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5026f006b85729a8b14553fae6af249ad16c9aab",
-      "name": "Wojak",
-      "symbol": "WOJAK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29856/large/wojak.png?1696528782"
+      "logoURI": "https://assets.coingecko.com/coins/images/8183/large/gate.png?1696508395"
     },
     {
       "chainId": 1,
@@ -2948,75 +2268,515 @@
     },
     {
       "chainId": 1,
-      "address": "0x0391d2021f89dc339f60fff84546ea23e337750f",
-      "name": "BarnBridge",
-      "symbol": "BOND",
+      "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+      "name": "Rocket Pool ETH",
+      "symbol": "RETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12811/large/barnbridge.jpg?1696512604"
+      "logoURI": "https://assets.coingecko.com/coins/images/20764/large/reth.png?1696520159"
     },
     {
       "chainId": 1,
-      "address": "0xc555d625828c4527d477e595ff1dd5801b4a600e",
-      "name": "MON Protocol",
-      "symbol": "MON",
+      "address": "0xd0a6053f087e87a25dc60701ba6e663b1a548e85",
+      "name": "BLOCKLORDS",
+      "symbol": "LRDS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37395/large/WhatsApp_Image_2024-02-27_at_18.34.45_01762153.jpg?1716261730"
+      "logoURI": "https://assets.coingecko.com/coins/images/34775/large/LRDS_PNG.png?1706001771"
     },
     {
       "chainId": 1,
-      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
-      "name": "Pocket Network",
-      "symbol": "POKT",
+      "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
+      "name": "Coinbase Wrapped Staked ETH",
+      "symbol": "CBETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1709186989"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe7c6bf469e97eeb0bfb74c8dbff5bd47d4c1c98a",
+      "name": "HashKey Platform Token",
+      "symbol": "HSK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29779/large/HSKlogo.jpg?1719445510"
+    },
+    {
+      "chainId": 1,
+      "address": "0x79f05c263055ba20ee0e814acd117c20caa10e0c",
+      "name": "Ice Open Network",
+      "symbol": "ICE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34674/large/ion-coingecko-200w.png?1714009819"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+      "name": "Alchemix",
+      "symbol": "ALCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14113/large/Alchemix.png?1696513834"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec12ba5ac0f259e9ac6fc9a3bc23a76ad2fde5d9",
+      "name": "HugeWin",
+      "symbol": "HUGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35923/large/2024-03-01_17.49.27_%281%29.png?1710221459"
+    },
+    {
+      "chainId": 1,
+      "address": "0x97a9a15168c22b3c137e6381037e1499c8ad0978",
+      "name": "Data Ownership Protocol",
+      "symbol": "DOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36706/large/DOP-Round-200x200.png?1720836160"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
+      "name": "Bone ShibaSwap",
+      "symbol": "BONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16916/large/bone_icon.png?1696516487"
+    },
+    {
+      "chainId": 1,
+      "address": "0x72e4f9f808c49a2a61de9c5896298920dc4eeea9",
+      "name": "HarryPotterObamaSonic10Inu  ETH ",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1495bc9e44af1f8bcb62278d2bec4540cf0c05ea",
+      "name": "Zero1 Labs",
+      "symbol": "DEAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36315/large/512x512-xion-ava03.png?1711092111"
+    },
+    {
+      "chainId": 1,
+      "address": "0xef3a930e1ffffacd2fc13434ac81bd278b0ecc8d",
+      "name": "Stafi",
+      "symbol": "FIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12423/large/FIS.png?1696512244"
+    },
+    {
+      "chainId": 1,
+      "address": "0x825459139c897d769339f295e962396c4f9e4a4d",
+      "name": "GameBuild",
+      "symbol": "GAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37789/large/Gamebuild-logo-200.png?1715586834"
+    },
+    {
+      "chainId": 1,
+      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
+      "name": "Telos",
+      "symbol": "TLOS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7588/large/tlos_png.png?1722391289"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3010ccb5419f1ef26d40a7cd3f0d707a0fa127dc",
+      "name": "Gems VIP",
+      "symbol": "GEMS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38725/large/200x200.png?1718478016"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3da932456d082cba208feb0b096d49b202bf89c8",
+      "name": "Dego Finance",
+      "symbol": "DEGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12503/large/Token.png?1733381203"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
+      "name": "Kaon",
+      "symbol": "AKRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3328/large/kaon.jpg?1730712283"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7613c48e0cd50e42dd9bf0f6c235063145f6f8dc",
+      "name": "Pirate Nation Token",
+      "symbol": "PIRATE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38524/large/_Pirate_Transparent_200x200.png?1717947813"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a9bdcff37ab68b95a53435adfd8892e86084f93",
+      "name": "Alpha Quark",
+      "symbol": "AQT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12872/large/alpha_quark_logo.png?1696512660"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa849eaae994fb86afa73382e9bd88c2b6b18dc71",
+      "name": "MVL",
+      "symbol": "MVL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3476/large/CoinGecko.png?1711620384"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3be7bf1a5f23bd8336787d0289b70602f1940875",
+      "name": "VIDT DAO",
+      "symbol": "VIDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27552/large/VIDTDAO_logo.png?1696526588"
+    },
+    {
+      "chainId": 1,
+      "address": "0x814e0908b12a99fecf5bc101bb5d0b8b5cdf7d26",
+      "name": "Measurable Data",
+      "symbol": "MDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2441/large/mdt_icon_120x120.png?1711452723"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc0b68eb52c89e3fffa62d78012ac8b661bfaa323",
+      "name": "Vixco",
+      "symbol": "VIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15405/large/vixco.png?1696515051"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2120b9e674d3fc3875f415a7df52e382f141225",
+      "name": "Automata",
+      "symbol": "ATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15985/large/ATA_Icon_%28Profile_2%29.png?1720487988"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd2ba23de8a19316a638dc1e7a9adda1d74233368",
+      "name": "Quickswap",
+      "symbol": "QUICK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25393/large/quickswap.png?1696524525"
+    },
+    {
+      "chainId": 1,
+      "address": "0x667102bd3413bfeaa3dffb48fa8288819e480a88",
+      "name": "Tokenize Xchange",
+      "symbol": "TKX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/4984/large/TKX_-_Logo_-_RGB-15.png?1696505519"
+    },
+    {
+      "chainId": 1,
+      "address": "0xea26c4ac16d4a5a106820bc8aee85fd0b7b2b664",
+      "name": "QuarkChain",
+      "symbol": "QKC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3849/large/QuarkChain.jpg?1730964236"
+    },
+    {
+      "chainId": 1,
+      "address": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
+      "name": "Staked USD0",
+      "symbol": "USD0++",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39169/large/0x35d8949372d46b7a3d5a56006ae77b215fc69bc0.png?1720798057"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd31a59c85ae9d8edefec411d448f90841571b89c",
+      "name": "SOL  Wormhole ",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/large/SOL_wh_small.png?1696522175"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ed97a637a790be1feff5e888d43629dc05408f6",
+      "name": "Non Playable Coin",
+      "symbol": "NPC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31193/large/NPC_200x200.png?1696530021"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbbc2ae13b23d715c30720f079fcd9b4a74093505",
+      "name": "Ethernity Chain",
+      "symbol": "ERN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14238/large/logo_black.png?1715198164"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1121acc14c63f3c872bfca497d10926a6098aac5",
+      "name": "Department Of Government Efficiency",
+      "symbol": "DOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39841/large/IMG_9775.PNG?1729771739"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7abc8a5768e6be61a6c693a6e4eacb5b60602c4d",
+      "name": "Covalent X Token",
+      "symbol": "CXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39177/large/CXT_Ticker.png?1720829918"
+    },
+    {
+      "chainId": 1,
+      "address": "0x69a1e699f562d7af66fc6cc473d99f4430c3acd2",
+      "name": "Param",
+      "symbol": "PARAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37697/large/param200.png?1715234889"
+    },
+    {
+      "chainId": 1,
+      "address": "0x25931894a86d47441213199621f1f2994e1c39aa",
+      "name": "ChainGPT",
+      "symbol": "CGPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29306/large/200x200.png?1696528257"
+    },
+    {
+      "chainId": 1,
+      "address": "0x425087bf4969f45818c225ae30f8560ce518582e",
+      "name": "lifedog",
+      "symbol": "LFDOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52278/large/lifedog.png?1732895178"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfc82bb4ba86045af6f327323a46e80412b91b27d",
+      "name": "Prom",
+      "symbol": "PROM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8825/large/Ticker.png?1696508978"
+    },
+    {
+      "chainId": 1,
+      "address": "0x26c8afbbfe1ebaca03c2bb082e69d0476bffe099",
+      "name": "Cellframe",
+      "symbol": "CELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14465/large/cellframe-coingecko.png?1696514152"
+    },
+    {
+      "chainId": 1,
+      "address": "0x74232704659ef37c08995e386a2e26cc27a8d7b1",
+      "name": "Strike",
+      "symbol": "STRIKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14607/large/Jw-36llq_400x400.jpg?1696514286"
+    },
+    {
+      "chainId": 1,
+      "address": "0x67466be17df832165f8c80a5a120ccc652bd7e69",
+      "name": "LandWolf",
+      "symbol": "WOLF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37403/large/wolf_200x200.png?1715222165"
+    },
+    {
+      "chainId": 1,
+      "address": "0x68749665ff8d2d112fa859aa293f07a622782f38",
+      "name": "Tether Gold",
+      "symbol": "XAUT",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
+      "logoURI": "https://assets.coingecko.com/coins/images/10481/large/Tether_Gold.png?1696510471"
     },
     {
       "chainId": 1,
-      "address": "0x865ec58b06bf6305b886793aa20a2da31d034e68",
-      "name": "Mossland",
-      "symbol": "MOC",
+      "address": "0x944824290cc12f31ae18ef51216a223ba4063092",
+      "name": "Masa",
+      "symbol": "MASA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2374/large/moc.png?1696503240"
+      "logoURI": "https://assets.coingecko.com/coins/images/35538/large/masa.png?1712635899"
     },
     {
       "chainId": 1,
-      "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
-      "name": "Pax Dollar",
-      "symbol": "USDP",
+      "address": "0xbe1a001fe942f96eea22ba08783140b9dcc09d28",
+      "name": "Beta Finance",
+      "symbol": "BETA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/6013/large/Pax_Dollar.png?1696506427"
+      "logoURI": "https://assets.coingecko.com/coins/images/18715/large/beta_finance.jpg?1696518183"
     },
     {
       "chainId": 1,
-      "address": "0xfb19075d77a0f111796fb259819830f4780f1429",
-      "name": "Fenerbah e",
-      "symbol": "FB",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17711/large/FB_Logo.png?1696517238"
-    },
-    {
-      "chainId": 1,
-      "address": "0x908ddb096bfb3acb19e2280aad858186ea4935c4",
-      "name": "Eesee",
-      "symbol": "ESE",
+      "address": "0x0c7d5ae016f806603cb1782bea29ac69471cab9c",
+      "name": "Bifrost",
+      "symbol": "BFC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35182/large/Eesee.jpg?1707796753"
+      "logoURI": "https://assets.coingecko.com/coins/images/4639/large/BFC_Symbol.png?1696505208"
     },
     {
       "chainId": 1,
-      "address": "0xa831a4e181f25d3b35949e582ff27cc44e703f37",
-      "name": "ALEX Lab",
-      "symbol": "ALEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25837/large/ALEX_Token.png?1696524922"
+      "address": "0x4527a3b4a8a150403090a99b87effc96f2195047",
+      "name": "P2P solutions foundation",
+      "symbol": "P2PS",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2798/large/p2ps.png?1696503565"
     },
     {
       "chainId": 1,
-      "address": "0x9ff58067bd8d239000010c154c6983a325df138e",
-      "name": "Propchain",
-      "symbol": "PROPC",
+      "address": "0x8642a849d0dcb7a15a974794668adcfbe4794b56",
+      "name": "Prosper",
+      "symbol": "PROS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30451/large/prop_%281%29.png?1702322253"
+      "logoURI": "https://assets.coingecko.com/coins/images/13668/large/PFP_Visual_CG.png?1727714135"
+    },
+    {
+      "chainId": 1,
+      "address": "0x508e00d5cef397b02d260d035e5ee80775e4c821",
+      "name": "Bitcoin Cats",
+      "symbol": "1CAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34059/large/779e5404024bcd3cec3db54370ea66c.jpg?1703752231"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc98d64da73a6616c42117b582e832812e7b8d57f",
+      "name": "RSS3",
+      "symbol": "RSS3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23575/large/rss3.jpeg?1718351333"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd7efb00d12c2c13131fd319336fdf952525da2af",
+      "name": "XPR Network",
+      "symbol": "XPR",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/10941/large/XPR.jpg?1696510891"
+    },
+    {
+      "chainId": 1,
+      "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
+      "name": "Telcoin",
+      "symbol": "TEL",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/1899/large/tel.png?1696502892"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdc9ac3c20d1ed0b540df9b1fedc10039df13f99c",
+      "name": "xMoney",
+      "symbol": "UTK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1824/large/200x200.png?1696723239"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0bb217e40f8a5cb79adf04e1aab60e5abd0dfc1e",
+      "name": "SWFTCOIN",
+      "symbol": "SWFTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2346/large/SWFTCoin.jpg?1696503223"
+    },
+    {
+      "chainId": 1,
+      "address": "0x38e382f74dfb84608f3c1f10187f6bef5951de93",
+      "name": "Multibit",
+      "symbol": "MUBI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33051/large/multi.jpg?1700473994"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
+      "name": "OriginTrail",
+      "symbol": "TRAC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1877/large/TRAC.jpg?1696502873"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5026f006b85729a8b14553fae6af249ad16c9aab",
+      "name": "Wojak",
+      "symbol": "WOJAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29856/large/wojak.png?1696528782"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4cc19356f2d37338b9802aa8e8fc58b0373296e7",
+      "name": "SelfKey",
+      "symbol": "KEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2034/large/selfkey.png?1696503004"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf8ebf4849f1fa4faf0dff2106a173d3a6cb2eb3a",
+      "name": "Troll",
+      "symbol": "TROLL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29897/large/TROLL.jpeg?1696528821"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe9689028ede16c2fdfe3d11855d28f8e3fc452a3",
+      "name": "Imaginary Ones",
+      "symbol": "BUBBLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37706/large/imaginary_ones.jpeg?1715255717"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd01409314acb3b245cea9500ece3f6fd4d70ea30",
+      "name": "LTO Network",
+      "symbol": "LTO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/6068/large/lto.png?1696506473"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9d1a7a3191102e9f900faa10540837ba84dcbae7",
+      "name": "Eurite",
+      "symbol": "EURI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39952/large/EURI.jpg?1724902829"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77fba179c79de5b7653f68b5039af940ada60ce0",
+      "name": "Ampleforth Governance",
+      "symbol": "FORTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14917/large/photo_2021-04-22_00.00.03.jpeg?1696514579"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe6829d9a7ee3040e1276fa75293bde931859e8fa",
+      "name": "Mantle Restaked ETH",
+      "symbol": "CMETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51114/large/symbol.png?1730117724"
+    },
+    {
+      "chainId": 1,
+      "address": "0x628a3b2e302c7e896acc432d2d0dd22b6cb9bc88",
+      "name": "LimeWire",
+      "symbol": "LMWR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30356/large/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa469b7ee9ee773642b3e93e842e5d9b5baa10067",
+      "name": "Anzen USDz",
+      "symbol": "USDZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38039/large/usdz-image-200x200.png?1716334412"
     },
     {
       "chainId": 1,
@@ -3028,11 +2788,299 @@
     },
     {
       "chainId": 1,
-      "address": "0x4ec1b60b96193a64acae44778e51f7bff2007831",
-      "name": "Edge",
-      "symbol": "EDGE",
+      "address": "0xc555d625828c4527d477e595ff1dd5801b4a600e",
+      "name": "MON Protocol",
+      "symbol": "MON",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1848/large/EDGE.png?1696502846"
+      "logoURI": "https://assets.coingecko.com/coins/images/37395/large/WhatsApp_Image_2024-02-27_at_18.34.45_01762153.jpg?1716261730"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde4ee8057785a7e8e800db58f9784845a5c2cbd6",
+      "name": "DeXe",
+      "symbol": "DEXE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12713/large/DEXE_token_logo.png?1696512514"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba41ddf06b7ffd89d1267b5a93bfef2424eb2003",
+      "name": "Mythos",
+      "symbol": "MYTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28045/large/Mythos_Logos_200x200.png?1696527059"
+    },
+    {
+      "chainId": 1,
+      "address": "0x823556202e86763853b40e9cde725f412e294689",
+      "name": "Altered State Machine",
+      "symbol": "ASTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24893/large/ASTO-Token.png?1732899741"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5dc60c4d5e75d22588fa17ffeb90a63e535efce0",
+      "name": "dKargo",
+      "symbol": "DKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11875/large/DKA_ticker.png?1732553189"
+    },
+    {
+      "chainId": 1,
+      "address": "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
+      "name": "Boba Network",
+      "symbol": "BOBA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20285/large/Boba-200x200---white.png?1696519690"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8971f9fd7196e5cee2c1032b50f656855af7dd26",
+      "name": "Lambda",
+      "symbol": "LAMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4703/large/lambda_200.png?1696505268"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
+      "name": "World Mobile Token",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
+    },
+    {
+      "chainId": 1,
+      "address": "0x94a8b4ee5cd64c79d0ee816f467ea73009f51aa0",
+      "name": "Realio Network Token",
+      "symbol": "RIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12206/large/Rio.png?1696512042"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8f693ca8d21b157107184d29d398a8d082b38b76",
+      "name": "Streamr",
+      "symbol": "DATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17869/large/DATA_new_symbol_3x.png?1696517392"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf94e7d0710709388bce3161c32b4eea56d3f91cc",
+      "name": "Destra Network",
+      "symbol": "DSYNC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35996/large/Destra_Network.png?1710316001"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc328a59e7321747aebbc49fd28d1b32c1af8d3b2",
+      "name": "Phil",
+      "symbol": "PHIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39975/large/yr0kMUrz_400x400.jpg?1724971221"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaa247c0d81b83812e1abf8bab078e4540d87e3fb",
+      "name": "Meson Network",
+      "symbol": "MSN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34981/large/meson-token-icon200.png?1714275908"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
+      "name": "Request",
+      "symbol": "REQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1031/large/Request_icon_green.png?1696502140"
+    },
+    {
+      "chainId": 1,
+      "address": "0x06450dee7fd2fb8e39061434babcfc05599a6fb8",
+      "name": "XEN Crypto",
+      "symbol": "XEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27713/large/Xen.jpeg?1696526739"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8236a87084f8b84306f72007f36f2618a5634494",
+      "name": "Lombard Staked BTC",
+      "symbol": "LBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39969/large/LBTC_Logo.png?1724959872"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2cd3d43c775978a96bdbf12d733d5a1ed94fb18",
+      "name": "Onyxcoin",
+      "symbol": "XCN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/large/onyxlogo.jpg?1696523397"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2e7e487d84b5baba5878a9833fb394bc89633fd7",
+      "name": "Omnia Protocol",
+      "symbol": "OMNIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24380/large/OMNIA-Logomark-white-transparent-BG.png?1728959886"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
+      "name": "Wrapped eETH",
+      "symbol": "WEETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
+    },
+    {
+      "chainId": 1,
+      "address": "0x037a54aab062628c9bbae1fdb1583c195585fe41",
+      "name": "LCX",
+      "symbol": "LCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9985/large/zRPSu_0o_400x400.jpg?1696510023"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c11249814f11b9346808179cf06e71ac328c1b5",
+      "name": "Oraichain",
+      "symbol": "ORAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12931/large/orai.png?1696512718"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2be5e8c109e2197d077d13a82daead6a9b3433c5",
+      "name": "Tokamak Network",
+      "symbol": "TON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12260/large/D919x5-s_400x400.png?1696512091"
+    },
+    {
+      "chainId": 1,
+      "address": "0x28561b8a2360f463011c16b6cc0b0cbef8dbbcad",
+      "name": "MOO DENG",
+      "symbol": "MOODENG",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/50348/large/1000000612.jpg?1727248974"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9ff58067bd8d239000010c154c6983a325df138e",
+      "name": "Propchain",
+      "symbol": "PROPC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30451/large/prop_%281%29.png?1702322253"
+    },
+    {
+      "chainId": 1,
+      "address": "0x590f820444fa3638e022776752c5eef34e2f89a6",
+      "name": "Alephium",
+      "symbol": "ALPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21598/large/Alephium-Logo_200x200_listing.png?1696520959"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe50e009ddb1a4d8ec668eac9d8b2df1f96348707",
+      "name": "Ctrl",
+      "symbol": "CTRL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50886/large/_CTRL_logo_.png?1732678338"
+    },
+    {
+      "chainId": 1,
+      "address": "0x594daad7d77592a2b97b725a7ad59d7e188b5bfa",
+      "name": "Apu Apustaja",
+      "symbol": "APU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35986/large/200x200.png?1710308147"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbef26bd568e421d6708cca55ad6e35f8bfa0c406",
+      "name": "bitsCrunch Token",
+      "symbol": "BCUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34832/large/logo-256_%281%29.png?1710244462"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa9e8acf069c58aec8825542845fd754e41a9489a",
+      "name": "PepeCoin",
+      "symbol": "PEPECOIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30219/large/pepecoin.jpeg?1696529130"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0921799cb1d702148131024d18fcde022129dc73",
+      "name": "LightLink",
+      "symbol": "LL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35357/large/lightlink-ticker-200.png?1708362303"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4123a133ae3c521fd134d7b13a2dec35b56c2463",
+      "name": "Open Custody Protocol",
+      "symbol": "OPEN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17541/large/OPEN-Token-Black.png?1712837762"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44",
+      "name": "Wrapped TAO",
+      "symbol": "WTAO",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/29087/large/wtao.png?1696528051"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd85a6ae55a7f33b0ee113c234d2ee308edeaf7fd",
+      "name": "Cobak",
+      "symbol": "CBK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13459/large/cbk-128-128.png?1696513222"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9f9c8ec3534c3ce16f928381372bfbfbfb9f4d24",
+      "name": "GraphLinq Chain",
+      "symbol": "GLQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14474/large/Logo_Dex_4_correct__%282%29.png?1712018526"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaaaaaa20d9e0e2461697782ef11675f668207961",
+      "name": "Aurora",
+      "symbol": "AURORA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20582/large/aurora.jpeg?1696519989"
+    },
+    {
+      "chainId": 1,
+      "address": "0x13e4b8cffe704d3de6f19e52b201d92c21ec18bd",
+      "name": "ParallelAI",
+      "symbol": "PAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50394/large/IMG_20240926_230930_523.jpg?1727589698"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcb21311d3b91b5324f6c11b4f5a656fcacbff122",
+      "name": "QuantixAI",
+      "symbol": "QAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36166/large/200px_Qai.png?1726228972"
     },
     {
       "chainId": 1,
@@ -3041,6 +3089,222 @@
       "symbol": "ZIG",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/14796/large/zig.jpg?1731990265"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
+      "name": "UniLend Finance",
+      "symbol": "UFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12819/large/UniLend_Finance_logo_PNG.png?1696512611"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa3f4341c3fef5963ab04135d2014ac7d68222e19",
+      "name": "LogX Network",
+      "symbol": "LOGX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50226/large/Token_200px.png?1726556358"
+    },
+    {
+      "chainId": 1,
+      "address": "0xadd5e881984783dd432f80381fb52f45b53f3e70",
+      "name": "Vite",
+      "symbol": "VITE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4513/large/VITE_new_logo_200px.png?1709175957"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0ef786bf476fe0810408caba05e536ac800ff86",
+      "name": "Myria",
+      "symbol": "MYRIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29273/large/myria.png?1696528226"
+    },
+    {
+      "chainId": 1,
+      "address": "0x32b77729cd87f1ef2bea4c650c16f89f08472c69",
+      "name": "DeBox",
+      "symbol": "BOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50224/large/v6TSd2dN_400x400.jpg?1726521525"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
+      "name": "Harvest Finance",
+      "symbol": "FARM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12304/large/FARM_200x200.png?1696512134"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb4b9dc1c77bdbb135ea907fd5a08094d98883a35",
+      "name": "Sweat Economy",
+      "symbol": "SWEAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25057/large/fhD9Xs16_400x400.jpg?1696524208"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbba39fd2935d5769116ce38d46a71bde9cf03099",
+      "name": "Choise ai",
+      "symbol": "CHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25935/large/CHO_%282%29.png?1721039541"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9cb1aeafcc8a9406632c5b084246ea72f62d37b6",
+      "name": "LBK",
+      "symbol": "LBK",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/9492/large/lbk.jpeg?1696509578"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5ca381bbfb58f0092df149bd3d243b08b9a8386e",
+      "name": "Moonchain",
+      "symbol": "MXC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4604/large/M_1-modified.png?1712206949"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd9d920aa40f578ab794426f5c90f6c731d159def",
+      "name": "Solv Protocol SolvBTC BBN",
+      "symbol": "SOLVBTCBBN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39384/large/unnamed.png?1721961640"
+    },
+    {
+      "chainId": 1,
+      "address": "0x31e4efe290973ebe91b3a875a7994f650942d28f",
+      "name": "Shrapnel",
+      "symbol": "SHRAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32793/large/shrapnel.png?1699441661"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdd3b11ef34cd511a2da159034a05fcb94d806686",
+      "name": "Rekt",
+      "symbol": "REKT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51727/large/rektcion_trans_200px.png?1731910587"
+    },
+    {
+      "chainId": 1,
+      "address": "0xccc8cb5229b0ac8069c51fd58367fd1e622afd97",
+      "name": "Gods Unchained",
+      "symbol": "GODS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17139/large/10631.png?1696516698"
+    },
+    {
+      "chainId": 1,
+      "address": "0x68bbed6a47194eff1cf514b50ea91895597fc91e",
+      "name": "ANDY ETH",
+      "symbol": "ANDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35910/large/IMG_20240309_044840_797.jpg?1710179397"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f51bb10119727a7e5ea3538074fb341f56b09ad",
+      "name": "DAO Maker",
+      "symbol": "DAO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13915/large/4.jpg?1727532864"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8fc8f8269ebca376d046ce292dc7eac40c8d358a",
+      "name": "DeFiChain",
+      "symbol": "DFI",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/11757/large/symbol-defi-blockchain_200.png?1696511638"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
+      "name": "Kyber Network Crystal Legacy",
+      "symbol": "KNCL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/947/large/logo-kncl.png?1696502063"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9ee8c380e1926730ad89e91665ff27063b13c90a",
+      "name": "Coupon Assets",
+      "symbol": "CA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32202/large/ca.jpg?1696746380"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb056c38f6b7dc4064367403e26424cd2c60655e1",
+      "name": "CEEK Smart VR",
+      "symbol": "CEEK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2581/large/ceek-smart-vr-token-logo.png?1696503385"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
+      "name": "Cream",
+      "symbol": "CREAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11976/large/Cream.png?1696511834"
+    },
+    {
+      "chainId": 1,
+      "address": "0x865ec58b06bf6305b886793aa20a2da31d034e68",
+      "name": "Mossland",
+      "symbol": "MOC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2374/large/moc.png?1696503240"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbdc7c08592ee4aa51d06c27ee23d5087d65adbcd",
+      "name": "Lift Dollar",
+      "symbol": "USDL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38484/large/USDL-Token-200px.png?1725022887"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa3d4bee77b05d4a0c943877558ce21a763c4fa29",
+      "name": "The Root Network",
+      "symbol": "ROOT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/33122/large/6T1Tapl__400x400.jpg?1700740439"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0391d2021f89dc339f60fff84546ea23e337750f",
+      "name": "BarnBridge",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/large/barnbridge.jpg?1696512604"
+    },
+    {
+      "chainId": 1,
+      "address": "0x643c4e15d7d62ad0abec4a9bd4b001aa3ef52d66",
+      "name": "Syrup",
+      "symbol": "SYRUP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51232/large/IMG_7420.png?1730831572"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44971abf0251958492fee97da3e5c5ada88b9185",
+      "name": "BasedAI",
+      "symbol": "BASEDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36607/large/1000004475.png?1711964332"
     },
     {
       "chainId": 1,
@@ -3060,147 +3324,67 @@
     },
     {
       "chainId": 1,
-      "address": "0x9aab071b4129b083b01cb5a0cb513ce7eca26fa5",
-      "name": "Hunt",
-      "symbol": "HUNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7989/large/HUNT.png?1696508215"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5dc60c4d5e75d22588fa17ffeb90a63e535efce0",
-      "name": "dKargo",
-      "symbol": "DKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11875/large/DKA_ticker.png?1732553189"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc56c7a0eaa804f854b536a5f3d5f49d2ec4b12b8",
-      "name": "GME  Ethereum ",
-      "symbol": "GME",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37895/large/GME200.jpg?1715847521"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe9689028ede16c2fdfe3d11855d28f8e3fc452a3",
-      "name": "Imaginary Ones",
-      "symbol": "BUBBLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37706/large/imaginary_ones.jpeg?1715255717"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdd3b11ef34cd511a2da159034a05fcb94d806686",
-      "name": "Rekt",
-      "symbol": "REKT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51727/large/rektcion_trans_200px.png?1731910587"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe7c6bf469e97eeb0bfb74c8dbff5bd47d4c1c98a",
-      "name": "HashKey Platform Token",
-      "symbol": "HSK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29779/large/HSKlogo.jpg?1719445510"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9cb1aeafcc8a9406632c5b084246ea72f62d37b6",
-      "name": "LBK",
-      "symbol": "LBK",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/9492/large/lbk.jpeg?1696509578"
-    },
-    {
-      "chainId": 1,
-      "address": "0x69a1e699f562d7af66fc6cc473d99f4430c3acd2",
-      "name": "Param",
-      "symbol": "PARAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37697/large/param200.png?1715234889"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe6829d9a7ee3040e1276fa75293bde931859e8fa",
-      "name": "Mantle Restaked ETH",
-      "symbol": "CMETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51114/large/symbol.png?1730117724"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
-      "name": "Cream",
-      "symbol": "CREAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11976/large/Cream.png?1696511834"
-    },
-    {
-      "chainId": 1,
-      "address": "0x13e4b8cffe704d3de6f19e52b201d92c21ec18bd",
-      "name": "ParallelAI",
-      "symbol": "PAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50394/large/IMG_20240926_230930_523.jpg?1727589698"
-    },
-    {
-      "chainId": 1,
-      "address": "0x823556202e86763853b40e9cde725f412e294689",
-      "name": "Altered State Machine",
-      "symbol": "ASTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24893/large/ASTO-Token.png?1732899741"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
-      "name": "World Mobile Token",
-      "symbol": "WMTX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
-    },
-    {
-      "chainId": 1,
-      "address": "0x32b77729cd87f1ef2bea4c650c16f89f08472c69",
-      "name": "DeBox",
-      "symbol": "BOX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50224/large/v6TSd2dN_400x400.jpg?1726521525"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5ca381bbfb58f0092df149bd3d243b08b9a8386e",
-      "name": "Moonchain",
-      "symbol": "MXC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4604/large/M_1-modified.png?1712206949"
-    },
-    {
-      "chainId": 1,
-      "address": "0x943af2ece93118b973c95c2f698ee9d15002e604",
-      "name": "GameGPT",
-      "symbol": "DUEL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34491/large/duel.jpeg?1705056819"
-    },
-    {
-      "chainId": 1,
-      "address": "0x39d5313c3750140e5042887413ba8aa6145a9bd2",
-      "name": "Empyreal",
-      "symbol": "EMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31374/large/logomainblacktransparent.png?1719953450"
-    },
-    {
-      "chainId": 1,
       "address": "0x3567aa22cd3ab9aef23d7e18ee0d7cf16974d7e6",
       "name": "Sharpe AI",
       "symbol": "SAI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/39385/large/Group_48095583.png?1721962174"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb0ac2b5a73da0e67a8e5489ba922b3f8d582e058",
+      "name": "Shiro Neko",
+      "symbol": "SHIRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52406/large/Shiro_Neko.png?1733453572"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2c974b2d0ba1716e644c1fc59982a89ddd2ff724",
+      "name": "Viberate",
+      "symbol": "VIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/983/large/Viberate.png?1696502096"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2b4c0af19cc16a6cfacce81f192b024d625817d",
+      "name": "Kishu Inu",
+      "symbol": "KISHU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/14890/large/uVLzCoP.png?1696514553"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
+      "name": "Pax Dollar",
+      "symbol": "USDP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6013/large/Pax_Dollar.png?1696506427"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa6c0c097741d55ecd9a3a7def3a8253fd022ceb9",
+      "name": "AVA  Travala ",
+      "symbol": "AVA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3014/large/AVA_Logo_160x160px_Black.png?1696503750"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1e053d89e08c24aa2ce5c5b4206744dc2d7bd8f5",
+      "name": "ThunderCore",
+      "symbol": "TT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4375/large/ThunderCore_Logo_Mark_Gradient_%283%29.png?1696504974"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7d8146cf21e8d7cbe46054e01588207b51198729",
+      "name": "BOB Token",
+      "symbol": "BOB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29929/large/bob.png?1696528857"
     },
     {
       "chainId": 1,
@@ -3220,339 +3404,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x441761326490cacf7af299725b6292597ee822c2",
-      "name": "Unifi Protocol DAO",
-      "symbol": "UNFI",
+      "address": "0x33349b282065b0284d756f0577fb39c158f935e6",
+      "name": "Maple",
+      "symbol": "MPL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13152/large/logo-2.png?1696512937"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6aa56e1d98b3805921c170eb4b3fe7d4fda6d89b",
-      "name": "MAGA",
-      "symbol": "TRUMP",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/31498/large/Maga-Trump-Logo-200px.png?1696530309"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa1290d69c65a6fe4df752f95823fae25cb99e5a7",
-      "name": "Kelp DAO Restaked ETH",
-      "symbol": "RSETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33800/large/Icon___Dark.png?1702991855"
-    },
-    {
-      "chainId": 1,
-      "address": "0x037a54aab062628c9bbae1fdb1583c195585fe41",
-      "name": "LCX",
-      "symbol": "LCX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9985/large/zRPSu_0o_400x400.jpg?1696510023"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb2492e97a68a6e4b9e9a11b99f6c42e5accd38c7",
-      "name": "Veloce",
-      "symbol": "VEXT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31214/large/VEXT_Logo.jpg?1696530041"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5e8422345238f34275888049021821e8e08caa1f",
-      "name": "Frax Ether",
-      "symbol": "FRXETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28284/large/frxETH_icon.png?1696527284"
-    },
-    {
-      "chainId": 1,
-      "address": "0x62b9c7356a2dc64a1969e19c23e4f579f9810aa7",
-      "name": "Convex CRV",
-      "symbol": "CVXCRV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15586/large/convex-crv.png?1696515222"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
-      "name": "Kyber Network Crystal Legacy",
-      "symbol": "KNCL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/947/large/logo-kncl.png?1696502063"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
-      "name": "Port3 Network",
-      "symbol": "PORT3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33383/large/port3-bc-200x200.png?1710075114"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
-      "name": "DFI money",
-      "symbol": "YFII",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11902/large/YFII-logo.78631676.png?1696511768"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7d8146cf21e8d7cbe46054e01588207b51198729",
-      "name": "BOB Token",
-      "symbol": "BOB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29929/large/bob.png?1696528857"
-    },
-    {
-      "chainId": 1,
-      "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
-      "name": "Ocean Protocol",
-      "symbol": "OCEAN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3687/large/ocean-protocol-logo.jpg?1696504363"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe50e009ddb1a4d8ec668eac9d8b2df1f96348707",
-      "name": "Ctrl",
-      "symbol": "CTRL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50886/large/_CTRL_logo_.png?1732678338"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2565ae0385659badcada1031db704442e1b69982",
-      "name": "Assemble Protocol",
-      "symbol": "ASM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11605/large/ASM_512X512_white.png?1717463859"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
-      "name": "Keep3rV1",
-      "symbol": "KP3R",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12966/large/kp3r_logo.jpg?1696512754"
-    },
-    {
-      "chainId": 1,
-      "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
-      "name": "Aleph im",
-      "symbol": "ALEPH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11676/large/Aleph-Logo-BW.png?1696511566"
-    },
-    {
-      "chainId": 1,
-      "address": "0x27c70cd1946795b66be9d954418546998b546634",
-      "name": "Doge Killer",
-      "symbol": "LEASH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15802/large/Leash.png?1696515425"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6b0b3a982b4634ac68dd83a4dbf02311ce324181",
-      "name": "Artificial Liquid Intelligence",
-      "symbol": "ALI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22062/large/ALI-v2.webp?1728501978"
-    },
-    {
-      "chainId": 1,
-      "address": "0x03aa6298f1370642642415edc0db8b957783e8d6",
-      "name": "NetMind Token",
-      "symbol": "NMT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35328/large/NMT-logo.png?1708267799"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9ce84f6a69986a83d92c324df10bc8e64771030f",
-      "name": "CHEX Token",
-      "symbol": "CHEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10349/large/logo-white-bg-dark.png?1733475849"
-    },
-    {
-      "chainId": 1,
-      "address": "0x946551dd05c5abd7cc808927480225ce36d8c475",
-      "name": "One",
-      "symbol": "ONE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4960/large/Screenshot_39.png?1696505497"
-    },
-    {
-      "chainId": 1,
-      "address": "0x74232704659ef37c08995e386a2e26cc27a8d7b1",
-      "name": "Strike",
-      "symbol": "STRIKE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14607/large/Jw-36llq_400x400.jpg?1696514286"
-    },
-    {
-      "chainId": 1,
-      "address": "0x226bb599a12c826476e3a771454697ea52e9e220",
-      "name": "Propy",
-      "symbol": "PRO",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/869/large/propy.png?1696502002"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa9e8acf069c58aec8825542845fd754e41a9489a",
-      "name": "PepeCoin",
-      "symbol": "PEPECOIN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30219/large/pepecoin.jpeg?1696529130"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd46ba6d942050d489dbd938a2c909a5d5039a161",
-      "name": "Ampleforth",
-      "symbol": "AMPL",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/4708/large/Ampleforth.png?1696505273"
-    },
-    {
-      "chainId": 1,
-      "address": "0xde2f7766c8bf14ca67193128535e5c7454f8387c",
-      "name": "Metadium",
-      "symbol": "META",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5247/large/metadium_symbol_black.png?1729148922"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6f40d4a6237c257fff2db00fa0510deeecd303eb",
-      "name": "Instadapp",
-      "symbol": "INST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14688/large/30hFM0-n_400x400.jpg?1696514361"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0c90c57aaf95a3a87eadda6ec3974c99d786511f",
-      "name": "HanChain",
-      "symbol": "HAN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27374/large/logo_200.png?1696526418"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe1bad922f84b198a08292fb600319300ae32471b",
-      "name": "Firmachain",
-      "symbol": "FCT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9892/large/6mHcLurm_400x400.jpg?1696509941"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa3d4bee77b05d4a0c943877558ce21a763c4fa29",
-      "name": "The Root Network",
-      "symbol": "ROOT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/33122/large/6T1Tapl__400x400.jpg?1700740439"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcb21311d3b91b5324f6c11b4f5a656fcacbff122",
-      "name": "QuantixAI",
-      "symbol": "QAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36166/large/200px_Qai.png?1726228972"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf8c4a95c92b0d0121d1d20f4575073b37883d663",
-      "name": "Tubes",
-      "symbol": "TUBES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37984/large/TUBES.jpg?1716205639"
-    },
-    {
-      "chainId": 1,
-      "address": "0xae78736cd615f374d3085123a210448e74fc6393",
-      "name": "Rocket Pool ETH",
-      "symbol": "RETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20764/large/reth.png?1696520159"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
-      "name": "UniLend Finance",
-      "symbol": "UFT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12819/large/UniLend_Finance_logo_PNG.png?1696512611"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
-      "name": "OX Coin",
-      "symbol": "OX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa6c0c097741d55ecd9a3a7def3a8253fd022ceb9",
-      "name": "AVA  Travala ",
-      "symbol": "AVA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3014/large/AVA_Logo_160x160px_Black.png?1696503750"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa0ef786bf476fe0810408caba05e536ac800ff86",
-      "name": "Myria",
-      "symbol": "MYRIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29273/large/myria.png?1696528226"
-    },
-    {
-      "chainId": 1,
-      "address": "0xed1167b6dc64e8a366db86f2e952a482d0981ebd",
-      "name": "Lybra",
-      "symbol": "LBR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29958/large/New_LBR_V2.png?1696528884"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbba39fd2935d5769116ce38d46a71bde9cf03099",
-      "name": "Choise ai",
-      "symbol": "CHO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25935/large/CHO_%282%29.png?1721039541"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8ab2ff0116a279a99950c66a12298962d152b83c",
-      "name": "Ordiswap",
-      "symbol": "ORDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33910/large/IMG-20240113-WA0018.jpg.jpg?1705169306"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2a3bff78b79a009976eea096a51a948a3dc00e34",
-      "name": "Wilder World",
-      "symbol": "WILD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15407/large/wld-logo.png?1712273448"
-    },
-    {
-      "chainId": 1,
-      "address": "0x865377367054516e17014ccded1e7d814edc9ce4",
-      "name": "DOLA",
-      "symbol": "DOLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
+      "logoURI": "https://assets.coingecko.com/coins/images/14097/large/Maple_Logo_Mark_Maple_Orange.png?1696513819"
     },
     {
       "chainId": 1,
@@ -3564,6 +3420,22 @@
     },
     {
       "chainId": 1,
+      "address": "0x9ce84f6a69986a83d92c324df10bc8e64771030f",
+      "name": "CHEX Token",
+      "symbol": "CHEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10349/large/logo-white-bg-dark.png?1733475849"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
+      "name": "DFI money",
+      "symbol": "YFII",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11902/large/YFII-logo.78631676.png?1696511768"
+    },
+    {
+      "chainId": 1,
       "address": "0xca5b0ae1d104030a9b8f879523508efd86c14483",
       "name": "TYBENG",
       "symbol": "TYBENG",
@@ -3572,387 +3444,67 @@
     },
     {
       "chainId": 1,
-      "address": "0x31e4efe290973ebe91b3a875a7994f650942d28f",
-      "name": "Shrapnel",
-      "symbol": "SHRAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32793/large/shrapnel.png?1699441661"
-    },
-    {
-      "chainId": 1,
-      "address": "0x986ee2b944c42d017f52af21c4c69b84dbea35d8",
-      "name": "BitMart",
-      "symbol": "BMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5236/large/bitmart-token.png?1696505741"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
-      "name": "Ignition FBTC",
-      "symbol": "FBTC",
+      "address": "0x3c4b6e6e1ea3d4863700d7f76b36b7f3d3f13e3d",
+      "name": "VGX Token",
+      "symbol": "VGX",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39182/large/FBTC_LOGO.png?1720850455"
+      "logoURI": "https://assets.coingecko.com/coins/images/794/large/vgx.png?1718076437"
     },
     {
       "chainId": 1,
-      "address": "0xaa247c0d81b83812e1abf8bab078e4540d87e3fb",
-      "name": "Meson Network",
-      "symbol": "MSN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34981/large/meson-token-icon200.png?1714275908"
-    },
-    {
-      "chainId": 1,
-      "address": "0x42726d074bba68ccc15200442b72afa2d495a783",
-      "name": "Isiklar Coin",
-      "symbol": "ISIKC",
+      "address": "0xd13c7342e1ef687c5ad21b27c2b65d772cab5c8c",
+      "name": "Ultra",
+      "symbol": "UOS",
       "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/10992/large/logo_%2866%29.png?1696510941"
+      "logoURI": "https://assets.coingecko.com/coins/images/4480/large/Ultra.png?1696505069"
     },
     {
       "chainId": 1,
-      "address": "0xb4b9dc1c77bdbb135ea907fd5a08094d98883a35",
-      "name": "Sweat Economy",
-      "symbol": "SWEAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25057/large/fhD9Xs16_400x400.jpg?1696524208"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfe39c384d702914127a005523f9915addb9bd59b",
-      "name": "Hippocrat",
-      "symbol": "HPO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4243/large/Hippocrat_Token_Logo_ver.1.0.jpg?1707157531"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2a414884a549ef5716bc1a4e648d3dc03f08b2cf",
-      "name": "PERQ",
-      "symbol": "PERQ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51486/large/coin-gecko-200.png?1731405387"
-    },
-    {
-      "chainId": 1,
-      "address": "0x549020a9cb845220d66d3e9c6d9f9ef61c981102",
-      "name": "Sidus",
-      "symbol": "SIDUS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21401/large/SIDUS_coin_logo.png?1696520765"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb31ef9e52d94d4120eb44fe1ddfde5b4654a6515",
-      "name": "DOSE",
-      "symbol": "DOSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18847/large/dose.PNG?1696518308"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4123a133ae3c521fd134d7b13a2dec35b56c2463",
-      "name": "Open Custody Protocol",
-      "symbol": "OPEN",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/17541/large/OPEN-Token-Black.png?1712837762"
-    },
-    {
-      "chainId": 1,
-      "address": "0x33349b282065b0284d756f0577fb39c158f935e6",
-      "name": "Maple",
-      "symbol": "MPL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14097/large/Maple_Logo_Mark_Maple_Orange.png?1696513819"
-    },
-    {
-      "chainId": 1,
-      "address": "0x15700b564ca08d9439c58ca5053166e8317aa138",
-      "name": "Elixir deUSD",
-      "symbol": "DEUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39494/large/deUSD_Logo_%281%29.png?1723689002"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd0a6053f087e87a25dc60701ba6e663b1a548e85",
-      "name": "BLOCKLORDS",
-      "symbol": "LRDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34775/large/LRDS_PNG.png?1706001771"
-    },
-    {
-      "chainId": 1,
-      "address": "0x839e71613f9aa06e5701cf6de63e303616b0dde3",
-      "name": "VVS Finance",
-      "symbol": "VVS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20210/large/8glAYOTM_400x400.jpg?1696519620"
-    },
-    {
-      "chainId": 1,
-      "address": "0x68bbed6a47194eff1cf514b50ea91895597fc91e",
-      "name": "ANDY ETH",
-      "symbol": "ANDY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35910/large/IMG_20240309_044840_797.jpg?1710179397"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb6667b04cb61aa16b59617f90ffa068722cf21da",
-      "name": "Worldwide USD",
-      "symbol": "WUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
-    },
-    {
-      "chainId": 1,
-      "address": "0x64d0f55cd8c7133a9d7102b13987235f486f2224",
-      "name": "SwissBorg",
-      "symbol": "BORG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2117/large/YJUrRy7r_400x400.png?1696503083"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa469b7ee9ee773642b3e93e842e5d9b5baa10067",
-      "name": "Anzen USDz",
-      "symbol": "USDZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38039/large/usdz-image-200x200.png?1716334412"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9ee8c380e1926730ad89e91665ff27063b13c90a",
-      "name": "Coupon Assets",
-      "symbol": "CA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32202/large/ca.jpg?1696746380"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd7efb00d12c2c13131fd319336fdf952525da2af",
-      "name": "XPR Network",
-      "symbol": "XPR",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/10941/large/XPR.jpg?1696510891"
-    },
-    {
-      "chainId": 1,
-      "address": "0x89d584a1edb3a70b3b07963f9a3ea5399e38b136",
-      "name": "AIT Protocol",
-      "symbol": "AIT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33962/large/ait-logo-200x200.png?1703567800"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdab396ccf3d84cf2d07c4454e10c8a6f5b008d2b",
-      "name": "Goldfinch",
-      "symbol": "GFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19081/large/GOLDFINCH.png?1696518531"
-    },
-    {
-      "chainId": 1,
-      "address": "0x046eee2cc3188071c02bfc1745a6b17c656e3f3d",
-      "name": "Rollbit Coin",
-      "symbol": "RLB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24552/large/unziL6wO_400x400.jpg?1696523729"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2c974b2d0ba1716e644c1fc59982a89ddd2ff724",
-      "name": "Viberate",
-      "symbol": "VIB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/983/large/Viberate.png?1696502096"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
-      "name": "Harvest Finance",
-      "symbol": "FARM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12304/large/FARM_200x200.png?1696512134"
-    },
-    {
-      "chainId": 1,
-      "address": "0x44709a920fccf795fbc57baa433cc3dd53c44dbe",
-      "name": "DappRadar",
-      "symbol": "RADAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20894/large/radar.png?1696520286"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0763fdccf1ae541a5961815c0872a8c5bc6de4d7",
-      "name": "SUKU",
-      "symbol": "SUKU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11969/large/suku-200.png?1696511828"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc52c326331e9ce41f04484d3b5e5648158028804",
-      "name": "Unizen",
-      "symbol": "ZCX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14830/large/logo128px.png?1700169101"
-    },
-    {
-      "chainId": 1,
-      "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
-      "name": "dForce",
-      "symbol": "DF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9709/large/xlGxxIjI_400x400.jpg?1696509776"
-    },
-    {
-      "chainId": 1,
-      "address": "0x590f820444fa3638e022776752c5eef34e2f89a6",
-      "name": "Alephium",
-      "symbol": "ALPH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21598/large/Alephium-Logo_200x200_listing.png?1696520959"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb4a3b0faf0ab53df58001804dda5bfc6a3d59008",
-      "name": "Sperax",
-      "symbol": "SPA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12232/large/sperax_logo.jpg?1696512065"
-    },
-    {
-      "chainId": 1,
-      "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
-      "name": "Gemini Dollar",
-      "symbol": "GUSD",
-      "decimals": 2,
-      "logoURI": "https://assets.coingecko.com/coins/images/5992/large/gemini-dollar-gusd.png?1696506408"
-    },
-    {
-      "chainId": 1,
-      "address": "0x525a8f6f3ba4752868cde25164382bfbae3990e1",
-      "name": "Nym",
-      "symbol": "NYM",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/24488/large/NYM_Token.png?1696523668"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf951e335afb289353dc249e82926178eac7ded78",
-      "name": "Swell Ethereum",
-      "symbol": "SWETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30326/large/_lB7zEtS_400x400.jpg?1696529227"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf19308f923582a6f7c465e5ce7a9dc1bec6665b1",
-      "name": "TitanX",
-      "symbol": "TITANX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32762/large/TitanXpng_%281%29.png?1704456654"
-    },
-    {
-      "chainId": 1,
-      "address": "0x174c47d6a4e548ed2b7d369dc0ffb2e60a6ac0f8",
-      "name": "Amulet Protocol",
-      "symbol": "AMU",
+      "address": "0x6aa56e1d98b3805921c170eb4b3fe7d4fda6d89b",
+      "name": "MAGA",
+      "symbol": "TRUMP",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/34716/large/AMT200x200.png?1705904544"
+      "logoURI": "https://assets.coingecko.com/coins/images/31498/large/Maga-Trump-Logo-200px.png?1696530309"
     },
     {
       "chainId": 1,
-      "address": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
-      "name": "Staked USD0",
-      "symbol": "USD0++",
+      "address": "0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110",
+      "name": "Resolv USR",
+      "symbol": "USR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39169/large/0x35d8949372d46b7a3d5a56006ae77b215fc69bc0.png?1720798057"
+      "logoURI": "https://assets.coingecko.com/coins/images/40008/large/USR_LOGO.png?1725222638"
     },
     {
       "chainId": 1,
-      "address": "0x0305f515fa978cf87226cf8a9776d25bcfb2cc0b",
-      "name": "Pepe 2 0",
-      "symbol": "PEPE20",
+      "address": "0x62b9c7356a2dc64a1969e19c23e4f579f9810aa7",
+      "name": "Convex CRV",
+      "symbol": "CVXCRV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30853/large/PEPE_2.0.png?1707684909"
+      "logoURI": "https://assets.coingecko.com/coins/images/15586/large/convex-crv.png?1696515222"
     },
     {
       "chainId": 1,
-      "address": "0x3a856d4effa670c54585a5d523e96513e148e95d",
-      "name": "TriasLab",
-      "symbol": "TRIAS",
+      "address": "0x9e9fbde7c7a83c43913bddc8779158f1368f0413",
+      "name": "Pandora",
+      "symbol": "PANDORA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13963/large/5ELqtwp__400x400_%281%29.jpg?1696513699"
+      "logoURI": "https://assets.coingecko.com/coins/images/34996/large/PandoraToken.png?1706954340"
     },
     {
       "chainId": 1,
-      "address": "0x8be3460a480c80728a8c4d7a5d5303c85ba7b3b9",
-      "name": "Ethena Staked ENA",
-      "symbol": "SENA",
+      "address": "0x0c90c57aaf95a3a87eadda6ec3974c99d786511f",
+      "name": "HanChain",
+      "symbol": "HAN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50235/large/ena.png?1726630994"
+      "logoURI": "https://assets.coingecko.com/coins/images/27374/large/logo_200.png?1696526418"
     },
     {
       "chainId": 1,
-      "address": "0xc581b735a1688071a1746c968e0798d642ede491",
-      "name": "Euro Tether",
-      "symbol": "EURT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17385/large/Tether_new.png?1696516934"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0921799cb1d702148131024d18fcde022129dc73",
-      "name": "LightLink",
-      "symbol": "LL",
+      "address": "0x2565ae0385659badcada1031db704442e1b69982",
+      "name": "Assemble Protocol",
+      "symbol": "ASM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35357/large/lightlink-ticker-200.png?1708362303"
-    },
-    {
-      "chainId": 1,
-      "address": "0xccc8cb5229b0ac8069c51fd58367fd1e622afd97",
-      "name": "Gods Unchained",
-      "symbol": "GODS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17139/large/10631.png?1696516698"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbb6cf73a00f480d0951ba979a7606857cdde626b",
-      "name": "Arix",
-      "symbol": "ARIX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13485/large/ARIX.png?1696513245"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfc4b4ec763722b71eb1d729749b447a9645f5f30",
-      "name": "DumbMoney",
-      "symbol": "GME",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/32058/large/DumbMoney_-_GME_-_Official_Logo_200x200px.png?1696530855"
-    },
-    {
-      "chainId": 1,
-      "address": "0xda987c655ebc38c801db64a8608bc1aa56cd9a31",
-      "name": "Synternet",
-      "symbol": "SYNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38888/large/_SYNT.png?1719380207"
-    },
-    {
-      "chainId": 1,
-      "address": "0x046bad07658f3b6cad9a396cfcbc1243af452ec1",
-      "name": "ArchLoot",
-      "symbol": "AL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28919/large/7.png?1696527894"
+      "logoURI": "https://assets.coingecko.com/coins/images/11605/large/ASM_512X512_white.png?1717463859"
     },
     {
       "chainId": 1,
@@ -3964,11 +3516,235 @@
     },
     {
       "chainId": 1,
-      "address": "0x487d62468282bd04ddf976631c23128a425555ee",
-      "name": "UPCX",
-      "symbol": "UPC",
-      "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/33308/large/02_UPC_logo_RGB_black_200_200.png?1701409035"
+      "address": "0xda987c655ebc38c801db64a8608bc1aa56cd9a31",
+      "name": "Synternet",
+      "symbol": "SYNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38888/large/_SYNT.png?1719380207"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd8c0b13b551718b808fc97ead59499d5ef862775",
+      "name": "Gala Music",
+      "symbol": "MUSIC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/33472/large/gmusic.jpeg?1701947141"
+    },
+    {
+      "chainId": 1,
+      "address": "0x66d79b8f60ec93bfce0b56f5ac14a2714e509a99",
+      "name": "MAP Protocol",
+      "symbol": "MAPO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10085/large/500*500.png?1723560204"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0bc37bea9068a86c221b8bd71ea6228260dad5a2",
+      "name": "Upland",
+      "symbol": "SPARKLET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39257/large/UPLAND.png?1721382041"
+    },
+    {
+      "chainId": 1,
+      "address": "0x826180541412d574cf1336d22c0c0a287822678a",
+      "name": "Chainflip",
+      "symbol": "FLIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25576/large/kdt_AgmT_400x400.png?1696524709"
+    },
+    {
+      "chainId": 1,
+      "address": "0x441761326490cacf7af299725b6292597ee822c2",
+      "name": "Unifi Protocol DAO",
+      "symbol": "UNFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13152/large/logo-2.png?1696512937"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6",
+      "name": "USDD",
+      "symbol": "USDD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25380/large/UUSD.jpg?1696524513"
+    },
+    {
+      "chainId": 1,
+      "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
+      "name": "dForce",
+      "symbol": "DF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9709/large/xlGxxIjI_400x400.jpg?1696509776"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0305f515fa978cf87226cf8a9776d25bcfb2cc0b",
+      "name": "Pepe 2 0",
+      "symbol": "PEPE20",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30853/large/PEPE_2.0.png?1707684909"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a3bff78b79a009976eea096a51a948a3dc00e34",
+      "name": "Wilder World",
+      "symbol": "WILD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15407/large/wld-logo.png?1712273448"
+    },
+    {
+      "chainId": 1,
+      "address": "0x549020a9cb845220d66d3e9c6d9f9ef61c981102",
+      "name": "Sidus",
+      "symbol": "SIDUS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21401/large/SIDUS_coin_logo.png?1696520765"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaaa9214f675316182eaa21c85f0ca99160cc3aaa",
+      "name": "QANplatform",
+      "symbol": "QANX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15977/large/qanx.png?1696515591"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde2f7766c8bf14ca67193128535e5c7454f8387c",
+      "name": "Metadium",
+      "symbol": "META",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5247/large/metadium_symbol_black.png?1729148922"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1c00c3e03c3a10a0c1d9b6d1a42e797d7cb4147a",
+      "name": "Legend of Arcadia",
+      "symbol": "ARCA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39564/large/ARCA.png?1722925525"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdab396ccf3d84cf2d07c4454e10c8a6f5b008d2b",
+      "name": "Goldfinch",
+      "symbol": "GFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19081/large/GOLDFINCH.png?1696518531"
+    },
+    {
+      "chainId": 1,
+      "address": "0x226bb599a12c826476e3a771454697ea52e9e220",
+      "name": "Propy",
+      "symbol": "PRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/869/large/propy.png?1696502002"
+    },
+    {
+      "chainId": 1,
+      "address": "0x678e840c640f619e17848045d23072844224dd37",
+      "name": "Cratos",
+      "symbol": "CRTS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17322/large/cratos.png?1696516876"
+    },
+    {
+      "chainId": 1,
+      "address": "0x64d0f55cd8c7133a9d7102b13987235f486f2224",
+      "name": "SwissBorg",
+      "symbol": "BORG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2117/large/YJUrRy7r_400x400.png?1696503083"
+    },
+    {
+      "chainId": 1,
+      "address": "0x046bad07658f3b6cad9a396cfcbc1243af452ec1",
+      "name": "ArchLoot",
+      "symbol": "AL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28919/large/7.png?1696527894"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfe39c384d702914127a005523f9915addb9bd59b",
+      "name": "Hippocrat",
+      "symbol": "HPO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4243/large/Hippocrat_Token_Logo_ver.1.0.jpg?1707157531"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2c3b62cdeab213ff58ad24fe8bbdf224c7f66dce",
+      "name": "MusmeCoin",
+      "symbol": "MSM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52485/large/ICN_01_ITEM_Coin_0001.png?1733427507"
+    },
+    {
+      "chainId": 1,
+      "address": "0x986ee2b944c42d017f52af21c4c69b84dbea35d8",
+      "name": "BitMart",
+      "symbol": "BMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5236/large/bitmart-token.png?1696505741"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf8c4a95c92b0d0121d1d20f4575073b37883d663",
+      "name": "Tubes",
+      "symbol": "TUBES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37984/large/TUBES.jpg?1716205639"
+    },
+    {
+      "chainId": 1,
+      "address": "0xed1167b6dc64e8a366db86f2e952a482d0981ebd",
+      "name": "Lybra",
+      "symbol": "LBR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29958/large/New_LBR_V2.png?1696528884"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb31ef9e52d94d4120eb44fe1ddfde5b4654a6515",
+      "name": "DOSE",
+      "symbol": "DOSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18847/large/dose.PNG?1696518308"
+    },
+    {
+      "chainId": 1,
+      "address": "0x236501327e701692a281934230af0b6be8df3353",
+      "name": "Fluence",
+      "symbol": "FLT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36339/large/IMG_3928.png?1727165842"
+    },
+    {
+      "chainId": 1,
+      "address": "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f",
+      "name": "GHO",
+      "symbol": "GHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30663/large/gho-token-logo.png?1720517092"
+    },
+    {
+      "chainId": 1,
+      "address": "0x865377367054516e17014ccded1e7d814edc9ce4",
+      "name": "DOLA",
+      "symbol": "DOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
+    },
+    {
+      "chainId": 1,
+      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
+      "name": "Pocket Network",
+      "symbol": "POKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
     },
     {
       "chainId": 1,
@@ -3980,6 +3756,238 @@
     },
     {
       "chainId": 1,
+      "address": "0xb8a87405d9a4f2f866319b77004e88dff66c0d92",
+      "name": "Sora AI",
+      "symbol": "SORA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35293/large/IMG_20240315_205215_106.jpg?1710729039"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c6e2c495b974b8d4220e370f23c7e0e1da9b644",
+      "name": "Smiley Coin",
+      "symbol": "SMILEY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/30809/large/photo_2023-06-21_03-25-14.jpg?1696529666"
+    },
+    {
+      "chainId": 1,
+      "address": "0x174c47d6a4e548ed2b7d369dc0ffb2e60a6ac0f8",
+      "name": "Amulet Protocol",
+      "symbol": "AMU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/34716/large/AMT200x200.png?1705904544"
+    },
+    {
+      "chainId": 1,
+      "address": "0x48b847cf774a5710f36f594b11fc10e2e59bba72",
+      "name": "Unit0",
+      "symbol": "UNIT0",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51237/large/200%D1%85200.png?1730448085"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
+      "name": "Bancor Network",
+      "symbol": "BNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/736/large/Bancor_Token.png?1710479159"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6b0b3a982b4634ac68dd83a4dbf02311ce324181",
+      "name": "Artificial Liquid Intelligence",
+      "symbol": "ALI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22062/large/ALI-v2.webp?1728501978"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa1290d69c65a6fe4df752f95823fae25cb99e5a7",
+      "name": "Kelp DAO Restaked ETH",
+      "symbol": "RSETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33800/large/Icon___Dark.png?1702991855"
+    },
+    {
+      "chainId": 1,
+      "address": "0x03aa6298f1370642642415edc0db8b957783e8d6",
+      "name": "NetMind Token",
+      "symbol": "NMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35328/large/NMT-logo.png?1708267799"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3c72fca8523686fd9e5740b0826fa4bb376e0241",
+      "name": "300FIT",
+      "symbol": "FIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9690/large/6mkyI4Ss_400x400.png?1696509759"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8d96b4ab6c741a4c8679ae323a100d74f085ba8f",
+      "name": "Bazaars",
+      "symbol": "BZR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26392/large/bazaars_logo-color-black-icon.png?1696525469"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
+      "name": "Keep3rV1",
+      "symbol": "KP3R",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12966/large/kp3r_logo.jpg?1696512754"
+    },
+    {
+      "chainId": 1,
+      "address": "0x83e6f1e41cdd28eaceb20cb649155049fac3d5aa",
+      "name": "Polkastarter",
+      "symbol": "POLS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12648/large/Group_11_%281%29_1.png?1725563541"
+    },
+    {
+      "chainId": 1,
+      "address": "0x39d5313c3750140e5042887413ba8aa6145a9bd2",
+      "name": "Empyreal",
+      "symbol": "EMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31374/large/logomainblacktransparent.png?1719953450"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb6667b04cb61aa16b59617f90ffa068722cf21da",
+      "name": "Worldwide USD",
+      "symbol": "WUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e79b51959cf968d87826592f46f819f92466615",
+      "name": "Hoppy",
+      "symbol": "HOPPY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37197/large/Hoppy_200x200_.png?1724175711"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6a9b3fdb4a3296ecba1ebfa2cf4a8b16032a769c",
+      "name": "bitSmiley",
+      "symbol": "SMILE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51309/large/Copy_of_Token_icon_White_background.png?1730635535"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb90b2a35c65dbc466b04240097ca756ad2005295",
+      "name": "BOBO Coin",
+      "symbol": "BOBO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30388/large/bobologo_200x200.png?1725466815"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9e46a38f5daabe8683e10793b06749eef7d733d1",
+      "name": "PolySwarm",
+      "symbol": "NCT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2843/large/ImcYCVfX_400x400.jpg?1696503602"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2e44f3f609ff5aa4819b323fd74690f07c3607c4",
+      "name": "PinLink",
+      "symbol": "PIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51611/large/200x00.png?1731616756"
+    },
+    {
+      "chainId": 1,
+      "address": "0x27c70cd1946795b66be9d954418546998b546634",
+      "name": "Doge Killer",
+      "symbol": "LEASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15802/large/Leash.png?1696515425"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2af5d2ad76741191d15dfe7bf6ac92d4bd912ca3",
+      "name": "LEO Token",
+      "symbol": "LEO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8418/large/leo-token.png?1696508607"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6f40d4a6237c257fff2db00fa0510deeecd303eb",
+      "name": "Instadapp",
+      "symbol": "INST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14688/large/30hFM0-n_400x400.jpg?1696514361"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba3335588d9403515223f109edc4eb7269a9ab5d",
+      "name": "Gearbox",
+      "symbol": "GEAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21630/large/gear.png?1696520990"
+    },
+    {
+      "chainId": 1,
+      "address": "0x70bc0dc6414eb8974bc70685f798838a87d8cce4",
+      "name": "Chirpley",
+      "symbol": "CHRP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27243/large/Chirpley-Logo_200x200.png?1696526293"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2fc246aa66f0da5bb1368f688548ecbbe9bdee5d",
+      "name": "TEMCO",
+      "symbol": "TEMCO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6210/large/bSZ7HUuS_400x400.jpg?1696506595"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc581b735a1688071a1746c968e0798d642ede491",
+      "name": "Euro Tether",
+      "symbol": "EURT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17385/large/Tether_new.png?1696516934"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+      "name": "Liquity USD",
+      "symbol": "LUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1696514341"
+    },
+    {
+      "chainId": 1,
+      "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
+      "name": "Ocean Protocol",
+      "symbol": "OCEAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3687/large/ocean-protocol-logo.jpg?1696504363"
+    },
+    {
+      "chainId": 1,
       "address": "0x1ce270557c1f68cfb577b856766310bf8b47fd9c",
       "name": "MongCoin",
       "symbol": "MONG",
@@ -3988,28 +3996,20 @@
     },
     {
       "chainId": 1,
-      "address": "0xc477d038d5420c6a9e0b031712f61c5120090de9",
-      "name": "Boson Protocol",
-      "symbol": "BOSON",
+      "address": "0x8be3460a480c80728a8c4d7a5d5303c85ba7b3b9",
+      "name": "Ethena Staked ENA",
+      "symbol": "SENA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14710/large/boson_logo.png?1696514381"
+      "logoURI": "https://assets.coingecko.com/coins/images/50235/large/ena.png?1726630994"
     },
     {
       "chainId": 1,
-      "address": "0x0b7f0e51cd1739d6c96982d55ad8fa634dd43a9c",
-      "name": "Dream Machine Token",
-      "symbol": "DMT",
+      "address": "0xe77f6acd24185e149e329c1c0f479201b9ec2f4b",
+      "name": "Zeebu",
+      "symbol": "ZBU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30505/large/dmt.png?1696529391"
-    },
-    {
-      "chainId": 1,
-      "address": "0x939069722d568b5498ccba4356e800eaefefd2a5",
-      "name": "Finanx AI",
-      "symbol": "FNXAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51119/large/200x200.png?1730126766"
+      "logoURI": "https://assets.coingecko.com/coins/images/31145/large/200x200_Front_token.png?1696529974"
     }
   ],
-  "timestamp": "2024-12-06T16:14:59.826Z"
+  "timestamp": "2024-12-10T17:05:15.790Z"
 }

--- a/src/public/CoinGecko.1.json
+++ b/src/public/CoinGecko.1.json
@@ -16,7 +16,7 @@
       "name": "Tether",
       "symbol": "USDT",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/325/thumb/Tether.png?1696501661"
+      "logoURI": "https://assets.coingecko.com/coins/images/325/large/Tether.png?1696501661"
     },
     {
       "chainId": 1,
@@ -24,7 +24,7 @@
       "name": "USDC",
       "symbol": "USDC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/6319/thumb/usdc.png?1696506694"
+      "logoURI": "https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696506694"
     },
     {
       "chainId": 1,
@@ -32,7 +32,7 @@
       "name": "First Digital USD",
       "symbol": "FDUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31079/thumb/FDUSD_icon_black.png?1731097953"
+      "logoURI": "https://assets.coingecko.com/coins/images/31079/large/FDUSD_icon_black.png?1731097953"
     },
     {
       "chainId": 1,
@@ -40,7 +40,7 @@
       "name": "Pepe",
       "symbol": "PEPE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29850/thumb/pepe-token.jpeg?1696528776"
+      "logoURI": "https://assets.coingecko.com/coins/images/29850/large/pepe-token.jpeg?1696528776"
     },
     {
       "chainId": 1,
@@ -48,7 +48,7 @@
       "name": "BNB",
       "symbol": "BNB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/825/thumb/bnb-icon2_2x.png?1696501970"
+      "logoURI": "https://assets.coingecko.com/coins/images/825/large/bnb-icon2_2x.png?1696501970"
     },
     {
       "chainId": 1,
@@ -56,7 +56,7 @@
       "name": "Shiba Inu",
       "symbol": "SHIB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1696511800"
+      "logoURI": "https://assets.coingecko.com/coins/images/11939/large/shiba.png?1696511800"
     },
     {
       "chainId": 1,
@@ -64,7 +64,7 @@
       "name": "JasmyCoin",
       "symbol": "JASMY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1696513620"
+      "logoURI": "https://assets.coingecko.com/coins/images/13876/large/JASMY200x200.jpg?1696513620"
     },
     {
       "chainId": 1,
@@ -72,7 +72,7 @@
       "name": "Worldcoin",
       "symbol": "WLD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31069/thumb/worldcoin.jpeg?1696529903"
+      "logoURI": "https://assets.coingecko.com/coins/images/31069/large/worldcoin.jpeg?1696529903"
     },
     {
       "chainId": 1,
@@ -80,7 +80,7 @@
       "name": "Chainlink",
       "symbol": "LINK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/877/thumb/chainlink-new-logo.png?1696502009"
+      "logoURI": "https://assets.coingecko.com/coins/images/877/large/chainlink-new-logo.png?1696502009"
     },
     {
       "chainId": 1,
@@ -88,15 +88,7 @@
       "name": "Curve DAO",
       "symbol": "CRV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12124/thumb/Curve.png?1696511967"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-      "name": "WETH",
-      "symbol": "WETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2518/thumb/weth.png?1696503332"
+      "logoURI": "https://assets.coingecko.com/coins/images/12124/large/Curve.png?1696511967"
     },
     {
       "chainId": 1,
@@ -104,7 +96,7 @@
       "name": "Uniswap",
       "symbol": "UNI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12504/thumb/uniswap-logo.png?1720676669"
+      "logoURI": "https://assets.coingecko.com/coins/images/12504/large/uniswap-logo.png?1720676669"
     },
     {
       "chainId": 1,
@@ -112,7 +104,7 @@
       "name": "Artificial Superintelligence Alliance",
       "symbol": "FET",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/ASI.png?1719827289"
+      "logoURI": "https://assets.coingecko.com/coins/images/5681/large/ASI.png?1719827289"
     },
     {
       "chainId": 1,
@@ -120,7 +112,7 @@
       "name": "NEAR Protocol",
       "symbol": "NEAR",
       "decimals": 24,
-      "logoURI": "https://assets.coingecko.com/coins/images/10365/thumb/near.jpg?1696510367"
+      "logoURI": "https://assets.coingecko.com/coins/images/10365/large/near.jpg?1696510367"
     },
     {
       "chainId": 1,
@@ -128,7 +120,7 @@
       "name": "Arbitrum",
       "symbol": "ARB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16547/thumb/arb.jpg?1721358242"
+      "logoURI": "https://assets.coingecko.com/coins/images/16547/large/arb.jpg?1721358242"
     },
     {
       "chainId": 1,
@@ -136,7 +128,7 @@
       "name": "Creditcoin",
       "symbol": "CTC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10569/thumb/ctc.png?1696510552"
+      "logoURI": "https://assets.coingecko.com/coins/images/10569/large/ctc.png?1696510552"
     },
     {
       "chainId": 1,
@@ -144,7 +136,7 @@
       "name": "0x Protocol",
       "symbol": "ZRX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/863/thumb/0x.png?1696501996"
+      "logoURI": "https://assets.coingecko.com/coins/images/863/large/0x.png?1696501996"
     },
     {
       "chainId": 1,
@@ -152,7 +144,7 @@
       "name": "The Sandbox",
       "symbol": "SAND",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1696511971"
+      "logoURI": "https://assets.coingecko.com/coins/images/12129/large/sandbox_logo.jpg?1696511971"
     },
     {
       "chainId": 1,
@@ -160,7 +152,7 @@
       "name": "Ethena",
       "symbol": "ENA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36530/thumb/ethena.png?1711701436"
+      "logoURI": "https://assets.coingecko.com/coins/images/36530/large/ethena.png?1711701436"
     },
     {
       "chainId": 1,
@@ -168,7 +160,15 @@
       "name": "Render",
       "symbol": "RENDER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1696511529"
+      "logoURI": "https://assets.coingecko.com/coins/images/11636/large/rndr.png?1696511529"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "name": "WETH",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2518/large/weth.png?1696503332"
     },
     {
       "chainId": 1,
@@ -176,7 +176,7 @@
       "name": "GALA",
       "symbol": "GALA",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/12493/thumb/GALA_token_image_-_200PNG.png?1709725869"
+      "logoURI": "https://assets.coingecko.com/coins/images/12493/large/GALA_token_image_-_200PNG.png?1709725869"
     },
     {
       "chainId": 1,
@@ -184,15 +184,7 @@
       "name": "Aave",
       "symbol": "AAVE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/aave-token-round.png?1720472354"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
-      "name": "LayerZero",
-      "symbol": "ZRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28206/thumb/ftxG9_TJ_400x400.jpeg?1696527208"
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/large/aave-token-round.png?1720472354"
     },
     {
       "chainId": 1,
@@ -200,7 +192,7 @@
       "name": "Bonk",
       "symbol": "BONK",
       "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/28600/thumb/bonk.jpg?1696527587"
+      "logoURI": "https://assets.coingecko.com/coins/images/28600/large/bonk.jpg?1696527587"
     },
     {
       "chainId": 1,
@@ -208,7 +200,15 @@
       "name": "Ethereum Name Service",
       "symbol": "ENS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/ENS.jpg?1727872989"
+      "logoURI": "https://assets.coingecko.com/coins/images/19785/large/ENS.jpg?1727872989"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "name": "LayerZero",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
     },
     {
       "chainId": 1,
@@ -216,7 +216,7 @@
       "name": "Wrapped Bitcoin",
       "symbol": "WBTC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/7598/thumb/wrapped_bitcoin_wbtc.png?1696507857"
+      "logoURI": "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1696507857"
     },
     {
       "chainId": 1,
@@ -224,7 +224,7 @@
       "name": "Coinbase Wrapped BTC",
       "symbol": "CBBTC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/40143/thumb/cbbtc.webp?1726136727"
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
     },
     {
       "chainId": 1,
@@ -232,39 +232,7 @@
       "name": "Toncoin",
       "symbol": "TON",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/17980/thumb/photo_2024-09-10_17.09.00.jpeg?1725963446"
-    },
-    {
-      "chainId": 1,
-      "address": "0x92d6c1e31e14520e676a687f0a93788b716beff5",
-      "name": "dYdX",
-      "symbol": "ETHDYDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1696517040"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe28b3b32b6c345a34ff64674606124dd5aceca30",
-      "name": "Injective",
-      "symbol": "INJ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1696512670"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
-      "name": "FLOKI",
-      "symbol": "FLOKI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/16746/thumb/PNG_image.png?1696516318"
-    },
-    {
-      "chainId": 1,
-      "address": "0x58b6a8a3302369daec383334672404ee733ab239",
-      "name": "Livepeer",
-      "symbol": "LPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/badge-logo-circuit-green.png?1719357686"
+      "logoURI": "https://assets.coingecko.com/coins/images/17980/large/photo_2024-09-10_17.09.00.jpeg?1725963446"
     },
     {
       "chainId": 1,
@@ -272,7 +240,39 @@
       "name": "POL  ex MATIC ",
       "symbol": "POL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32440/thumb/polygon.png?1698233684"
+      "logoURI": "https://assets.coingecko.com/coins/images/32440/large/polygon.png?1698233684"
+    },
+    {
+      "chainId": 1,
+      "address": "0x92d6c1e31e14520e676a687f0a93788b716beff5",
+      "name": "dYdX",
+      "symbol": "ETHDYDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17500/large/hjnIm9bV.jpg?1696517040"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe28b3b32b6c345a34ff64674606124dd5aceca30",
+      "name": "Injective",
+      "symbol": "INJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12882/large/Secondary_Symbol.png?1696512670"
+    },
+    {
+      "chainId": 1,
+      "address": "0x58b6a8a3302369daec383334672404ee733ab239",
+      "name": "Livepeer",
+      "symbol": "LPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/large/badge-logo-circuit-green.png?1719357686"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
+      "name": "FLOKI",
+      "symbol": "FLOKI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16746/large/PNG_image.png?1696516318"
     },
     {
       "chainId": 1,
@@ -280,7 +280,7 @@
       "name": "Ether fi",
       "symbol": "ETHFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35958/thumb/etherfi.jpeg?1710254562"
+      "logoURI": "https://assets.coingecko.com/coins/images/35958/large/etherfi.jpeg?1710254562"
     },
     {
       "chainId": 1,
@@ -288,7 +288,7 @@
       "name": "IQ",
       "symbol": "IQ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5010/thumb/YAIS3fUh.png?1696505542"
+      "logoURI": "https://assets.coingecko.com/coins/images/5010/large/YAIS3fUh.png?1696505542"
     },
     {
       "chainId": 1,
@@ -296,7 +296,7 @@
       "name": "Ondo",
       "symbol": "ONDO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26580/thumb/ONDO.png?1696525656"
+      "logoURI": "https://assets.coingecko.com/coins/images/26580/large/ONDO.png?1696525656"
     },
     {
       "chainId": 1,
@@ -304,7 +304,7 @@
       "name": "Lido DAO",
       "symbol": "LDO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1696513326"
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1696513326"
     },
     {
       "chainId": 1,
@@ -312,47 +312,7 @@
       "name": "ApeCoin",
       "symbol": "APE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24383/thumb/apecoin.jpg?1696523566"
-    },
-    {
-      "chainId": 1,
-      "address": "0x812ba41e071c7b7fa4ebcfb62df5f45f6fa853ee",
-      "name": "Neiro",
-      "symbol": "NEIRO",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/39488/thumb/neiro.jpg?1731449567"
-    },
-    {
-      "chainId": 1,
-      "address": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
-      "name": "Eigenlayer",
-      "symbol": "EIGEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37441/thumb/eigen.jpg?1728023974"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
-      "name": "Decentraland",
-      "symbol": "MANA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1696502010"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6e2a43be0b1d33b726f0ca3b8de60b3482b8b050",
-      "name": "Arkham",
-      "symbol": "ARKM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30929/thumb/Arkham_Logo_CG.png?1696529771"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3506424f91fd33084466f402d5d97f05f8e3b4af",
-      "name": "Chiliz",
-      "symbol": "CHZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8834/thumb/CHZ_Token_updated.png?1696508986"
+      "logoURI": "https://assets.coingecko.com/coins/images/24383/large/apecoin.jpg?1696523566"
     },
     {
       "chainId": 1,
@@ -360,7 +320,47 @@
       "name": "The Graph",
       "symbol": "GRT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1696513159"
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/large/Graph_Token.png?1696513159"
+    },
+    {
+      "chainId": 1,
+      "address": "0x812ba41e071c7b7fa4ebcfb62df5f45f6fa853ee",
+      "name": "Neiro",
+      "symbol": "NEIRO",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/39488/large/neiro.jpg?1731449567"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
+      "name": "Eigenlayer",
+      "symbol": "EIGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37441/large/eigen.jpg?1728023974"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+      "name": "Decentraland",
+      "symbol": "MANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/878/large/decentraland-mana.png?1696502010"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e2a43be0b1d33b726f0ca3b8de60b3482b8b050",
+      "name": "Arkham",
+      "symbol": "ARKM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30929/large/Arkham_Logo_CG.png?1696529771"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3506424f91fd33084466f402d5d97f05f8e3b4af",
+      "name": "Chiliz",
+      "symbol": "CHZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8834/large/CHZ_Token_updated.png?1696508986"
     },
     {
       "chainId": 1,
@@ -368,7 +368,7 @@
       "name": "Reserve Rights",
       "symbol": "RSR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8365/thumb/RSR_Blue_Circle_1000.png?1721777856"
+      "logoURI": "https://assets.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
     },
     {
       "chainId": 1,
@@ -376,7 +376,7 @@
       "name": "Mog Coin",
       "symbol": "MOG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31059/thumb/MOG_LOGO_200x200.png?1696529893"
+      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png?1696529893"
     },
     {
       "chainId": 1,
@@ -384,15 +384,7 @@
       "name": "Morpho",
       "symbol": "MORPHO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29837/thumb/Morpho-token-icon.png?1726771230"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb0ffa8000886e57f86dd5264b9582b2ad87b2b91",
-      "name": "Wormhole",
-      "symbol": "W",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35087/thumb/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
+      "logoURI": "https://assets.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
     },
     {
       "chainId": 1,
@@ -400,7 +392,15 @@
       "name": "Starknet",
       "symbol": "STRK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26433/thumb/starknet.png?1696525507"
+      "logoURI": "https://assets.coingecko.com/coins/images/26433/large/starknet.png?1696525507"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb0ffa8000886e57f86dd5264b9582b2ad87b2b91",
+      "name": "Wormhole",
+      "symbol": "W",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35087/large/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
     },
     {
       "chainId": 1,
@@ -408,7 +408,7 @@
       "name": "PancakeSwap",
       "symbol": "CAKE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12632/thumb/pancakeswap-cake-logo_%281%29.png?1696512440"
+      "logoURI": "https://assets.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
     },
     {
       "chainId": 1,
@@ -416,15 +416,7 @@
       "name": "Compound",
       "symbol": "COMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10775/thumb/COMP.png?1696510737"
-    },
-    {
-      "chainId": 1,
-      "address": "0x50327c6c5a14dcade707abad2e27eb517df87ab5",
-      "name": "Wrapped Tron",
-      "symbol": "WTRX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/22471/thumb/xOesRfpN_400x400.jpg?1696521795"
+      "logoURI": "https://assets.coingecko.com/coins/images/10775/large/COMP.png?1696510737"
     },
     {
       "chainId": 1,
@@ -432,7 +424,15 @@
       "name": "Aevo",
       "symbol": "AEVO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35893/thumb/aevo.png?1710138340"
+      "logoURI": "https://assets.coingecko.com/coins/images/35893/large/aevo.png?1710138340"
+    },
+    {
+      "chainId": 1,
+      "address": "0x50327c6c5a14dcade707abad2e27eb517df87ab5",
+      "name": "Wrapped Tron",
+      "symbol": "WTRX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22471/large/xOesRfpN_400x400.jpg?1696521795"
     },
     {
       "chainId": 1,
@@ -440,7 +440,7 @@
       "name": "Virtuals Protocol",
       "symbol": "VIRTUAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34057/thumb/LOGOMARK.png?1708356054"
+      "logoURI": "https://assets.coingecko.com/coins/images/34057/large/LOGOMARK.png?1708356054"
     },
     {
       "chainId": 1,
@@ -448,15 +448,7 @@
       "name": "Pendle",
       "symbol": "PENDLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15069/thumb/Pendle_Logo_Normal-03.png?1696514728"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
-      "name": "Ethena USDe",
-      "symbol": "USDE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33613/thumb/USDE.png?1716355685"
+      "logoURI": "https://assets.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
     },
     {
       "chainId": 1,
@@ -464,7 +456,15 @@
       "name": "Bitget Token",
       "symbol": "BGB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11610/thumb/icon_colour.png?1696511504"
+      "logoURI": "https://assets.coingecko.com/coins/images/11610/large/icon_colour.png?1696511504"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
+      "name": "Ethena USDe",
+      "symbol": "USDE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33613/large/USDE.png?1716355685"
     },
     {
       "chainId": 1,
@@ -472,31 +472,7 @@
       "name": "OPENLOOT",
       "symbol": "OL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51801/thumb/_OPENLOOT_token-icon_black_%282%29.png?1731989426"
-    },
-    {
-      "chainId": 1,
-      "address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
-      "name": "Across Protocol",
-      "symbol": "ACX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28161/thumb/across-200x200.png?1696527165"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
-      "name": "Sushi",
-      "symbol": "SUSHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1696512101"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3c3a81e81dc49a522a592e7622a7e711c06bf354",
-      "name": "Mantle",
-      "symbol": "MNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30980/thumb/token-logo.png?1696529819"
+      "logoURI": "https://assets.coingecko.com/coins/images/51801/large/_OPENLOOT_token-icon_black_%282%29.png?1731989426"
     },
     {
       "chainId": 1,
@@ -504,15 +480,23 @@
       "name": "ConstitutionDAO",
       "symbol": "PEOPLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20612/thumb/GN_UVm3d_400x400.jpg?1696520017"
+      "logoURI": "https://assets.coingecko.com/coins/images/20612/large/GN_UVm3d_400x400.jpg?1696520017"
     },
     {
       "chainId": 1,
-      "address": "0xa35923162c49cf95e6bf26623385eb431ad920d3",
-      "name": "Turbo",
-      "symbol": "TURBO",
+      "address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+      "name": "Across Protocol",
+      "symbol": "ACX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30117/thumb/TurboMark-QL_200.png?1708079597"
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+      "name": "Sushi",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/large/512x512_Logo_no_chop.png?1696512101"
     },
     {
       "chainId": 1,
@@ -520,7 +504,15 @@
       "name": "Ankr Network",
       "symbol": "ANKR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1696504928"
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1696504928"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa35923162c49cf95e6bf26623385eb431ad920d3",
+      "name": "Turbo",
+      "symbol": "TURBO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30117/large/TurboMark-QL_200.png?1708079597"
     },
     {
       "chainId": 1,
@@ -528,7 +520,7 @@
       "name": "Axie Infinity",
       "symbol": "AXS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1696512817"
+      "logoURI": "https://assets.coingecko.com/coins/images/13029/large/axie_infinity_logo.png?1696512817"
     },
     {
       "chainId": 1,
@@ -536,7 +528,15 @@
       "name": "Maker",
       "symbol": "MKR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1364/thumb/Mark_Maker.png?1696502423"
+      "logoURI": "https://assets.coingecko.com/coins/images/1364/large/Mark_Maker.png?1696502423"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3c3a81e81dc49a522a592e7622a7e711c06bf354",
+      "name": "Mantle",
+      "symbol": "MNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30980/large/token-logo.png?1696529819"
     },
     {
       "chainId": 1,
@@ -544,15 +544,7 @@
       "name": "Memecoin",
       "symbol": "MEME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32528/thumb/memecoin_%282%29.png?1698912168"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
-      "name": "yearn finance",
-      "symbol": "YFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yearn.jpg?1696511720"
+      "logoURI": "https://assets.coingecko.com/coins/images/32528/large/memecoin_%282%29.png?1698912168"
     },
     {
       "chainId": 1,
@@ -560,7 +552,15 @@
       "name": "Mask Network",
       "symbol": "MASK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1696513776"
+      "logoURI": "https://assets.coingecko.com/coins/images/14051/large/Mask_Network.jpg?1696513776"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+      "name": "yearn finance",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/large/yearn.jpg?1696511720"
     },
     {
       "chainId": 1,
@@ -568,23 +568,7 @@
       "name": "1inch",
       "symbol": "1INCH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1696513230"
-    },
-    {
-      "chainId": 1,
-      "address": "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9",
-      "name": "FTX",
-      "symbol": "FTT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9026/thumb/F.png?1696509161"
-    },
-    {
-      "chainId": 1,
-      "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
-      "name": "Tellor Tributes",
-      "symbol": "TRB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1696509713"
+      "logoURI": "https://assets.coingecko.com/coins/images/13469/large/1inch-token.png?1696513230"
     },
     {
       "chainId": 1,
@@ -592,7 +576,23 @@
       "name": "Dai",
       "symbol": "DAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9956/thumb/Badge_Dai.png?1696509996"
+      "logoURI": "https://assets.coingecko.com/coins/images/9956/large/Badge_Dai.png?1696509996"
+    },
+    {
+      "chainId": 1,
+      "address": "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9",
+      "name": "FTX",
+      "symbol": "FTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9026/large/F.png?1696509161"
+    },
+    {
+      "chainId": 1,
+      "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
+      "name": "Tellor Tributes",
+      "symbol": "TRB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/large/Blk_icon_current.png?1696509713"
     },
     {
       "chainId": 1,
@@ -600,7 +600,7 @@
       "name": "Immutable",
       "symbol": "IMX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/immutableX-symbol-BLK-RGB.png?1696516787"
+      "logoURI": "https://assets.coingecko.com/coins/images/17233/large/immutableX-symbol-BLK-RGB.png?1696516787"
     },
     {
       "chainId": 1,
@@ -608,7 +608,7 @@
       "name": "Amp",
       "symbol": "AMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1696512231"
+      "logoURI": "https://assets.coingecko.com/coins/images/12409/large/amp-200x200.png?1696512231"
     },
     {
       "chainId": 1,
@@ -616,7 +616,7 @@
       "name": "Yield Guild Games",
       "symbol": "YGG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
+      "logoURI": "https://assets.coingecko.com/coins/images/17358/large/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
     },
     {
       "chainId": 1,
@@ -624,231 +624,7 @@
       "name": "Blur",
       "symbol": "BLUR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28453/thumb/blur.png?1696527448"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2dff88a56767223a5529ea5960da7a3f5f766406",
-      "name": "SPACE ID",
-      "symbol": "ID",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29468/thumb/sid_token_logo_%28green2%29.png?1696528413"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
-      "name": "Synthetix Network",
-      "symbol": "SNX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3406/thumb/SNX.png?1696504103"
-    },
-    {
-      "chainId": 1,
-      "address": "0x62d0a8458ed7719fdaf978fe5929c6d342b0bfce",
-      "name": "Beam",
-      "symbol": "BEAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32417/thumb/chain-logo.png?1698114384"
-    },
-    {
-      "chainId": 1,
-      "address": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
-      "name": "Lido Staked Ether",
-      "symbol": "STETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13442/thumb/steth_logo.png?1696513206"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9d65ff81a3c488d585bbfb0bfe3c7707c7917f54",
-      "name": "SSV Network",
-      "symbol": "SSV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19155/thumb/ssv.png?1696518606"
-    },
-    {
-      "chainId": 1,
-      "address": "0x10dea67478c5f8c5e2d90e5e9b26dbe60c54d800",
-      "name": "Taiko",
-      "symbol": "TAIKO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38058/thumb/icon.png?1717626867"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
-      "name": "Basic Attention",
-      "symbol": "BAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1696501867"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3593d125a4f7849a1b059e64f4517a86dd60c95d",
-      "name": "MANTRA",
-      "symbol": "OM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12151/thumb/OM_Token.png?1696511991"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4d1c297d39c5c1277964d0e3f8aa901493664530",
-      "name": "Puffer",
-      "symbol": "PUFFER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50630/thumb/PUFFER_token_Logo.png?1729574024"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1bbe973bef3a977fc51cbed703e8ffdefe001fed",
-      "name": "Portal",
-      "symbol": "PORTAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35436/thumb/portal.jpeg?1708590254"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8457ca5040ad67fdebbcc8edce889a335bc0fbfb",
-      "name": "AltLayer",
-      "symbol": "ALT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34608/thumb/Logomark_200x200.png?1715107868"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
-      "name": "Wrapped stETH",
-      "symbol": "WSTETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18834/thumb/wstETH.png?1696518295"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaedf386b755465871ff874e3e37af5976e247064",
-      "name": "Fasttoken",
-      "symbol": "FTN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28478/thumb/lightenicon_200x200.png?1696527472"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
-      "name": "Quant",
-      "symbol": "QNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1696504070"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
-      "name": "Convex Finance",
-      "symbol": "CVX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1696515221"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
-      "name": "Loopring",
-      "symbol": "LRC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/913/thumb/LRC.png?1696502034"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe3c408bd53c31c085a1746af401a4042954ff740",
-      "name": "GMT",
-      "symbol": "GMT",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/23597/thumb/token-gmt-200x200.png?1703153841"
-    },
-    {
-      "chainId": 1,
-      "address": "0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7",
-      "name": "SKALE",
-      "symbol": "SKL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13245/thumb/SKALE_token_300x300.png?1696513021"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfd418e42783382e86ae91e445406600ba144d162",
-      "name": "Zircuit",
-      "symbol": "ZRC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35960/thumb/zircuit_token_icon_2.png?1732502352"
-    },
-    {
-      "chainId": 1,
-      "address": "0x11eef04c884e24d9b7b4760e7476d06ddf797f36",
-      "name": "MX",
-      "symbol": "MX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8545/thumb/MEXC_GLOBAL_LOGO.jpeg?1696508719"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5afe3855358e112b5647b952709e6165e1c1eeee",
-      "name": "Safe",
-      "symbol": "SAFE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27032/thumb/Artboard_1_copy_8circle-1.png?1696526084"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3429d03c6f7521aec737a0bbf2e5ddcef2c3ae31",
-      "name": "Pixels",
-      "symbol": "PIXEL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35100/thumb/pixel-icon.png?1708339519"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfee293840d23b0b2de8c55e1cf7a9f01c157767c",
-      "name": "Degen  Base ",
-      "symbol": "DEGEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34515/thumb/android-chrome-512x512.png?1706198225"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
-      "name": "Enjin Coin",
-      "symbol": "ENJ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/Symbol_Only_-_Purple.png?1709725966"
-    },
-    {
-      "chainId": 1,
-      "address": "0xed04915c23f00a313a544955524eb7dbd823143d",
-      "name": "Alchemy Pay",
-      "symbol": "ACH",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/12390/thumb/ACH_%281%29.png?1696512213"
-    },
-    {
-      "chainId": 1,
-      "address": "0xddb3422497e61e13543bea06989c0789117555c5",
-      "name": "COTI",
-      "symbol": "COTI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1696503705"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6fb3e0a217407efff7ca062d46c26e5d60a14d69",
-      "name": "IoTeX",
-      "symbol": "IOTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3334/thumb/Token_Icon_Token_Icon.png?1727899869"
-    },
-    {
-      "chainId": 1,
-      "address": "0xae12c5930881c53715b369cec7606b70d8eb229f",
-      "name": "Coin98",
-      "symbol": "C98",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17117/thumb/logo.png?1696516677"
+      "logoURI": "https://assets.coingecko.com/coins/images/28453/large/blur.png?1696527448"
     },
     {
       "chainId": 1,
@@ -856,15 +632,223 @@
       "name": "Gravity",
       "symbol": "G",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39200/thumb/gravity.jpg?1721020647"
+      "logoURI": "https://assets.coingecko.com/coins/images/39200/large/gravity.jpg?1721020647"
     },
     {
       "chainId": 1,
-      "address": "0x64bc2ca1be492be7185faa2c8835d9b824c8a194",
-      "name": "Big Time",
-      "symbol": "BIGTIME",
+      "address": "0x2dff88a56767223a5529ea5960da7a3f5f766406",
+      "name": "SPACE ID",
+      "symbol": "ID",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32251/thumb/-6136155493475923781_121.jpg?1696998691"
+      "logoURI": "https://assets.coingecko.com/coins/images/29468/large/sid_token_logo_%28green2%29.png?1696528413"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+      "name": "Synthetix Network",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3406/large/SNX.png?1696504103"
+    },
+    {
+      "chainId": 1,
+      "address": "0x62d0a8458ed7719fdaf978fe5929c6d342b0bfce",
+      "name": "Beam",
+      "symbol": "BEAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32417/large/chain-logo.png?1698114384"
+    },
+    {
+      "chainId": 1,
+      "address": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
+      "name": "Lido Staked Ether",
+      "symbol": "STETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13442/large/steth_logo.png?1696513206"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9d65ff81a3c488d585bbfb0bfe3c7707c7917f54",
+      "name": "SSV Network",
+      "symbol": "SSV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19155/large/ssv.png?1696518606"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3593d125a4f7849a1b059e64f4517a86dd60c95d",
+      "name": "MANTRA",
+      "symbol": "OM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12151/large/OM_Token.png?1696511991"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+      "name": "Basic Attention",
+      "symbol": "BAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/677/large/basic-attention-token.png?1696501867"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4d1c297d39c5c1277964d0e3f8aa901493664530",
+      "name": "Puffer",
+      "symbol": "PUFFER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50630/large/PUFFER_token_Logo.png?1729574024"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1bbe973bef3a977fc51cbed703e8ffdefe001fed",
+      "name": "Portal",
+      "symbol": "PORTAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35436/large/portal.jpeg?1708590254"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+      "name": "Wrapped stETH",
+      "symbol": "WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8457ca5040ad67fdebbcc8edce889a335bc0fbfb",
+      "name": "AltLayer",
+      "symbol": "ALT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34608/large/Logomark_200x200.png?1715107868"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaedf386b755465871ff874e3e37af5976e247064",
+      "name": "Fasttoken",
+      "symbol": "FTN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28478/large/lightenicon_200x200.png?1696527472"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
+      "name": "Convex Finance",
+      "symbol": "CVX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15585/large/convex.png?1696515221"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
+      "name": "Quant",
+      "symbol": "QNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3370/large/5ZOu7brX_400x400.jpg?1696504070"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+      "name": "Loopring",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/913/large/LRC.png?1696502034"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe3c408bd53c31c085a1746af401a4042954ff740",
+      "name": "GMT",
+      "symbol": "GMT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/23597/large/token-gmt-200x200.png?1703153841"
+    },
+    {
+      "chainId": 1,
+      "address": "0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7",
+      "name": "SKALE",
+      "symbol": "SKL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13245/large/SKALE_token_300x300.png?1696513021"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfd418e42783382e86ae91e445406600ba144d162",
+      "name": "Zircuit",
+      "symbol": "ZRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35960/large/zircuit_token_icon_2.png?1732502352"
+    },
+    {
+      "chainId": 1,
+      "address": "0x11eef04c884e24d9b7b4760e7476d06ddf797f36",
+      "name": "MX",
+      "symbol": "MX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8545/large/MEXC_GLOBAL_LOGO.jpeg?1696508719"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3429d03c6f7521aec737a0bbf2e5ddcef2c3ae31",
+      "name": "Pixels",
+      "symbol": "PIXEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35100/large/pixel-icon.png?1708339519"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5afe3855358e112b5647b952709e6165e1c1eeee",
+      "name": "Safe",
+      "symbol": "SAFE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27032/large/Artboard_1_copy_8circle-1.png?1696526084"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfee293840d23b0b2de8c55e1cf7a9f01c157767c",
+      "name": "Degen  Base ",
+      "symbol": "DEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
+      "name": "Enjin Coin",
+      "symbol": "ENJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1102/large/Symbol_Only_-_Purple.png?1709725966"
+    },
+    {
+      "chainId": 1,
+      "address": "0xed04915c23f00a313a544955524eb7dbd823143d",
+      "name": "Alchemy Pay",
+      "symbol": "ACH",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12390/large/ACH_%281%29.png?1696512213"
+    },
+    {
+      "chainId": 1,
+      "address": "0xddb3422497e61e13543bea06989c0789117555c5",
+      "name": "COTI",
+      "symbol": "COTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2962/large/Coti.png?1696503705"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6fb3e0a217407efff7ca062d46c26e5d60a14d69",
+      "name": "IoTeX",
+      "symbol": "IOTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3334/large/Token_Icon_Token_Icon.png?1727899869"
+    },
+    {
+      "chainId": 1,
+      "address": "0xae12c5930881c53715b369cec7606b70d8eb229f",
+      "name": "Coin98",
+      "symbol": "C98",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17117/large/logo.png?1696516677"
     },
     {
       "chainId": 1,
@@ -872,7 +856,7 @@
       "name": "Adventure Gold",
       "symbol": "AGLD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1696517628"
+      "logoURI": "https://assets.coingecko.com/coins/images/18125/large/lpgblc4h_400x400.jpg?1696517628"
     },
     {
       "chainId": 1,
@@ -880,7 +864,7 @@
       "name": "Aethir",
       "symbol": "ATH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36179/thumb/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
+      "logoURI": "https://assets.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
     },
     {
       "chainId": 1,
@@ -888,7 +872,7 @@
       "name": "ZetaChain",
       "symbol": "ZETA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26718/thumb/Twitter_icon.png?1696525788"
+      "logoURI": "https://assets.coingecko.com/coins/images/26718/large/Twitter_icon.png?1696525788"
     },
     {
       "chainId": 1,
@@ -896,7 +880,7 @@
       "name": "Bounce",
       "symbol": "AUCTION",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13860/thumb/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1696513606"
+      "logoURI": "https://assets.coingecko.com/coins/images/13860/large/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1696513606"
     },
     {
       "chainId": 1,
@@ -904,79 +888,7 @@
       "name": "Golem",
       "symbol": "GLM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/542/thumb/Golem_Submark_Positive_RGB.png?1696501761"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc669928185dbce49d2230cc9b0979be6dc797957",
-      "name": "BitTorrent",
-      "symbol": "BTT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22457/thumb/btt_logo.png?1696521780"
-    },
-    {
-      "chainId": 1,
-      "address": "0x767fe9edc9e0df98e07454847909b5e959d7ca0e",
-      "name": "Illuvium",
-      "symbol": "ILV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14468/thumb/logo-200x200.png?1696514154"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
-      "name": "Holo",
-      "symbol": "HOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3348/thumb/Holologo_Profile.png?1696504052"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6e15a54b5ecac17e58dadeddbe8506a7560252f9",
-      "name": "SynFutures",
-      "symbol": "F",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52186/thumb/synfutures_f_token_light_200.png?1732722899"
-    },
-    {
-      "chainId": 1,
-      "address": "0x80c62fe4487e1351b47ba49809ebd60ed085bf52",
-      "name": "Clover Finance",
-      "symbol": "CLV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15278/thumb/photo_2022-03-24_10-22-33.jpg?1696514930"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
-      "name": "WOO",
-      "symbol": "WOO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
-      "name": "Frax Share",
-      "symbol": "FXS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/Frax_Shares_icon.png?1696513183"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
-      "name": "Stargate Finance",
-      "symbol": "STG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1696523595"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
-      "name": "Liquity",
-      "symbol": "LQTY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/logo_V2.png?1725437146"
+      "logoURI": "https://assets.coingecko.com/coins/images/542/large/Golem_Submark_Positive_RGB.png?1696501761"
     },
     {
       "chainId": 1,
@@ -984,7 +896,71 @@
       "name": "Cronos",
       "symbol": "CRO",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/cro_token_logo.png?1696507599"
+      "logoURI": "https://assets.coingecko.com/coins/images/7310/large/cro_token_logo.png?1696507599"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc669928185dbce49d2230cc9b0979be6dc797957",
+      "name": "BitTorrent",
+      "symbol": "BTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22457/large/btt_logo.png?1696521780"
+    },
+    {
+      "chainId": 1,
+      "address": "0x767fe9edc9e0df98e07454847909b5e959d7ca0e",
+      "name": "Illuvium",
+      "symbol": "ILV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14468/large/logo-200x200.png?1696514154"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
+      "name": "Holo",
+      "symbol": "HOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3348/large/Holologo_Profile.png?1696504052"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e15a54b5ecac17e58dadeddbe8506a7560252f9",
+      "name": "SynFutures",
+      "symbol": "F",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52186/large/synfutures_f_token_light_200.png?1732722899"
+    },
+    {
+      "chainId": 1,
+      "address": "0x80c62fe4487e1351b47ba49809ebd60ed085bf52",
+      "name": "Clover Finance",
+      "symbol": "CLV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15278/large/photo_2022-03-24_10-22-33.jpg?1696514930"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
+      "name": "WOO",
+      "symbol": "WOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+      "name": "Frax Share",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1696513183"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
+      "name": "Stargate Finance",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
     },
     {
       "chainId": 1,
@@ -992,7 +968,7 @@
       "name": "TrueFi",
       "symbol": "TRU",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1696512963"
+      "logoURI": "https://assets.coingecko.com/coins/images/13180/large/truefi_glyph_color.png?1696512963"
     },
     {
       "chainId": 1,
@@ -1000,39 +976,7 @@
       "name": "Treasure",
       "symbol": "MAGIC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18623/thumb/magic.png?1696518095"
-    },
-    {
-      "chainId": 1,
-      "address": "0x61ec85ab89377db65762e234c946b5c25a56e99e",
-      "name": "HTX DAO",
-      "symbol": "HTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35491/thumb/Frame_1321318576.png?1708908626"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe53ec727dbdeb9e2d5456c3be40cff031ab40a55",
-      "name": "SuperVerse",
-      "symbol": "SUPER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/SV-Logo-200x200.png?1706880312"
-    },
-    {
-      "chainId": 1,
-      "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
-      "name": "Status",
-      "symbol": "SNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1696501931"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
-      "name": "CARV",
-      "symbol": "CARV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37689/thumb/CARV_%281%29.png?1728418485"
+      "logoURI": "https://assets.coingecko.com/coins/images/18623/large/magic.png?1696518095"
     },
     {
       "chainId": 1,
@@ -1040,7 +984,39 @@
       "name": "Swell",
       "symbol": "SWELL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28777/thumb/swell1.png?1727899715"
+      "logoURI": "https://assets.coingecko.com/coins/images/28777/large/swell1.png?1727899715"
+    },
+    {
+      "chainId": 1,
+      "address": "0x61ec85ab89377db65762e234c946b5c25a56e99e",
+      "name": "HTX DAO",
+      "symbol": "HTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35491/large/Frame_1321318576.png?1708908626"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe53ec727dbdeb9e2d5456c3be40cff031ab40a55",
+      "name": "SuperVerse",
+      "symbol": "SUPER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14040/large/SV-Logo-200x200.png?1706880312"
+    },
+    {
+      "chainId": 1,
+      "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
+      "name": "Status",
+      "symbol": "SNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/779/large/status.png?1696501931"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+      "name": "CARV",
+      "symbol": "CARV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
     },
     {
       "chainId": 1,
@@ -1048,7 +1024,7 @@
       "name": "TrueUSD",
       "symbol": "TUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3449/thumb/tusd.png?1696504140"
+      "logoURI": "https://assets.coingecko.com/coins/images/3449/large/tusd.png?1696504140"
     },
     {
       "chainId": 1,
@@ -1056,519 +1032,7 @@
       "name": "Chromia",
       "symbol": "CHR",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1696505533"
-    },
-    {
-      "chainId": 1,
-      "address": "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
-      "name": "Civic",
-      "symbol": "CVC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic-orange.png?1696501939"
-    },
-    {
-      "chainId": 1,
-      "address": "0x03dde9e5bb31ee40a471476e2fccf75c67921062",
-      "name": "EML Protocol",
-      "symbol": "EML",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30950/thumb/EML_LOGO.png?1696529788"
-    },
-    {
-      "chainId": 1,
-      "address": "0x467719ad09025fcc6cf6f8311755809d45a5e5f3",
-      "name": "Axelar",
-      "symbol": "AXL",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/27277/thumb/V-65_xQ1_400x400.jpeg?1696526329"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb23d80f5fefcddaa212212f028021b41ded428cf",
-      "name": "Echelon Prime",
-      "symbol": "PRIME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29053/thumb/prime-logo-small-border_%282%29.png?1696528020"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcc8fa225d80b9c7d42f96e9570156c65d6caaa25",
-      "name": "Smooth Love Potion",
-      "symbol": "SLP",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/10366/thumb/SLP.png?1696510368"
-    },
-    {
-      "chainId": 1,
-      "address": "0x198d14f2ad9ce69e76ea330b374de4957c3f850a",
-      "name": "APENFT",
-      "symbol": "NFT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/15687/thumb/apenft.jpg?1696515316"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf4fb9bf10e489ea3edb03e094939341399587b0c",
-      "name": "AirDAO",
-      "symbol": "AMB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1041/thumb/amb.png?1696502148"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8de5b80a0c1b02fe4976851d030b36122dbb8624",
-      "name": "Vanar Chain",
-      "symbol": "VANRY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33466/thumb/apple-touch-icon.png?1701942541"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2a79324c19ef2b89ea98b23bc669b7e7c9f8a517",
-      "name": "WAX",
-      "symbol": "WAXP",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/1372/thumb/WAX_Coin_Tickers_P_512px.png?1696502430"
-    },
-    {
-      "chainId": 1,
-      "address": "0x14778860e937f509e651192a90589de711fb88a9",
-      "name": "CYBER",
-      "symbol": "CYBER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31274/thumb/token.png?1715826754"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4be10da47a07716af28ad199fbe020501bddd7af",
-      "name": "XT com",
-      "symbol": "XT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8391/thumb/20240701-155217.jpeg?1719895785"
-    },
-    {
-      "chainId": 1,
-      "address": "0x888888848b652b3e3a0f34c96e00eec0f3a23f72",
-      "name": "Alien Worlds",
-      "symbol": "TLM",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/14676/thumb/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1696514350"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
-      "name": "PayPal USD",
-      "symbol": "PYUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/31212/thumb/PYUSD_Logo_%282%29.png?1696530039"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
-      "name": "EURC",
-      "symbol": "EURC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro.png?1696525125"
-    },
-    {
-      "chainId": 1,
-      "address": "0x626e8036deb333b408be468f951bdb42433cbf18",
-      "name": "AIOZ Network",
-      "symbol": "AIOZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz-logo-200.png?1696514309"
-    },
-    {
-      "chainId": 1,
-      "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
-      "name": "UMA",
-      "symbol": "UMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10951/thumb/UMA.png?1696510900"
-    },
-    {
-      "chainId": 1,
-      "address": "0x52a8845df664d76c69d2eea607cd793565af42b8",
-      "name": "ApeX",
-      "symbol": "APEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25266/thumb/CxpMECpk_400x400_%281%29.png?1696524406"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
-      "name": "Threshold Network",
-      "symbol": "T",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22228/thumb/nFPNiSbL_400x400.jpg?1696521570"
-    },
-    {
-      "chainId": 1,
-      "address": "0x38e68a37e401f7271568cecaac63c6b1e19130b4",
-      "name": "Banana Gun",
-      "symbol": "BANANA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31744/thumb/bg-logo-coingecko-200.png?1716971024"
-    },
-    {
-      "chainId": 1,
-      "address": "0x57b946008913b82e4df85f501cbaed910e58d26c",
-      "name": "Marlin",
-      "symbol": "POND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/200x200.png?1706115827"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3b50805453023a91a8bf641e279401a0b23fa6f9",
-      "name": "Renzo",
-      "symbol": "REZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37327/thumb/renzo_200x200.png?1714025012"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
-      "name": "Numeraire",
-      "symbol": "NMR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/752/thumb/numeraire.png?1696501906"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
-      "name": "Solar",
-      "symbol": "SXP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1696509466"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6033f7f88332b8db6ad452b7c6d5bb643990ae3f",
-      "name": "Lisk",
-      "symbol": "LSK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/385/thumb/Lisk_logo.png?1722338450"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
-      "name": "CoW Protocol",
-      "symbol": "COW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24384/thumb/CoW-token_logo.png?1719524382"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9e32b13ce7f2e80a01932b42553652e053d6ed8e",
-      "name": "Metis",
-      "symbol": "METIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/Metis_Black_Bg.png?1702968192"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
-      "name": "Storj",
-      "symbol": "STORJ",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/949/thumb/storj.png?1696502065"
-    },
-    {
-      "chainId": 1,
-      "address": "0x137ddb47ee24eaa998a535ab00378d6bfa84f893",
-      "name": "Radiant Capital",
-      "symbol": "RDNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26536/thumb/Radiant-Logo-200x200.png?1696525610"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
-      "name": "Wrapped eETH",
-      "symbol": "WEETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33033/thumb/weETH.png?1701438396"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
-      "name": "Ethena Staked USDe",
-      "symbol": "SUSDE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33669/thumb/sUSDe-Symbol-Color.png?1716307680"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
-      "name": "Perpetual Protocol",
-      "symbol": "PERP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
-      "name": "API3",
-      "symbol": "API3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1696513031"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa62cc35625b0c8dc1faea39d33625bb4c15bd71c",
-      "name": "StormX",
-      "symbol": "STMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1369/thumb/StormX.png?1696502427"
-    },
-    {
-      "chainId": 1,
-      "address": "0x090185f2135308bad17527004364ebcc2d37e5f6",
-      "name": "Spell",
-      "symbol": "SPELL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1696515477"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
-      "name": "Biconomy",
-      "symbol": "BICO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1696520444"
-    },
-    {
-      "chainId": 1,
-      "address": "0xac51066d7bec65dc4589368da368b212745d63e8",
-      "name": "My Neighbor Alice",
-      "symbol": "ALICE",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1696514067"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
-      "name": "Badger",
-      "symbol": "BADGER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1696513059"
-    },
-    {
-      "chainId": 1,
-      "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
-      "name": "Audius",
-      "symbol": "AUDIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1696512701"
-    },
-    {
-      "chainId": 1,
-      "address": "0xadf7c35560035944e805d98ff17d58cde2449389",
-      "name": "Spectral",
-      "symbol": "SPEC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36138/thumb/ls7wS7vf_400x400.jpg?1724975224"
-    },
-    {
-      "chainId": 1,
-      "address": "0x83f20f44975d03b1b09e64809b757c47f942beea",
-      "name": "Savings Dai",
-      "symbol": "SDAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32254/thumb/sdai.png?1697015278"
-    },
-    {
-      "chainId": 1,
-      "address": "0x430ef9263e76dae63c84292c3409d61c598e9682",
-      "name": "Vulcan Forged",
-      "symbol": "PYR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14770/thumb/1617088937196.png?1696514439"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba11d00c5f74255f56a5e366f4f77f5a186d7f55",
-      "name": "Band Protocol",
-      "symbol": "BAND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/Band_token_blue_violet_token.png?1696509627"
-    },
-    {
-      "chainId": 1,
-      "address": "0x940a2db1b7008b6c776d4faaca729d6d4a4aa551",
-      "name": "Dusk",
-      "symbol": "DUSK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5217/thumb/image_widget_biddfvxd454b1.png?1696505726"
-    },
-    {
-      "chainId": 1,
-      "address": "0x24fcfc492c1393274b6bcd568ac9e225bec93584",
-      "name": "Heroes of Mavia",
-      "symbol": "MAVIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33895/thumb/2023-12-20_21.21.41_%281%29.jpg?1703230771"
-    },
-    {
-      "chainId": 1,
-      "address": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd",
-      "name": "DODO",
-      "symbol": "DODO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12651/thumb/dodo_logo.png?1696512458"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
-      "name": "Celer Network",
-      "symbol": "CELR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1696504978"
-    },
-    {
-      "chainId": 1,
-      "address": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
-      "name": "AUSD",
-      "symbol": "AUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39284/thumb/Circle_Agora_White_on_Olive_1080px.png?1722961274"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdefa4e8a7bcba345f687a2f1456f5edd9ce97202",
-      "name": "Kyber Network Crystal",
-      "symbol": "KNC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14899/thumb/RwdVsGcw_400x400.jpg?1696514562"
-    },
-    {
-      "chainId": 1,
-      "address": "0x595832f8fc6bf59c85c527fec3740a1b7a361269",
-      "name": "Powerledger",
-      "symbol": "POWR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/Powerledger_Northstar_colour_digital_%282%29.png?1706702222"
-    },
-    {
-      "chainId": 1,
-      "address": "0x925206b8a707096ed26ae47c84747fe0bb734f59",
-      "name": "WhiteBIT Coin",
-      "symbol": "WBT",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/27045/thumb/wbt_token.png?1696526096"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa1faa113cbe53436df28ff0aee54275c13b40975",
-      "name": "Stella",
-      "symbol": "ALPHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/Stella200x200-06.png?1696512537"
-    },
-    {
-      "chainId": 1,
-      "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
-      "name": "Radworks",
-      "symbol": "RAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1696513741"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
-      "name": "Origin Token",
-      "symbol": "OGN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1696504006"
-    },
-    {
-      "chainId": 1,
-      "address": "0x491604c0fdf08347dd1fa4ee062a822a5dd06b5d",
-      "name": "Cartesi",
-      "symbol": "CTSI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/Cartesi_Logo.png?1696510982"
-    },
-    {
-      "chainId": 1,
-      "address": "0x14fee680690900ba0cccfc76ad70fd1b95d10e16",
-      "name": "PAAL AI",
-      "symbol": "PAAL",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/30815/thumb/Paal_New_Logo_%281%29.png?1718160584"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
-      "name": "USDS",
-      "symbol": "USDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39926/thumb/usds.webp?1726666683"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb3999f658c0391d94a37f7ff328f3fec942bcadc",
-      "name": "Hashflow",
-      "symbol": "HFT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26136/thumb/200x200_360.png?1728551257"
-    },
-    {
-      "chainId": 1,
-      "address": "0x71ab77b7dbb4fa7e017bc15090b2163221420282",
-      "name": "Highstreet",
-      "symbol": "HIGH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18973/thumb/logosq200200Coingecko.png?1696518427"
-    },
-    {
-      "chainId": 1,
-      "address": "0xabd4c63d2616a5201454168269031355f4764337",
-      "name": "Orderly Network",
-      "symbol": "ORDER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38501/thumb/Orderly_Network_Coingecko_200*200.png?1717751359"
-    },
-    {
-      "chainId": 1,
-      "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
-      "name": "iExec RLC",
-      "symbol": "RLC",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1696501840"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba50933c268f567bdc86e1ac131be072c6b0b71a",
-      "name": "ARPA",
-      "symbol": "ARPA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1696508685"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd5f7838f5c461feff7fe49ea5ebaf7728bb0adfa",
-      "name": "Mantle Staked Ether",
-      "symbol": "METH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33345/thumb/symbol_transparent_bg.png?1701697066"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa2e3356610840701bdf5611a53974510ae27e2e1",
-      "name": "Wrapped Beacon ETH",
-      "symbol": "WBETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30061/thumb/wbeth-icon.png?1696528983"
-    },
-    {
-      "chainId": 1,
-      "address": "0x26aad156ba8efa501b32b42ffcdc8413f90e9c99",
-      "name": "Open Campus",
-      "symbol": "EDU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29948/thumb/EDU_Logo.png?1696528874"
+      "logoURI": "https://assets.coingecko.com/coins/images/5000/large/Chromia.png?1696505533"
     },
     {
       "chainId": 1,
@@ -1576,79 +1040,495 @@
       "name": "Delysium",
       "symbol": "AGI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29299/thumb/AGI_logo_200.png?1696528251"
+      "logoURI": "https://assets.coingecko.com/coins/images/29299/large/AGI_logo_200.png?1696528251"
     },
     {
       "chainId": 1,
-      "address": "0x55296f69f40ea6d20e478533c15a6b08b654e758",
-      "name": "XYO Network",
-      "symbol": "XYO",
+      "address": "0x10dea67478c5f8c5e2d90e5e9b26dbe60c54d800",
+      "name": "Taiko",
+      "symbol": "TAIKO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1696505103"
+      "logoURI": "https://assets.coingecko.com/coins/images/38058/large/icon.png?1717626867"
     },
     {
       "chainId": 1,
-      "address": "0x0f3a12b78fee11ee088e454a0547bdbc5a253a6d",
-      "name": "Merlin Chain",
-      "symbol": "MERL",
+      "address": "0xb23d80f5fefcddaa212212f028021b41ded428cf",
+      "name": "Echelon Prime",
+      "symbol": "PRIME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37118/thumb/merlin.jpeg?1713352230"
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/prime-logo-small-border_%282%29.png?1696528020"
     },
     {
       "chainId": 1,
-      "address": "0x5cf04716ba20127f1e2297addcf4b5035000c9eb",
-      "name": "NKN",
-      "symbol": "NKN",
+      "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+      "name": "Liquity",
+      "symbol": "LQTY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3375/thumb/nkn.png?1696504074"
+      "logoURI": "https://assets.coingecko.com/coins/images/14665/large/logo_V2.png?1725437146"
     },
     {
       "chainId": 1,
-      "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
-      "name": "Aavegotchi",
-      "symbol": "GHST",
+      "address": "0x03dde9e5bb31ee40a471476e2fccf75c67921062",
+      "name": "EML Protocol",
+      "symbol": "EML",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/GHST.png?1696512286"
+      "logoURI": "https://assets.coingecko.com/coins/images/30950/large/EML_LOGO.png?1696529788"
     },
     {
       "chainId": 1,
-      "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
-      "name": "Dent",
-      "symbol": "DENT",
+      "address": "0x64bc2ca1be492be7185faa2c8835d9b824c8a194",
+      "name": "Big Time",
+      "symbol": "BIGTIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32251/large/-6136155493475923781_121.jpg?1696998691"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcc8fa225d80b9c7d42f96e9570156c65d6caaa25",
+      "name": "Smooth Love Potion",
+      "symbol": "SLP",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/10366/large/SLP.png?1696510368"
+    },
+    {
+      "chainId": 1,
+      "address": "0x467719ad09025fcc6cf6f8311755809d45a5e5f3",
+      "name": "Axelar",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg?1696526329"
+    },
+    {
+      "chainId": 1,
+      "address": "0x198d14f2ad9ce69e76ea330b374de4957c3f850a",
+      "name": "APENFT",
+      "symbol": "NFT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/15687/large/apenft.jpg?1696515316"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf4fb9bf10e489ea3edb03e094939341399587b0c",
+      "name": "AirDAO",
+      "symbol": "AMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1041/large/amb.png?1696502148"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a79324c19ef2b89ea98b23bc669b7e7c9f8a517",
+      "name": "WAX",
+      "symbol": "WAXP",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/1152/thumb/DENT_Token.png?1718837065"
+      "logoURI": "https://assets.coingecko.com/coins/images/1372/large/WAX_Coin_Tickers_P_512px.png?1696502430"
     },
     {
       "chainId": 1,
-      "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
-      "name": "tBTC",
-      "symbol": "TBTC",
+      "address": "0x8de5b80a0c1b02fe4976851d030b36122dbb8624",
+      "name": "Vanar Chain",
+      "symbol": "VANRY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+      "logoURI": "https://assets.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
     },
     {
       "chainId": 1,
-      "address": "0x4575f41308ec1483f3d399aa9a2826d74da13deb",
-      "name": "Orchid Protocol",
-      "symbol": "OXT",
+      "address": "0x14778860e937f509e651192a90589de711fb88a9",
+      "name": "CYBER",
+      "symbol": "CYBER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3916/thumb/download_%285%29.png?1696504574"
+      "logoURI": "https://assets.coingecko.com/coins/images/31274/large/token.png?1715826754"
     },
     {
       "chainId": 1,
-      "address": "0xba100000625a3754423978a60c9317c58a424e3d",
-      "name": "Balancer",
-      "symbol": "BAL",
+      "address": "0x4be10da47a07716af28ad199fbe020501bddd7af",
+      "name": "XT com",
+      "symbol": "XT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1696511572"
+      "logoURI": "https://assets.coingecko.com/coins/images/8391/large/20240701-155217.jpeg?1719895785"
     },
     {
       "chainId": 1,
-      "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
-      "name": "OKB",
-      "symbol": "OKB",
+      "address": "0x888888848b652b3e3a0f34c96e00eec0f3a23f72",
+      "name": "Alien Worlds",
+      "symbol": "TLM",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/14676/large/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1696514350"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
+      "name": "PayPal USD",
+      "symbol": "PYUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1696530039"
+    },
+    {
+      "chainId": 1,
+      "address": "0x38e68a37e401f7271568cecaac63c6b1e19130b4",
+      "name": "Banana Gun",
+      "symbol": "BANANA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4463/thumb/WeChat_Image_20220118095654.png?1696505053"
+      "logoURI": "https://assets.coingecko.com/coins/images/31744/large/bg-logo-coingecko-200.png?1716971024"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
+      "name": "EURC",
+      "symbol": "EURC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/large/euro.png?1696525125"
+    },
+    {
+      "chainId": 1,
+      "address": "0x626e8036deb333b408be468f951bdb42433cbf18",
+      "name": "AIOZ Network",
+      "symbol": "AIOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14631/large/aioz-logo-200.png?1696514309"
+    },
+    {
+      "chainId": 1,
+      "address": "0x52a8845df664d76c69d2eea607cd793565af42b8",
+      "name": "ApeX",
+      "symbol": "APEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25266/large/CxpMECpk_400x400_%281%29.png?1696524406"
+    },
+    {
+      "chainId": 1,
+      "address": "0x57b946008913b82e4df85f501cbaed910e58d26c",
+      "name": "Marlin",
+      "symbol": "POND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8903/large/200x200.png?1706115827"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3b50805453023a91a8bf641e279401a0b23fa6f9",
+      "name": "Renzo",
+      "symbol": "REZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37327/large/renzo_200x200.png?1714025012"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
+      "name": "Numeraire",
+      "symbol": "NMR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/752/large/numeraire.png?1696501906"
+    },
+    {
+      "chainId": 1,
+      "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+      "name": "UMA",
+      "symbol": "UMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10951/large/UMA.png?1696510900"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6033f7f88332b8db6ad452b7c6d5bb643990ae3f",
+      "name": "Lisk",
+      "symbol": "LSK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/385/large/Lisk_logo.png?1722338450"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9e32b13ce7f2e80a01932b42553652e053d6ed8e",
+      "name": "Metis",
+      "symbol": "METIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15595/large/Metis_Black_Bg.png?1702968192"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+      "name": "CoW Protocol",
+      "symbol": "COW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
+      "name": "Storj",
+      "symbol": "STORJ",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/949/large/storj.png?1696502065"
+    },
+    {
+      "chainId": 1,
+      "address": "0x137ddb47ee24eaa998a535ab00378d6bfa84f893",
+      "name": "Radiant Capital",
+      "symbol": "RDNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
+      "name": "Wrapped eETH",
+      "symbol": "WEETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+      "name": "Ethena Staked USDe",
+      "symbol": "SUSDE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33669/large/sUSDe-Symbol-Color.png?1716307680"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+      "name": "Perpetual Protocol",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
+      "name": "API3",
+      "symbol": "API3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13256/large/api3.jpg?1696513031"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa62cc35625b0c8dc1faea39d33625bb4c15bd71c",
+      "name": "StormX",
+      "symbol": "STMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1369/large/StormX.png?1696502427"
+    },
+    {
+      "chainId": 1,
+      "address": "0x090185f2135308bad17527004364ebcc2d37e5f6",
+      "name": "Spell",
+      "symbol": "SPELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/large/abracadabra-3.png?1696515477"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
+      "name": "Biconomy",
+      "symbol": "BICO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/large/biconomy_logo.jpg?1696520444"
+    },
+    {
+      "chainId": 1,
+      "address": "0xac51066d7bec65dc4589368da368b212745d63e8",
+      "name": "My Neighbor Alice",
+      "symbol": "ALICE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14375/large/alice_logo.jpg?1696514067"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+      "name": "Badger",
+      "symbol": "BADGER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1696513059"
+    },
+    {
+      "chainId": 1,
+      "address": "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
+      "name": "Civic",
+      "symbol": "CVC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/788/large/civic-orange.png?1696501939"
+    },
+    {
+      "chainId": 1,
+      "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+      "name": "Audius",
+      "symbol": "AUDIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12913/large/AudiusCoinLogo_2x.png?1696512701"
+    },
+    {
+      "chainId": 1,
+      "address": "0xadf7c35560035944e805d98ff17d58cde2449389",
+      "name": "Spectral",
+      "symbol": "SPEC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36138/large/ls7wS7vf_400x400.jpg?1724975224"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
+      "name": "Celer Network",
+      "symbol": "CELR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/large/Celr.png?1696504978"
+    },
+    {
+      "chainId": 1,
+      "address": "0x83f20f44975d03b1b09e64809b757c47f942beea",
+      "name": "Savings Dai",
+      "symbol": "SDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32254/large/sdai.png?1697015278"
+    },
+    {
+      "chainId": 1,
+      "address": "0x430ef9263e76dae63c84292c3409d61c598e9682",
+      "name": "Vulcan Forged",
+      "symbol": "PYR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14770/large/1617088937196.png?1696514439"
+    },
+    {
+      "chainId": 1,
+      "address": "0x24fcfc492c1393274b6bcd568ac9e225bec93584",
+      "name": "Heroes of Mavia",
+      "symbol": "MAVIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33895/large/2023-12-20_21.21.41_%281%29.jpg?1703230771"
+    },
+    {
+      "chainId": 1,
+      "address": "0x940a2db1b7008b6c776d4faaca729d6d4a4aa551",
+      "name": "Dusk",
+      "symbol": "DUSK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5217/large/image_widget_biddfvxd454b1.png?1696505726"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba11d00c5f74255f56a5e366f4f77f5a186d7f55",
+      "name": "Band Protocol",
+      "symbol": "BAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9545/large/Band_token_blue_violet_token.png?1696509627"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
+      "name": "Solar",
+      "symbol": "SXP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9368/large/swipe.png?1696509466"
+    },
+    {
+      "chainId": 1,
+      "address": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd",
+      "name": "DODO",
+      "symbol": "DODO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12651/large/dodo_logo.png?1696512458"
+    },
+    {
+      "chainId": 1,
+      "address": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
+      "name": "AUSD",
+      "symbol": "AUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39284/large/Circle_Agora_White_on_Olive_1080px.png?1722961274"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdefa4e8a7bcba345f687a2f1456f5edd9ce97202",
+      "name": "Kyber Network Crystal",
+      "symbol": "KNC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14899/large/RwdVsGcw_400x400.jpg?1696514562"
+    },
+    {
+      "chainId": 1,
+      "address": "0x595832f8fc6bf59c85c527fec3740a1b7a361269",
+      "name": "Powerledger",
+      "symbol": "POWR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/1104/large/Powerledger_Northstar_colour_digital_%282%29.png?1706702222"
+    },
+    {
+      "chainId": 1,
+      "address": "0x925206b8a707096ed26ae47c84747fe0bb734f59",
+      "name": "WhiteBIT Coin",
+      "symbol": "WBT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/27045/large/wbt_token.png?1696526096"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa1faa113cbe53436df28ff0aee54275c13b40975",
+      "name": "Stella",
+      "symbol": "ALPHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12738/large/Stella200x200-06.png?1696512537"
+    },
+    {
+      "chainId": 1,
+      "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
+      "name": "Radworks",
+      "symbol": "RAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14013/large/radicle.png?1696513741"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
+      "name": "Threshold Network",
+      "symbol": "T",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22228/large/nFPNiSbL_400x400.jpg?1696521570"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
+      "name": "Origin Token",
+      "symbol": "OGN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3296/large/op.jpg?1696504006"
+    },
+    {
+      "chainId": 1,
+      "address": "0x491604c0fdf08347dd1fa4ee062a822a5dd06b5d",
+      "name": "Cartesi",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
+    },
+    {
+      "chainId": 1,
+      "address": "0x14fee680690900ba0cccfc76ad70fd1b95d10e16",
+      "name": "PAAL AI",
+      "symbol": "PAAL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/30815/large/Paal_New_Logo_%281%29.png?1718160584"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
+      "name": "USDS",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb3999f658c0391d94a37f7ff328f3fec942bcadc",
+      "name": "Hashflow",
+      "symbol": "HFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26136/large/200x200_360.png?1728551257"
+    },
+    {
+      "chainId": 1,
+      "address": "0x71ab77b7dbb4fa7e017bc15090b2163221420282",
+      "name": "Highstreet",
+      "symbol": "HIGH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18973/large/logosq200200Coingecko.png?1696518427"
     },
     {
       "chainId": 1,
@@ -1656,7 +1536,127 @@
       "name": "PAX Gold",
       "symbol": "PAXG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxgold.png?1696509604"
+      "logoURI": "https://assets.coingecko.com/coins/images/9519/large/paxgold.png?1696509604"
+    },
+    {
+      "chainId": 1,
+      "address": "0xabd4c63d2616a5201454168269031355f4764337",
+      "name": "Orderly Network",
+      "symbol": "ORDER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38501/large/Orderly_Network_Coingecko_200*200.png?1717751359"
+    },
+    {
+      "chainId": 1,
+      "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
+      "name": "iExec RLC",
+      "symbol": "RLC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/646/large/pL1VuXm.png?1696501840"
+    },
+    {
+      "chainId": 1,
+      "address": "0x26aad156ba8efa501b32b42ffcdc8413f90e9c99",
+      "name": "Open Campus",
+      "symbol": "EDU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29948/large/EDU_Logo.png?1696528874"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd5f7838f5c461feff7fe49ea5ebaf7728bb0adfa",
+      "name": "Mantle Staked Ether",
+      "symbol": "METH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33345/large/symbol_transparent_bg.png?1701697066"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba50933c268f567bdc86e1ac131be072c6b0b71a",
+      "name": "ARPA",
+      "symbol": "ARPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8506/large/9u0a23XY_400x400.jpg?1696508685"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2e3356610840701bdf5611a53974510ae27e2e1",
+      "name": "Wrapped Beacon ETH",
+      "symbol": "WBETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30061/large/wbeth-icon.png?1696528983"
+    },
+    {
+      "chainId": 1,
+      "address": "0x55296f69f40ea6d20e478533c15a6b08b654e758",
+      "name": "XYO Network",
+      "symbol": "XYO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4519/large/XYO_Network-logo.png?1696505103"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f3a12b78fee11ee088e454a0547bdbc5a253a6d",
+      "name": "Merlin Chain",
+      "symbol": "MERL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37118/large/merlin.jpeg?1713352230"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5cf04716ba20127f1e2297addcf4b5035000c9eb",
+      "name": "NKN",
+      "symbol": "NKN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3375/large/nkn.png?1696504074"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
+      "name": "Aavegotchi",
+      "symbol": "GHST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12467/large/GHST.png?1696512286"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
+      "name": "Dent",
+      "symbol": "DENT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/1152/large/DENT_Token.png?1718837065"
+    },
+    {
+      "chainId": 1,
+      "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
+      "name": "tBTC",
+      "symbol": "TBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4575f41308ec1483f3d399aa9a2826d74da13deb",
+      "name": "Orchid Protocol",
+      "symbol": "OXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3916/large/download_%285%29.png?1696504574"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+      "name": "Balancer",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
+    },
+    {
+      "chainId": 1,
+      "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
+      "name": "OKB",
+      "symbol": "OKB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4463/large/WeChat_Image_20220118095654.png?1696505053"
     },
     {
       "chainId": 1,
@@ -1664,7 +1664,7 @@
       "name": "Baby Doge Coin",
       "symbol": "BABYDOGE",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/16125/thumb/babydoge.jpg?1696515731"
+      "logoURI": "https://assets.coingecko.com/coins/images/16125/large/babydoge.jpg?1696515731"
     },
     {
       "chainId": 1,
@@ -1672,31 +1672,7 @@
       "name": "Mines of Dalarnia",
       "symbol": "DAR",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/19837/thumb/dar.png?1696519259"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3da932456d082cba208feb0b096d49b202bf89c8",
-      "name": "Dego Finance",
-      "symbol": "DEGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12503/thumb/Token.png?1733381203"
-    },
-    {
-      "chainId": 1,
-      "address": "0x12e2b8033420270db2f3b328e32370cb5b2ca134",
-      "name": "SafePal",
-      "symbol": "SFP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13905/thumb/sfp.png?1696513647"
-    },
-    {
-      "chainId": 1,
-      "address": "0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419",
-      "name": "DIA",
-      "symbol": "DIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/Token_Logo.png?1696511815"
+      "logoURI": "https://assets.coingecko.com/coins/images/19837/large/dar.png?1696519259"
     },
     {
       "chainId": 1,
@@ -1704,63 +1680,15 @@
       "name": "Synapse",
       "symbol": "SYN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/synapse_social_icon.png?1696517540"
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/large/synapse_social_icon.png?1696517540"
     },
     {
       "chainId": 1,
-      "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
-      "name": "Polygon",
-      "symbol": "MATIC",
+      "address": "0x12e2b8033420270db2f3b328e32370cb5b2ca134",
+      "name": "SafePal",
+      "symbol": "SFP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/polygon.png?1698233745"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb7109df1a93f8fe2b8162c6207c9b846c1c68090",
-      "name": "Matr1x",
-      "symbol": "MAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39481/thumb/t05.png?1722465175"
-    },
-    {
-      "chainId": 1,
-      "address": "0x408e41876cccdc0f92210600ef50372656052a38",
-      "name": "Ren",
-      "symbol": "REN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3139/thumb/REN.png?1696503862"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf2b2f7b47715256ce4ea43363a867fdce9353e3a",
-      "name": "Bitgert",
-      "symbol": "BRISE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/17388/thumb/200x200.png?1696516937"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe0f63a424a4439cbe457d80e4f4b51ad25b2c56c",
-      "name": "SPX6900",
-      "symbol": "SPX",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/31401/thumb/sticker_%281%29.jpg?1702371083"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
-      "name": "Rocket Pool",
-      "symbol": "RPL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2090/thumb/rocket_pool_%28RPL%29.png?1696503058"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7448c7456a97769f6cd04f1e83a4a23ccdc46abd",
-      "name": "Maverick Protocol",
-      "symbol": "MAV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30850/thumb/MAV_Logo.png?1696529701"
+      "logoURI": "https://assets.coingecko.com/coins/images/13905/large/sfp.png?1696513647"
     },
     {
       "chainId": 1,
@@ -1768,7 +1696,71 @@
       "name": "Radio Caca",
       "symbol": "RACA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17841/thumb/ez44_BSs_400x400.jpg?1696517365"
+      "logoURI": "https://assets.coingecko.com/coins/images/17841/large/ez44_BSs_400x400.jpg?1696517365"
+    },
+    {
+      "chainId": 1,
+      "address": "0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419",
+      "name": "DIA",
+      "symbol": "DIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11955/large/Token_Logo.png?1696511815"
+    },
+    {
+      "chainId": 1,
+      "address": "0x408e41876cccdc0f92210600ef50372656052a38",
+      "name": "Ren",
+      "symbol": "REN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3139/large/REN.png?1696503862"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+      "name": "Polygon",
+      "symbol": "MATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/large/polygon.png?1698233745"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb7109df1a93f8fe2b8162c6207c9b846c1c68090",
+      "name": "Matr1x",
+      "symbol": "MAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39481/large/t05.png?1722465175"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3da932456d082cba208feb0b096d49b202bf89c8",
+      "name": "Dego Finance",
+      "symbol": "DEGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12503/large/Token.png?1733381203"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7448c7456a97769f6cd04f1e83a4a23ccdc46abd",
+      "name": "Maverick Protocol",
+      "symbol": "MAV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30850/large/MAV_Logo.png?1696529701"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf2b2f7b47715256ce4ea43363a867fdce9353e3a",
+      "name": "Bitgert",
+      "symbol": "BRISE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17388/large/200x200.png?1696516937"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+      "name": "Rocket Pool",
+      "symbol": "RPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
     },
     {
       "chainId": 1,
@@ -1776,7 +1768,7 @@
       "name": "Frax",
       "symbol": "FRAX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/FRAX_icon.png?1696513182"
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1696513182"
     },
     {
       "chainId": 1,
@@ -1784,23 +1776,7 @@
       "name": "AdEx",
       "symbol": "ADX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/847/thumb/adex.jpeg?1696501984"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1cf4592ebffd730c7dc92c1bdffdfc3b9efcf29a",
-      "name": "Waves",
-      "symbol": "WAVES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/425/thumb/waves.png?1696501700"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
-      "name": "Linear",
-      "symbol": "LINA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12509/thumb/1649227343-linalogo200px.png?1696512324"
+      "logoURI": "https://assets.coingecko.com/coins/images/847/large/adex.jpeg?1696501984"
     },
     {
       "chainId": 1,
@@ -1808,7 +1784,23 @@
       "name": "aelf",
       "symbol": "ELF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1371/thumb/aelf-logo.png?1696502429"
+      "logoURI": "https://assets.coingecko.com/coins/images/1371/large/aelf-logo.png?1696502429"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
+      "name": "Linear",
+      "symbol": "LINA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12509/large/1649227343-linalogo200px.png?1696512324"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1cf4592ebffd730c7dc92c1bdffdfc3b9efcf29a",
+      "name": "Waves",
+      "symbol": "WAVES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/425/large/waves.png?1696501700"
     },
     {
       "chainId": 1,
@@ -1816,7 +1808,15 @@
       "name": "Orbs",
       "symbol": "ORBS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4630/thumb/Orbs.jpg?1696505200"
+      "logoURI": "https://assets.coingecko.com/coins/images/4630/large/Orbs.jpg?1696505200"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe0f63a424a4439cbe457d80e4f4b51ad25b2c56c",
+      "name": "SPX6900",
+      "symbol": "SPX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/31401/large/sticker_%281%29.jpg?1702371083"
     },
     {
       "chainId": 1,
@@ -1824,7 +1824,7 @@
       "name": "Verasity",
       "symbol": "VRA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14025/thumb/logo_%281%29.png?1716968890"
+      "logoURI": "https://assets.coingecko.com/coins/images/14025/large/logo_%281%29.png?1716968890"
     },
     {
       "chainId": 1,
@@ -1832,7 +1832,7 @@
       "name": "tomiNet",
       "symbol": "TOMI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28730/thumb/logo_for_token.png?1696527710"
+      "logoURI": "https://assets.coingecko.com/coins/images/28730/large/logo_for_token.png?1696527710"
     },
     {
       "chainId": 1,
@@ -1840,7 +1840,7 @@
       "name": "Venus",
       "symbol": "XVS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12677/thumb/XVS_Token.jpg?1727454303"
+      "logoURI": "https://assets.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
     },
     {
       "chainId": 1,
@@ -1848,63 +1848,7 @@
       "name": "LayerAI",
       "symbol": "LAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29223/thumb/Favicon_200x200px.png?1696528181"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
-      "name": "NEXO",
-      "symbol": "NEXO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3695/thumb/CG-nexo-token-200x200_2x.png?1730414360"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6c5ba91642f10282b576d91922ae6448c9d52f4e",
-      "name": "PHALA",
-      "symbol": "PHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12451/thumb/phala.png?1696512270"
-    },
-    {
-      "chainId": 1,
-      "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
-      "name": "XSGD",
-      "symbol": "XSGD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/12832/thumb/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcf3c8be2e2c42331da80ef210e9b1b307c03d36a",
-      "name": "Bepro",
-      "symbol": "BEPRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10251/thumb/bepro_logo_200x200.png?1718012232"
-    },
-    {
-      "chainId": 1,
-      "address": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
-      "name": "Stader",
-      "symbol": "SD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20658/thumb/SD_Token_Logo.png?1696520060"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4507cef57c46789ef8d1a19ea45f4216bae2b528",
-      "name": "TokenFi",
-      "symbol": "TOKEN",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/32507/thumb/MAIN_TokenFi_logo_icon.png?1698918427"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0bb217e40f8a5cb79adf04e1aab60e5abd0dfc1e",
-      "name": "SWFTCOIN",
-      "symbol": "SWFTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/2346/thumb/SWFTCoin.jpg?1696503223"
+      "logoURI": "https://assets.coingecko.com/coins/images/29223/large/Favicon_200x200px.png?1696528181"
     },
     {
       "chainId": 1,
@@ -1912,7 +1856,63 @@
       "name": "Lambda",
       "symbol": "LAMB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4703/thumb/lambda_200.png?1696505268"
+      "logoURI": "https://assets.coingecko.com/coins/images/4703/large/lambda_200.png?1696505268"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
+      "name": "NEXO",
+      "symbol": "NEXO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3695/large/CG-nexo-token-200x200_2x.png?1730414360"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c5ba91642f10282b576d91922ae6448c9d52f4e",
+      "name": "PHALA",
+      "symbol": "PHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12451/large/phala.png?1696512270"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcf3c8be2e2c42331da80ef210e9b1b307c03d36a",
+      "name": "Bepro",
+      "symbol": "BEPRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10251/large/bepro_logo_200x200.png?1718012232"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0bb217e40f8a5cb79adf04e1aab60e5abd0dfc1e",
+      "name": "SWFTCOIN",
+      "symbol": "SWFTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2346/large/SWFTCoin.jpg?1696503223"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4507cef57c46789ef8d1a19ea45f4216bae2b528",
+      "name": "TokenFi",
+      "symbol": "TOKEN",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32507/large/MAIN_TokenFi_logo_icon.png?1698918427"
+    },
+    {
+      "chainId": 1,
+      "address": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
+      "name": "Stader",
+      "symbol": "SD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20658/large/SD_Token_Logo.png?1696520060"
+    },
+    {
+      "chainId": 1,
+      "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
+      "name": "XSGD",
+      "symbol": "XSGD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/12832/large/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623"
     },
     {
       "chainId": 1,
@@ -1920,7 +1920,7 @@
       "name": "Bluzelle",
       "symbol": "BLZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1696503607"
+      "logoURI": "https://assets.coingecko.com/coins/images/2848/large/ColorIcon_3x.png?1696503607"
     },
     {
       "chainId": 1,
@@ -1928,7 +1928,7 @@
       "name": "Mythos",
       "symbol": "MYTH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28045/thumb/Mythos_Logos_200x200.png?1696527059"
+      "logoURI": "https://assets.coingecko.com/coins/images/28045/large/Mythos_Logos_200x200.png?1696527059"
     },
     {
       "chainId": 1,
@@ -1936,7 +1936,7 @@
       "name": "Gnosis",
       "symbol": "GNO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/662/thumb/logo_square_simple_300px.png?1696501854"
+      "logoURI": "https://assets.coingecko.com/coins/images/662/large/logo_square_simple_300px.png?1696501854"
     },
     {
       "chainId": 1,
@@ -1944,15 +1944,7 @@
       "name": "Neiro on ETH",
       "symbol": "NEIRO",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/39438/thumb/Neiro.png?1722915026"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3be7bf1a5f23bd8336787d0289b70602f1940875",
-      "name": "VIDT DAO",
-      "symbol": "VIDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27552/thumb/VIDTDAO_logo.png?1696526588"
+      "logoURI": "https://assets.coingecko.com/coins/images/39438/large/Neiro.png?1722915026"
     },
     {
       "chainId": 1,
@@ -1960,7 +1952,15 @@
       "name": "LooksRare",
       "symbol": "LOOKS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22173/thumb/circle-black-256.png?1696521517"
+      "logoURI": "https://assets.coingecko.com/coins/images/22173/large/circle-black-256.png?1696521517"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3be7bf1a5f23bd8336787d0289b70602f1940875",
+      "name": "VIDT DAO",
+      "symbol": "VIDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27552/large/VIDTDAO_logo.png?1696526588"
     },
     {
       "chainId": 1,
@@ -1968,7 +1968,7 @@
       "name": "Moca Coin",
       "symbol": "MOCA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37812/thumb/moca.jpg?1720693068"
+      "logoURI": "https://assets.coingecko.com/coins/images/37812/large/moca.jpg?1720693068"
     },
     {
       "chainId": 1,
@@ -1976,7 +1976,7 @@
       "name": "Kaon",
       "symbol": "AKRO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3328/thumb/kaon.jpg?1730712283"
+      "logoURI": "https://assets.coingecko.com/coins/images/3328/large/kaon.jpg?1730712283"
     },
     {
       "chainId": 1,
@@ -1984,7 +1984,7 @@
       "name": "Hifi Finance",
       "symbol": "HIFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28712/thumb/hft.png?1696527693"
+      "logoURI": "https://assets.coingecko.com/coins/images/28712/large/hft.png?1696527693"
     },
     {
       "chainId": 1,
@@ -1992,7 +1992,7 @@
       "name": "OMG Network",
       "symbol": "OMG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1696501928"
+      "logoURI": "https://assets.coingecko.com/coins/images/776/large/OMG_Network.jpg?1696501928"
     },
     {
       "chainId": 1,
@@ -2000,63 +2000,7 @@
       "name": "SuperRare",
       "symbol": "RARE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17753/thumb/RARE.png?1709598473"
-    },
-    {
-      "chainId": 1,
-      "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
-      "name": "FUNToken",
-      "symbol": "FUN",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/761/thumb/FUN.png?1696501914"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4b5f49487ea7b3609b1ad05459be420548789f1f",
-      "name": "LeverFi",
-      "symbol": "LEVER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26205/thumb/WI72SpBl_400x400.jpeg?1696525291"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e",
-      "name": "crvUSD",
-      "symbol": "CRVUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30118/thumb/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1121acc14c63f3c872bfca497d10926a6098aac5",
-      "name": "Department Of Government Efficiency",
-      "symbol": "DOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39841/thumb/IMG_9775.PNG?1729771739"
-    },
-    {
-      "chainId": 1,
-      "address": "0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44",
-      "name": "Wrapped TAO",
-      "symbol": "WTAO",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/29087/thumb/wtao.png?1696528051"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd29da236dd4aac627346e1bba06a619e8c22d7c5",
-      "name": "MAGA Hat",
-      "symbol": "MAGA",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37988/thumb/MAGA200.jpg?1716223291"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1a4b46696b2bb4794eb3d4c26f1c55f9170fa4c5",
-      "name": "BitDAO",
-      "symbol": "BIT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1696517158"
+      "logoURI": "https://assets.coingecko.com/coins/images/17753/large/RARE.png?1709598473"
     },
     {
       "chainId": 1,
@@ -2064,87 +2008,47 @@
       "name": "PlayDapp",
       "symbol": "PDA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14316/thumb/PDA-symbol.png?1710234068"
+      "logoURI": "https://assets.coingecko.com/coins/images/14316/large/PDA-symbol.png?1710234068"
     },
     {
       "chainId": 1,
-      "address": "0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5",
-      "name": "Usual USD",
-      "symbol": "USD0",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38272/thumb/USD0LOGO.png?1716962811"
+      "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
+      "name": "FUNToken",
+      "symbol": "FUN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/761/large/FUN.png?1696501914"
     },
     {
       "chainId": 1,
-      "address": "0xa849eaae994fb86afa73382e9bd88c2b6b18dc71",
-      "name": "MVL",
-      "symbol": "MVL",
+      "address": "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e",
+      "name": "crvUSD",
+      "symbol": "CRVUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3476/thumb/CoinGecko.png?1711620384"
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/large/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
     },
     {
       "chainId": 1,
-      "address": "0xec12ba5ac0f259e9ac6fc9a3bc23a76ad2fde5d9",
-      "name": "HugeWin",
-      "symbol": "HUGE",
+      "address": "0x1a4b46696b2bb4794eb3d4c26f1c55f9170fa4c5",
+      "name": "BitDAO",
+      "symbol": "BIT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35923/thumb/2024-03-01_17.49.27_%281%29.png?1710221459"
+      "logoURI": "https://assets.coingecko.com/coins/images/17627/large/rI_YptK8.png?1696517158"
     },
     {
       "chainId": 1,
-      "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
-      "name": "Coinbase Wrapped Staked ETH",
-      "symbol": "CBETH",
+      "address": "0x4b5f49487ea7b3609b1ad05459be420548789f1f",
+      "name": "LeverFi",
+      "symbol": "LEVER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27008/thumb/cbeth.png?1709186989"
+      "logoURI": "https://assets.coingecko.com/coins/images/26205/large/WI72SpBl_400x400.jpeg?1696525291"
     },
     {
       "chainId": 1,
-      "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
-      "name": "Gitcoin",
-      "symbol": "GTC",
+      "address": "0x1121acc14c63f3c872bfca497d10926a6098aac5",
+      "name": "Department Of Government Efficiency",
+      "symbol": "DOGE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1696515429"
-    },
-    {
-      "chainId": 1,
-      "address": "0x572975ff6d5136c81c8d7448b6361ef9eefe1ab0",
-      "name": "Wrapped Staked USDT",
-      "symbol": "WSTUSDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31160/thumb/wstusdt.jpeg?1696529988"
-    },
-    {
-      "chainId": 1,
-      "address": "0x61e90a50137e1f645c9ef4a0d3a4f01477738406",
-      "name": "League of Kingdoms",
-      "symbol": "LOKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22572/thumb/loka_64pix.png?1696521891"
-    },
-    {
-      "chainId": 1,
-      "address": "0x814e0908b12a99fecf5bc101bb5d0b8b5cdf7d26",
-      "name": "Measurable Data",
-      "symbol": "MDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2441/thumb/mdt_icon_120x120.png?1711452723"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc71b5f631354be6853efe9c3ab6b9590f8302e81",
-      "name": "Polyhedra Network",
-      "symbol": "ZKJ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36198/thumb/ZK.jpg?1710812518"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4cc19356f2d37338b9802aa8e8fc58b0373296e7",
-      "name": "SelfKey",
-      "symbol": "KEY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2034/thumb/selfkey.png?1696503004"
+      "logoURI": "https://assets.coingecko.com/coins/images/39841/large/IMG_9775.PNG?1729771739"
     },
     {
       "chainId": 1,
@@ -2152,7 +2056,79 @@
       "name": "COMBO",
       "symbol": "COMBO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4932/thumb/COMBO.jpg?1696505472"
+      "logoURI": "https://assets.coingecko.com/coins/images/4932/large/COMBO.jpg?1696505472"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44",
+      "name": "Wrapped TAO",
+      "symbol": "WTAO",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/29087/large/wtao.png?1696528051"
+    },
+    {
+      "chainId": 1,
+      "address": "0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5",
+      "name": "Usual USD",
+      "symbol": "USD0",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38272/large/USD0LOGO.png?1716962811"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa849eaae994fb86afa73382e9bd88c2b6b18dc71",
+      "name": "MVL",
+      "symbol": "MVL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3476/large/CoinGecko.png?1711620384"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
+      "name": "Coinbase Wrapped Staked ETH",
+      "symbol": "CBETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1709186989"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec12ba5ac0f259e9ac6fc9a3bc23a76ad2fde5d9",
+      "name": "HugeWin",
+      "symbol": "HUGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35923/large/2024-03-01_17.49.27_%281%29.png?1710221459"
+    },
+    {
+      "chainId": 1,
+      "address": "0x572975ff6d5136c81c8d7448b6361ef9eefe1ab0",
+      "name": "Wrapped Staked USDT",
+      "symbol": "WSTUSDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31160/large/wstusdt.jpeg?1696529988"
+    },
+    {
+      "chainId": 1,
+      "address": "0x61e90a50137e1f645c9ef4a0d3a4f01477738406",
+      "name": "League of Kingdoms",
+      "symbol": "LOKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22572/large/loka_64pix.png?1696521891"
+    },
+    {
+      "chainId": 1,
+      "address": "0x814e0908b12a99fecf5bc101bb5d0b8b5cdf7d26",
+      "name": "Measurable Data",
+      "symbol": "MDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2441/large/mdt_icon_120x120.png?1711452723"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc71b5f631354be6853efe9c3ab6b9590f8302e81",
+      "name": "Polyhedra Network",
+      "symbol": "ZKJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36198/large/ZK.jpg?1710812518"
     },
     {
       "chainId": 1,
@@ -2160,7 +2136,31 @@
       "name": "Clearpool",
       "symbol": "CPOOL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19252/thumb/photo_2022-08-31_12.45.02.jpeg?1696518697"
+      "logoURI": "https://assets.coingecko.com/coins/images/19252/large/photo_2022-08-31_12.45.02.jpeg?1696518697"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd29da236dd4aac627346e1bba06a619e8c22d7c5",
+      "name": "MAGA Hat",
+      "symbol": "MAGA",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37988/large/MAGA200.jpg?1716223291"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4cc19356f2d37338b9802aa8e8fc58b0373296e7",
+      "name": "SelfKey",
+      "symbol": "KEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2034/large/selfkey.png?1696503004"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+      "name": "Gitcoin",
+      "symbol": "GTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15810/large/gitcoin.png?1696515429"
     },
     {
       "chainId": 1,
@@ -2168,7 +2168,7 @@
       "name": "Pundi X",
       "symbol": "PUNDIX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14571/thumb/vDyefsXq_400x400.jpg?1696514252"
+      "logoURI": "https://assets.coingecko.com/coins/images/14571/large/vDyefsXq_400x400.jpg?1696514252"
     },
     {
       "chainId": 1,
@@ -2176,7 +2176,7 @@
       "name": "Loom Network  NEW ",
       "symbol": "LOOM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14735/thumb/LOOM.png?1696514405"
+      "logoURI": "https://assets.coingecko.com/coins/images/14735/large/LOOM.png?1696514405"
     },
     {
       "chainId": 1,
@@ -2184,7 +2184,7 @@
       "name": "Bitrue Coin",
       "symbol": "BTR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8873/thumb/Bittrue_logo.png?1696509025"
+      "logoURI": "https://assets.coingecko.com/coins/images/8873/large/Bittrue_logo.png?1696509025"
     },
     {
       "chainId": 1,
@@ -2192,7 +2192,7 @@
       "name": "SOL  Wormhole ",
       "symbol": "SOL",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1696522175"
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/large/SOL_wh_small.png?1696522175"
     },
     {
       "chainId": 1,
@@ -2200,7 +2200,7 @@
       "name": "Ethernity Chain",
       "symbol": "ERN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/logo_black.png?1715198164"
+      "logoURI": "https://assets.coingecko.com/coins/images/14238/large/logo_black.png?1715198164"
     },
     {
       "chainId": 1,
@@ -2208,7 +2208,7 @@
       "name": "Gems VIP",
       "symbol": "GEMS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38725/thumb/200x200.png?1718478016"
+      "logoURI": "https://assets.coingecko.com/coins/images/38725/large/200x200.png?1718478016"
     },
     {
       "chainId": 1,
@@ -2216,31 +2216,7 @@
       "name": "Masa",
       "symbol": "MASA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35538/thumb/masa.png?1712635899"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbf5495efe5db9ce00f80364c8b423567e58d2110",
-      "name": "Renzo Restaked ETH",
-      "symbol": "EZETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34753/thumb/Ezeth_logo_circle.png?1713496404"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
-      "name": "Alchemix",
-      "symbol": "ALCX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1696513834"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2a9bdcff37ab68b95a53435adfd8892e86084f93",
-      "name": "Alpha Quark",
-      "symbol": "AQT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12872/thumb/alpha_quark_logo.png?1696512660"
+      "logoURI": "https://assets.coingecko.com/coins/images/35538/large/masa.png?1712635899"
     },
     {
       "chainId": 1,
@@ -2248,7 +2224,23 @@
       "name": "Stafi",
       "symbol": "FIS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/FIS.png?1696512244"
+      "logoURI": "https://assets.coingecko.com/coins/images/12423/large/FIS.png?1696512244"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+      "name": "Alchemix",
+      "symbol": "ALCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14113/large/Alchemix.png?1696513834"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a9bdcff37ab68b95a53435adfd8892e86084f93",
+      "name": "Alpha Quark",
+      "symbol": "AQT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12872/large/alpha_quark_logo.png?1696512660"
     },
     {
       "chainId": 1,
@@ -2256,7 +2248,7 @@
       "name": "Reef",
       "symbol": "REEF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13504/thumb/Group_10572.png?1696513266"
+      "logoURI": "https://assets.coingecko.com/coins/images/13504/large/Group_10572.png?1696513266"
     },
     {
       "chainId": 1,
@@ -2264,7 +2256,7 @@
       "name": "Gate",
       "symbol": "GT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8183/thumb/gate.png?1696508395"
+      "logoURI": "https://assets.coingecko.com/coins/images/8183/large/gate.png?1696508395"
     },
     {
       "chainId": 1,
@@ -2272,23 +2264,7 @@
       "name": "CEEK Smart VR",
       "symbol": "CEEK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2581/thumb/ceek-smart-vr-token-logo.png?1696503385"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb59490ab09a0f526cc7305822ac65f2ab12f9723",
-      "name": "Litentry",
-      "symbol": "LIT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13825/thumb/logo_200x200.png?1696513568"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd2ba23de8a19316a638dc1e7a9adda1d74233368",
-      "name": "Quickswap",
-      "symbol": "QUICK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25393/thumb/quickswap.png?1696524525"
+      "logoURI": "https://assets.coingecko.com/coins/images/2581/large/ceek-smart-vr-token-logo.png?1696503385"
     },
     {
       "chainId": 1,
@@ -2296,55 +2272,15 @@
       "name": "Non Playable Coin",
       "symbol": "NPC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31193/thumb/NPC_200x200.png?1696530021"
+      "logoURI": "https://assets.coingecko.com/coins/images/31193/large/NPC_200x200.png?1696530021"
     },
     {
       "chainId": 1,
-      "address": "0x77777feddddffc19ff86db637967013e6c6a116c",
-      "name": "Tornado Cash",
-      "symbol": "TORN",
+      "address": "0xd2ba23de8a19316a638dc1e7a9adda1d74233368",
+      "name": "Quickswap",
+      "symbol": "QUICK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13496/thumb/ZINt8NSB_400x400.jpg?1696513257"
-    },
-    {
-      "chainId": 1,
-      "address": "0x56072c95faa701256059aa122697b133aded9279",
-      "name": "Sky",
-      "symbol": "SKY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39925/thumb/sky.jpg?1724827980"
-    },
-    {
-      "chainId": 1,
-      "address": "0xec67005c4e498ec7f55e092bd1d35cbc47c91892",
-      "name": "Enzyme",
-      "symbol": "MLN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/Enzyme_Icon_Secondary.png?1696501803"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9d1a7a3191102e9f900faa10540837ba84dcbae7",
-      "name": "Eurite",
-      "symbol": "EURI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39952/thumb/EURI.jpg?1724902829"
-    },
-    {
-      "chainId": 1,
-      "address": "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
-      "name": "Boba Network",
-      "symbol": "BOBA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/Boba-200x200---white.png?1696519690"
-    },
-    {
-      "chainId": 1,
-      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
-      "name": "Telos",
-      "symbol": "TLOS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7588/thumb/tlos_png.png?1722391289"
+      "logoURI": "https://assets.coingecko.com/coins/images/25393/large/quickswap.png?1696524525"
     },
     {
       "chainId": 1,
@@ -2352,111 +2288,23 @@
       "name": "Onyxcoin",
       "symbol": "XCN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/onyxlogo.jpg?1696523397"
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/large/onyxlogo.jpg?1696523397"
     },
     {
       "chainId": 1,
-      "address": "0xbe1a001fe942f96eea22ba08783140b9dcc09d28",
-      "name": "Beta Finance",
-      "symbol": "BETA",
+      "address": "0xb59490ab09a0f526cc7305822ac65f2ab12f9723",
+      "name": "Litentry",
+      "symbol": "LIT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18715/thumb/beta_finance.jpg?1696518183"
+      "logoURI": "https://assets.coingecko.com/coins/images/13825/large/logo_200x200.png?1696513568"
     },
     {
       "chainId": 1,
-      "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
-      "name": "Telcoin",
-      "symbol": "TEL",
-      "decimals": 2,
-      "logoURI": "https://assets.coingecko.com/coins/images/1899/thumb/tel.png?1696502892"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
-      "name": "Bone ShibaSwap",
-      "symbol": "BONE",
+      "address": "0x77777feddddffc19ff86db637967013e6c6a116c",
+      "name": "Tornado Cash",
+      "symbol": "TORN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16916/thumb/bone_icon.png?1696516487"
-    },
-    {
-      "chainId": 1,
-      "address": "0x826180541412d574cf1336d22c0c0a287822678a",
-      "name": "Chainflip",
-      "symbol": "FLIP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25576/thumb/kdt_AgmT_400x400.png?1696524709"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7ddc52c4de30e94be3a6a0a2b259b2850f421989",
-      "name": "Gomining Token",
-      "symbol": "GOMINING",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15662/thumb/GoMining_Logo.png?1714757256"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfc385a1df85660a7e041423db512f779070fcede",
-      "name": "zkLink",
-      "symbol": "ZKL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34982/thumb/Logo1.png?1714980729"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf94e7d0710709388bce3161c32b4eea56d3f91cc",
-      "name": "Destra Network",
-      "symbol": "DSYNC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35996/thumb/Destra_Network.png?1710316001"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc98d64da73a6616c42117b582e832812e7b8d57f",
-      "name": "RSS3",
-      "symbol": "RSS3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23575/thumb/rss3.jpeg?1718351333"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa2120b9e674d3fc3875f415a7df52e382f141225",
-      "name": "Automata",
-      "symbol": "ATA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA_Icon_%28Profile_2%29.png?1720487988"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8642a849d0dcb7a15a974794668adcfbe4794b56",
-      "name": "Prosper",
-      "symbol": "PROS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13668/thumb/PFP_Visual_CG.png?1727714135"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd01409314acb3b245cea9500ece3f6fd4d70ea30",
-      "name": "LTO Network",
-      "symbol": "LTO",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/6068/thumb/lto.png?1696506473"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
-      "name": "IDEX",
-      "symbol": "IDEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2565/thumb/idexlogo.png?1696503371"
-    },
-    {
-      "chainId": 1,
-      "address": "0x594daad7d77592a2b97b725a7ad59d7e188b5bfa",
-      "name": "Apu Apustaja",
-      "symbol": "APU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35986/thumb/200x200.png?1710308147"
+      "logoURI": "https://assets.coingecko.com/coins/images/13496/large/ZINt8NSB_400x400.jpg?1696513257"
     },
     {
       "chainId": 1,
@@ -2464,7 +2312,143 @@
       "name": "Wrapped Fantom",
       "symbol": "WFTM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16036/thumb/Fantom.png?1696515646"
+      "logoURI": "https://assets.coingecko.com/coins/images/16036/large/Fantom.png?1696515646"
+    },
+    {
+      "chainId": 1,
+      "address": "0x56072c95faa701256059aa122697b133aded9279",
+      "name": "Sky",
+      "symbol": "SKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39925/large/sky.jpg?1724827980"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec67005c4e498ec7f55e092bd1d35cbc47c91892",
+      "name": "Enzyme",
+      "symbol": "MLN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/605/large/Enzyme_Icon_Secondary.png?1696501803"
+    },
+    {
+      "chainId": 1,
+      "address": "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
+      "name": "Boba Network",
+      "symbol": "BOBA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20285/large/Boba-200x200---white.png?1696519690"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9d1a7a3191102e9f900faa10540837ba84dcbae7",
+      "name": "Eurite",
+      "symbol": "EURI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39952/large/EURI.jpg?1724902829"
+    },
+    {
+      "chainId": 1,
+      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
+      "name": "Telos",
+      "symbol": "TLOS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7588/large/tlos_png.png?1722391289"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe1a001fe942f96eea22ba08783140b9dcc09d28",
+      "name": "Beta Finance",
+      "symbol": "BETA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18715/large/beta_finance.jpg?1696518183"
+    },
+    {
+      "chainId": 1,
+      "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
+      "name": "Telcoin",
+      "symbol": "TEL",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/1899/large/tel.png?1696502892"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
+      "name": "Bone ShibaSwap",
+      "symbol": "BONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16916/large/bone_icon.png?1696516487"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfc385a1df85660a7e041423db512f779070fcede",
+      "name": "zkLink",
+      "symbol": "ZKL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34982/large/Logo1.png?1714980729"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf94e7d0710709388bce3161c32b4eea56d3f91cc",
+      "name": "Destra Network",
+      "symbol": "DSYNC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35996/large/Destra_Network.png?1710316001"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbf5495efe5db9ce00f80364c8b423567e58d2110",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc98d64da73a6616c42117b582e832812e7b8d57f",
+      "name": "RSS3",
+      "symbol": "RSS3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23575/large/rss3.jpeg?1718351333"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2120b9e674d3fc3875f415a7df52e382f141225",
+      "name": "Automata",
+      "symbol": "ATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15985/large/ATA_Icon_%28Profile_2%29.png?1720487988"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8642a849d0dcb7a15a974794668adcfbe4794b56",
+      "name": "Prosper",
+      "symbol": "PROS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13668/large/PFP_Visual_CG.png?1727714135"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd01409314acb3b245cea9500ece3f6fd4d70ea30",
+      "name": "LTO Network",
+      "symbol": "LTO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/6068/large/lto.png?1696506473"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
+      "name": "IDEX",
+      "symbol": "IDEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2565/large/idexlogo.png?1696503371"
+    },
+    {
+      "chainId": 1,
+      "address": "0x594daad7d77592a2b97b725a7ad59d7e188b5bfa",
+      "name": "Apu Apustaja",
+      "symbol": "APU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35986/large/200x200.png?1710308147"
     },
     {
       "chainId": 1,
@@ -2472,7 +2456,7 @@
       "name": "Zero1 Labs",
       "symbol": "DEAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36315/thumb/512x512-xion-ava03.png?1711092111"
+      "logoURI": "https://assets.coingecko.com/coins/images/36315/large/512x512-xion-ava03.png?1711092111"
     },
     {
       "chainId": 1,
@@ -2480,159 +2464,7 @@
       "name": "Tokenize Xchange",
       "symbol": "TKX",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/4984/thumb/TKX_-_Logo_-_RGB-15.png?1696505519"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdc9ac3c20d1ed0b540df9b1fedc10039df13f99c",
-      "name": "xMoney",
-      "symbol": "UTK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1824/thumb/200x200.png?1696723239"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7abc8a5768e6be61a6c693a6e4eacb5b60602c4d",
-      "name": "Covalent X Token",
-      "symbol": "CXT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39177/thumb/CXT_Ticker.png?1720829918"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa91ac63d040deb1b7a5e4d4134ad23eb0ba07e14",
-      "name": "Bella Protocol",
-      "symbol": "BEL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12478/thumb/Bella.png?1696512296"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
-      "name": "OriginTrail",
-      "symbol": "TRAC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1696502873"
-    },
-    {
-      "chainId": 1,
-      "address": "0xadd5e881984783dd432f80381fb52f45b53f3e70",
-      "name": "Vite",
-      "symbol": "VITE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4513/thumb/VITE_new_logo_200px.png?1709175957"
-    },
-    {
-      "chainId": 1,
-      "address": "0x67466be17df832165f8c80a5a120ccc652bd7e69",
-      "name": "LandWolf",
-      "symbol": "WOLF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37403/thumb/wolf_200x200.png?1715222165"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfc82bb4ba86045af6f327323a46e80412b91b27d",
-      "name": "Prom",
-      "symbol": "PROM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8825/thumb/Ticker.png?1696508978"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9e9fbde7c7a83c43913bddc8779158f1368f0413",
-      "name": "Pandora",
-      "symbol": "PANDORA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34996/thumb/PandoraToken.png?1706954340"
-    },
-    {
-      "chainId": 1,
-      "address": "0x25931894a86d47441213199621f1f2994e1c39aa",
-      "name": "ChainGPT",
-      "symbol": "CGPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29306/thumb/200x200.png?1696528257"
-    },
-    {
-      "chainId": 1,
-      "address": "0x68749665ff8d2d112fa859aa293f07a622782f38",
-      "name": "Tether Gold",
-      "symbol": "XAUT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/10481/thumb/Tether_Gold.png?1696510471"
-    },
-    {
-      "chainId": 1,
-      "address": "0x79f05c263055ba20ee0e814acd117c20caa10e0c",
-      "name": "Ice Open Network",
-      "symbol": "ICE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34674/thumb/ion-coingecko-200w.png?1714009819"
-    },
-    {
-      "chainId": 1,
-      "address": "0x28561b8a2360f463011c16b6cc0b0cbef8dbbcad",
-      "name": "MOO DENG",
-      "symbol": "MOODENG",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/50348/thumb/1000000612.jpg?1727248974"
-    },
-    {
-      "chainId": 1,
-      "address": "0x97a9a15168c22b3c137e6381037e1499c8ad0978",
-      "name": "Data Ownership Protocol",
-      "symbol": "DOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36706/thumb/DOP-Round-200x200.png?1720836160"
-    },
-    {
-      "chainId": 1,
-      "address": "0x12970e6868f88f6557b76120662c1b3e50a646bf",
-      "name": "Milady Meme Coin",
-      "symbol": "LADYS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30194/thumb/LADYS_Clean.png?1725897475"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4c11249814f11b9346808179cf06e71ac328c1b5",
-      "name": "Oraichain",
-      "symbol": "ORAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12931/thumb/orai.png?1696512718"
-    },
-    {
-      "chainId": 1,
-      "address": "0x761d38e5ddf6ccf6cf7c55759d5210750b5d60f3",
-      "name": "Dogelon Mars",
-      "symbol": "ELON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1696514622"
-    },
-    {
-      "chainId": 1,
-      "address": "0xde7d85157d9714eadf595045cc12ca4a5f3e2adb",
-      "name": "STP",
-      "symbol": "STPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8713/thumb/STP.png?1696508875"
-    },
-    {
-      "chainId": 1,
-      "address": "0xea26c4ac16d4a5a106820bc8aee85fd0b7b2b664",
-      "name": "QuarkChain",
-      "symbol": "QKC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3849/thumb/QuarkChain.jpg?1730964236"
-    },
-    {
-      "chainId": 1,
-      "address": "0x48b847cf774a5710f36f594b11fc10e2e59bba72",
-      "name": "Unit0",
-      "symbol": "UNIT0",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51237/thumb/200%D1%85200.png?1730448085"
+      "logoURI": "https://assets.coingecko.com/coins/images/4984/large/TKX_-_Logo_-_RGB-15.png?1696505519"
     },
     {
       "chainId": 1,
@@ -2640,39 +2472,143 @@
       "name": "Multibit",
       "symbol": "MUBI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33051/thumb/multi.jpg?1700473994"
+      "logoURI": "https://assets.coingecko.com/coins/images/33051/large/multi.jpg?1700473994"
     },
     {
       "chainId": 1,
-      "address": "0xde4ee8057785a7e8e800db58f9784845a5c2cbd6",
-      "name": "DeXe",
-      "symbol": "DEXE",
+      "address": "0x7ddc52c4de30e94be3a6a0a2b259b2850f421989",
+      "name": "Gomining Token",
+      "symbol": "GOMINING",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12713/thumb/DEXE_token_logo.png?1696512514"
+      "logoURI": "https://assets.coingecko.com/coins/images/15662/large/GoMining_Logo.png?1714757256"
     },
     {
       "chainId": 1,
-      "address": "0x508e00d5cef397b02d260d035e5ee80775e4c821",
-      "name": "Bitcoin Cats",
-      "symbol": "1CAT",
+      "address": "0xdc9ac3c20d1ed0b540df9b1fedc10039df13f99c",
+      "name": "xMoney",
+      "symbol": "UTK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34059/thumb/779e5404024bcd3cec3db54370ea66c.jpg?1703752231"
+      "logoURI": "https://assets.coingecko.com/coins/images/1824/large/200x200.png?1696723239"
     },
     {
       "chainId": 1,
-      "address": "0x7613c48e0cd50e42dd9bf0f6c235063145f6f8dc",
-      "name": "Pirate Nation Token",
-      "symbol": "PIRATE",
+      "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
+      "name": "OriginTrail",
+      "symbol": "TRAC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38524/thumb/_Pirate_Transparent_200x200.png?1717947813"
+      "logoURI": "https://assets.coingecko.com/coins/images/1877/large/TRAC.jpg?1696502873"
     },
     {
       "chainId": 1,
-      "address": "0x96f6ef951840721adbf46ac996b59e0235cb985c",
-      "name": "Ondo US Dollar Yield",
-      "symbol": "USDY",
+      "address": "0x67466be17df832165f8c80a5a120ccc652bd7e69",
+      "name": "LandWolf",
+      "symbol": "WOLF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31700/thumb/usdy_%281%29.png?1696530524"
+      "logoURI": "https://assets.coingecko.com/coins/images/37403/large/wolf_200x200.png?1715222165"
+    },
+    {
+      "chainId": 1,
+      "address": "0xadd5e881984783dd432f80381fb52f45b53f3e70",
+      "name": "Vite",
+      "symbol": "VITE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4513/large/VITE_new_logo_200px.png?1709175957"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7abc8a5768e6be61a6c693a6e4eacb5b60602c4d",
+      "name": "Covalent X Token",
+      "symbol": "CXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39177/large/CXT_Ticker.png?1720829918"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa91ac63d040deb1b7a5e4d4134ad23eb0ba07e14",
+      "name": "Bella Protocol",
+      "symbol": "BEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12478/large/Bella.png?1696512296"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfc82bb4ba86045af6f327323a46e80412b91b27d",
+      "name": "Prom",
+      "symbol": "PROM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8825/large/Ticker.png?1696508978"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9e9fbde7c7a83c43913bddc8779158f1368f0413",
+      "name": "Pandora",
+      "symbol": "PANDORA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34996/large/PandoraToken.png?1706954340"
+    },
+    {
+      "chainId": 1,
+      "address": "0x826180541412d574cf1336d22c0c0a287822678a",
+      "name": "Chainflip",
+      "symbol": "FLIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25576/large/kdt_AgmT_400x400.png?1696524709"
+    },
+    {
+      "chainId": 1,
+      "address": "0x25931894a86d47441213199621f1f2994e1c39aa",
+      "name": "ChainGPT",
+      "symbol": "CGPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29306/large/200x200.png?1696528257"
+    },
+    {
+      "chainId": 1,
+      "address": "0x68749665ff8d2d112fa859aa293f07a622782f38",
+      "name": "Tether Gold",
+      "symbol": "XAUT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/10481/large/Tether_Gold.png?1696510471"
+    },
+    {
+      "chainId": 1,
+      "address": "0x28561b8a2360f463011c16b6cc0b0cbef8dbbcad",
+      "name": "MOO DENG",
+      "symbol": "MOODENG",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/50348/large/1000000612.jpg?1727248974"
+    },
+    {
+      "chainId": 1,
+      "address": "0x79f05c263055ba20ee0e814acd117c20caa10e0c",
+      "name": "Ice Open Network",
+      "symbol": "ICE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34674/large/ion-coingecko-200w.png?1714009819"
+    },
+    {
+      "chainId": 1,
+      "address": "0x97a9a15168c22b3c137e6381037e1499c8ad0978",
+      "name": "Data Ownership Protocol",
+      "symbol": "DOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36706/large/DOP-Round-200x200.png?1720836160"
+    },
+    {
+      "chainId": 1,
+      "address": "0x12970e6868f88f6557b76120662c1b3e50a646bf",
+      "name": "Milady Meme Coin",
+      "symbol": "LADYS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30194/large/LADYS_Clean.png?1725897475"
+    },
+    {
+      "chainId": 1,
+      "address": "0x761d38e5ddf6ccf6cf7c55759d5210750b5d60f3",
+      "name": "Dogelon Mars",
+      "symbol": "ELON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14962/large/6GxcPRo3_400x400.jpg?1696514622"
     },
     {
       "chainId": 1,
@@ -2680,455 +2616,63 @@
       "name": "Avail",
       "symbol": "AVAIL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37372/thumb/avail-logo.png?1714145201"
+      "logoURI": "https://assets.coingecko.com/coins/images/37372/large/avail-logo.png?1714145201"
     },
     {
       "chainId": 1,
-      "address": "0x1e053d89e08c24aa2ce5c5b4206744dc2d7bd8f5",
-      "name": "ThunderCore",
-      "symbol": "TT",
+      "address": "0xde7d85157d9714eadf595045cc12ca4a5f3e2adb",
+      "name": "STP",
+      "symbol": "STPT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4375/thumb/ThunderCore_Logo_Mark_Gradient_%283%29.png?1696504974"
+      "logoURI": "https://assets.coingecko.com/coins/images/8713/large/STP.png?1696508875"
     },
     {
       "chainId": 1,
-      "address": "0x3ffeea07a27fab7ad1df5297fa75e77a43cb5790",
-      "name": "PeiPei",
-      "symbol": "PEIPEI",
+      "address": "0x48b847cf774a5710f36f594b11fc10e2e59bba72",
+      "name": "Unit0",
+      "symbol": "UNIT0",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38512/thumb/PeiPei.png?1718315778"
+      "logoURI": "https://assets.coingecko.com/coins/images/51237/large/200%D1%85200.png?1730448085"
     },
     {
       "chainId": 1,
-      "address": "0x0c7d5ae016f806603cb1782bea29ac69471cab9c",
-      "name": "Bifrost",
-      "symbol": "BFC",
+      "address": "0xde4ee8057785a7e8e800db58f9784845a5c2cbd6",
+      "name": "DeXe",
+      "symbol": "DEXE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4639/thumb/BFC_Symbol.png?1696505208"
+      "logoURI": "https://assets.coingecko.com/coins/images/12713/large/DEXE_token_logo.png?1696512514"
     },
     {
       "chainId": 1,
-      "address": "0x06450dee7fd2fb8e39061434babcfc05599a6fb8",
-      "name": "XEN Crypto",
-      "symbol": "XEN",
+      "address": "0x508e00d5cef397b02d260d035e5ee80775e4c821",
+      "name": "Bitcoin Cats",
+      "symbol": "1CAT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27713/thumb/Xen.jpeg?1696526739"
+      "logoURI": "https://assets.coingecko.com/coins/images/34059/large/779e5404024bcd3cec3db54370ea66c.jpg?1703752231"
     },
     {
       "chainId": 1,
-      "address": "0x8f693ca8d21b157107184d29d398a8d082b38b76",
-      "name": "Streamr",
-      "symbol": "DATA",
+      "address": "0xea26c4ac16d4a5a106820bc8aee85fd0b7b2b664",
+      "name": "QuarkChain",
+      "symbol": "QKC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17869/thumb/DATA_new_symbol_3x.png?1696517392"
+      "logoURI": "https://assets.coingecko.com/coins/images/3849/large/QuarkChain.jpg?1730964236"
     },
     {
       "chainId": 1,
-      "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
-      "name": "Request",
-      "symbol": "REQ",
+      "address": "0x4c11249814f11b9346808179cf06e71ac328c1b5",
+      "name": "Oraichain",
+      "symbol": "ORAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1696502140"
+      "logoURI": "https://assets.coingecko.com/coins/images/12931/large/orai.png?1696512718"
     },
     {
       "chainId": 1,
-      "address": "0x8236a87084f8b84306f72007f36f2618a5634494",
-      "name": "Lombard Staked BTC",
-      "symbol": "LBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39969/thumb/LBTC_Logo.png?1724959872"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaaaaaa20d9e0e2461697782ef11675f668207961",
-      "name": "Aurora",
-      "symbol": "AURORA",
+      "address": "0x7613c48e0cd50e42dd9bf0f6c235063145f6f8dc",
+      "name": "Pirate Nation Token",
+      "symbol": "PIRATE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20582/thumb/aurora.jpeg?1696519989"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0f51bb10119727a7e5ea3538074fb341f56b09ad",
-      "name": "DAO Maker",
-      "symbol": "DAO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13915/thumb/4.jpg?1727532864"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2be5e8c109e2197d077d13a82daead6a9b3433c5",
-      "name": "Tokamak Network",
-      "symbol": "TON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12260/thumb/D919x5-s_400x400.png?1696512091"
-    },
-    {
-      "chainId": 1,
-      "address": "0x628a3b2e302c7e896acc432d2d0dd22b6cb9bc88",
-      "name": "LimeWire",
-      "symbol": "LMWR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30356/thumb/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
-    },
-    {
-      "chainId": 1,
-      "address": "0x72e4f9f808c49a2a61de9c5896298920dc4eeea9",
-      "name": "HarryPotterObamaSonic10Inu  ETH ",
-      "symbol": "BITCOIN",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/30323/thumb/hpos10i_logo_casino_night-dexview.png?1696529224"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3e5a19c91266ad8ce2477b91585d1856b84062df",
-      "name": "Ancient8",
-      "symbol": "A8",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39170/thumb/A8_Token-04_200x200.png?1720798300"
-    },
-    {
-      "chainId": 1,
-      "address": "0x77fba179c79de5b7653f68b5039af940ada60ce0",
-      "name": "Ampleforth Governance",
-      "symbol": "FORTH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1696514579"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8390a1da07e376ef7add4be859ba74fb83aa02d5",
-      "name": "Grok",
-      "symbol": "GROK",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/32788/thumb/GROK.png?1707579427"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd795eb12034c2b77d787a22292c26fab5f5c70aa",
-      "name": "Pixelverse",
-      "symbol": "PIXFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38279/thumb/pixelverse_logo.png?1716993023"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbef26bd568e421d6708cca55ad6e35f8bfa0c406",
-      "name": "bitsCrunch Token",
-      "symbol": "BCUT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34832/thumb/logo-256_%281%29.png?1710244462"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf8ebf4849f1fa4faf0dff2106a173d3a6cb2eb3a",
-      "name": "Troll",
-      "symbol": "TROLL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29897/thumb/TROLL.jpeg?1696528821"
-    },
-    {
-      "chainId": 1,
-      "address": "0x91af0fbb28aba7e31403cb457106ce79397fd4e6",
-      "name": "Aergo",
-      "symbol": "AERGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4490/thumb/aergo.png?1696505079"
-    },
-    {
-      "chainId": 1,
-      "address": "0xed35af169af46a02ee13b9d79eb57d6d68c1749e",
-      "name": "ECOMI",
-      "symbol": "OMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4428/thumb/ECOMI.png?1696505023"
-    },
-    {
-      "chainId": 1,
-      "address": "0xae78736cd615f374d3085123a210448e74fc6393",
-      "name": "Rocket Pool ETH",
-      "symbol": "RETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20764/thumb/reth.png?1696520159"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4527a3b4a8a150403090a99b87effc96f2195047",
-      "name": "P2P solutions foundation",
-      "symbol": "P2PS",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/2798/thumb/p2ps.png?1696503565"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6e79b51959cf968d87826592f46f819f92466615",
-      "name": "Hoppy",
-      "symbol": "HOPPY",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37197/thumb/Hoppy_200x200_.png?1724175711"
-    },
-    {
-      "chainId": 1,
-      "address": "0x52284158e02425290f6b627aeb5fff65edf058ad",
-      "name": "FlappyMoonbird",
-      "symbol": "FMB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30659/thumb/200_%282%29.jpg?1696529529"
-    },
-    {
-      "chainId": 1,
-      "address": "0x701c244b988a513c945973defa05de933b23fe1d",
-      "name": "OAX",
-      "symbol": "OAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/853/thumb/OAXlogo.png?1696501987"
-    },
-    {
-      "chainId": 1,
-      "address": "0x554fb3b6c1cf4a3cef49779ced321ca51c667d7d",
-      "name": "Arata AGI",
-      "symbol": "ARATA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51555/thumb/500px.png?1731517839"
-    },
-    {
-      "chainId": 1,
-      "address": "0x94a8b4ee5cd64c79d0ee816f467ea73009f51aa0",
-      "name": "Realio Network Token",
-      "symbol": "RIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12206/thumb/Rio.png?1696512042"
-    },
-    {
-      "chainId": 1,
-      "address": "0x44971abf0251958492fee97da3e5c5ada88b9185",
-      "name": "BasedAI",
-      "symbol": "BASEDAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36607/thumb/1000004475.png?1711964332"
-    },
-    {
-      "chainId": 1,
-      "address": "0x825459139c897d769339f295e962396c4f9e4a4d",
-      "name": "GameBuild",
-      "symbol": "GAME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37789/thumb/Gamebuild-logo-200.png?1715586834"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc328a59e7321747aebbc49fd28d1b32c1af8d3b2",
-      "name": "Phil",
-      "symbol": "PHIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39975/thumb/yr0kMUrz_400x400.jpg?1724971221"
-    },
-    {
-      "chainId": 1,
-      "address": "0x678e840c640f619e17848045d23072844224dd37",
-      "name": "Cratos",
-      "symbol": "CRTS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17322/thumb/cratos.png?1696516876"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5026f006b85729a8b14553fae6af249ad16c9aab",
-      "name": "Wojak",
-      "symbol": "WOJAK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29856/thumb/wojak.png?1696528782"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0391d2021f89dc339f60fff84546ea23e337750f",
-      "name": "BarnBridge",
-      "symbol": "BOND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1696512604"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdbb7a34bf10169d6d2d0d02a6cbb436cf4381bfa",
-      "name": "Zentry",
-      "symbol": "ZENT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36979/thumb/Zentry-rebrand-Primary_200px.png?1713743277"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc555d625828c4527d477e595ff1dd5801b4a600e",
-      "name": "MON Protocol",
-      "symbol": "MON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37395/thumb/WhatsApp_Image_2024-02-27_at_18.34.45_01762153.jpg?1716261730"
-    },
-    {
-      "chainId": 1,
-      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
-      "name": "Pocket Network",
-      "symbol": "POKT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/22506/thumb/POKT.jpg?1703257310"
-    },
-    {
-      "chainId": 1,
-      "address": "0x865ec58b06bf6305b886793aa20a2da31d034e68",
-      "name": "Mossland",
-      "symbol": "MOC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2374/thumb/moc.png?1696503240"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
-      "name": "Pax Dollar",
-      "symbol": "USDP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/6013/thumb/Pax_Dollar.png?1696506427"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb2617246d0c6c0087f18703d576831899ca94f01",
-      "name": "Zignaly",
-      "symbol": "ZIG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14796/thumb/zig.jpg?1731990265"
-    },
-    {
-      "chainId": 1,
-      "address": "0x908ddb096bfb3acb19e2280aad858186ea4935c4",
-      "name": "Eesee",
-      "symbol": "ESE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35182/thumb/Eesee.jpg?1707796753"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfb19075d77a0f111796fb259819830f4780f1429",
-      "name": "Fenerbah e",
-      "symbol": "FB",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17711/thumb/FB_Logo.png?1696517238"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa831a4e181f25d3b35949e582ff27cc44e703f37",
-      "name": "ALEX Lab",
-      "symbol": "ALEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25837/thumb/ALEX_Token.png?1696524922"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9ff58067bd8d239000010c154c6983a325df138e",
-      "name": "Propchain",
-      "symbol": "PROPC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30451/thumb/prop_%281%29.png?1702322253"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8802269d1283cdb2a5a329649e5cb4cdcee91ab6",
-      "name": "Fight to MAGA",
-      "symbol": "FIGHT",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/39208/thumb/photo_2024-07-14_03-15-23.jpg?1721101331"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4ec1b60b96193a64acae44778e51f7bff2007831",
-      "name": "Edge",
-      "symbol": "EDGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1848/thumb/EDGE.png?1696502846"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc9bca88b04581699fab5aa276ccaff7df957cbbf",
-      "name": "Ethervista",
-      "symbol": "VISTA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40014/thumb/ethervista.jpg?1725289970"
-    },
-    {
-      "chainId": 1,
-      "address": "0x728f30fa2f100742c7949d1961804fa8e0b1387d",
-      "name": "GamerCoin",
-      "symbol": "GHX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14714/thumb/ghx_icon.png?1696514385"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9aab071b4129b083b01cb5a0cb513ce7eca26fa5",
-      "name": "Hunt",
-      "symbol": "HUNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7989/thumb/HUNT.png?1696508215"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5dc60c4d5e75d22588fa17ffeb90a63e535efce0",
-      "name": "dKargo",
-      "symbol": "DKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11875/thumb/DKA_ticker.png?1732553189"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc56c7a0eaa804f854b536a5f3d5f49d2ec4b12b8",
-      "name": "GME  Ethereum ",
-      "symbol": "GME",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37895/thumb/GME200.jpg?1715847521"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe9689028ede16c2fdfe3d11855d28f8e3fc452a3",
-      "name": "Imaginary Ones",
-      "symbol": "BUBBLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37706/thumb/imaginary_ones.jpeg?1715255717"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe7c6bf469e97eeb0bfb74c8dbff5bd47d4c1c98a",
-      "name": "HashKey Platform Token",
-      "symbol": "HSK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29779/thumb/HSKlogo.jpg?1719445510"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdd3b11ef34cd511a2da159034a05fcb94d806686",
-      "name": "Rekt",
-      "symbol": "REKT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51727/thumb/rektcion_trans_200px.png?1731910587"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9cb1aeafcc8a9406632c5b084246ea72f62d37b6",
-      "name": "LBK",
-      "symbol": "LBK",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/9492/thumb/lbk.jpeg?1696509578"
-    },
-    {
-      "chainId": 1,
-      "address": "0x69a1e699f562d7af66fc6cc473d99f4430c3acd2",
-      "name": "Param",
-      "symbol": "PARAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37697/thumb/param200.png?1715234889"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
-      "name": "Cream",
-      "symbol": "CREAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11976/thumb/Cream.png?1696511834"
+      "logoURI": "https://assets.coingecko.com/coins/images/38524/large/_Pirate_Transparent_200x200.png?1717947813"
     },
     {
       "chainId": 1,
@@ -3136,63 +2680,447 @@
       "name": "Solv Protocol SolvBTC",
       "symbol": "SOLVBTC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36800/thumb/solvBTC.png?1719810684"
+      "logoURI": "https://assets.coingecko.com/coins/images/36800/large/solvBTC.png?1719810684"
     },
     {
       "chainId": 1,
-      "address": "0x13e4b8cffe704d3de6f19e52b201d92c21ec18bd",
-      "name": "ParallelAI",
-      "symbol": "PAI",
+      "address": "0x96f6ef951840721adbf46ac996b59e0235cb985c",
+      "name": "Ondo US Dollar Yield",
+      "symbol": "USDY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50394/thumb/IMG_20240926_230930_523.jpg?1727589698"
+      "logoURI": "https://assets.coingecko.com/coins/images/31700/large/usdy_%281%29.png?1696530524"
     },
     {
       "chainId": 1,
-      "address": "0x823556202e86763853b40e9cde725f412e294689",
-      "name": "Altered State Machine",
-      "symbol": "ASTO",
+      "address": "0x3ffeea07a27fab7ad1df5297fa75e77a43cb5790",
+      "name": "PeiPei",
+      "symbol": "PEIPEI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24893/thumb/ASTO-Token.png?1732899741"
+      "logoURI": "https://assets.coingecko.com/coins/images/38512/large/PeiPei.png?1718315778"
     },
     {
       "chainId": 1,
-      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
-      "name": "World Mobile Token",
-      "symbol": "WMTX",
+      "address": "0x1e053d89e08c24aa2ce5c5b4206744dc2d7bd8f5",
+      "name": "ThunderCore",
+      "symbol": "TT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4375/large/ThunderCore_Logo_Mark_Gradient_%283%29.png?1696504974"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f51bb10119727a7e5ea3538074fb341f56b09ad",
+      "name": "DAO Maker",
+      "symbol": "DAO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13915/large/4.jpg?1727532864"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0c7d5ae016f806603cb1782bea29ac69471cab9c",
+      "name": "Bifrost",
+      "symbol": "BFC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4639/large/BFC_Symbol.png?1696505208"
+    },
+    {
+      "chainId": 1,
+      "address": "0x06450dee7fd2fb8e39061434babcfc05599a6fb8",
+      "name": "XEN Crypto",
+      "symbol": "XEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27713/large/Xen.jpeg?1696526739"
+    },
+    {
+      "chainId": 1,
+      "address": "0x628a3b2e302c7e896acc432d2d0dd22b6cb9bc88",
+      "name": "LimeWire",
+      "symbol": "LMWR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30356/large/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8f693ca8d21b157107184d29d398a8d082b38b76",
+      "name": "Streamr",
+      "symbol": "DATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17869/large/DATA_new_symbol_3x.png?1696517392"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8236a87084f8b84306f72007f36f2618a5634494",
+      "name": "Lombard Staked BTC",
+      "symbol": "LBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39969/large/LBTC_Logo.png?1724959872"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaaaaaa20d9e0e2461697782ef11675f668207961",
+      "name": "Aurora",
+      "symbol": "AURORA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20582/large/aurora.jpeg?1696519989"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
+      "name": "Request",
+      "symbol": "REQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1031/large/Request_icon_green.png?1696502140"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2be5e8c109e2197d077d13a82daead6a9b3433c5",
+      "name": "Tokamak Network",
+      "symbol": "TON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12260/large/D919x5-s_400x400.png?1696512091"
+    },
+    {
+      "chainId": 1,
+      "address": "0x72e4f9f808c49a2a61de9c5896298920dc4eeea9",
+      "name": "HarryPotterObamaSonic10Inu  ETH ",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77fba179c79de5b7653f68b5039af940ada60ce0",
+      "name": "Ampleforth Governance",
+      "symbol": "FORTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14917/large/photo_2021-04-22_00.00.03.jpeg?1696514579"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3e5a19c91266ad8ce2477b91585d1856b84062df",
+      "name": "Ancient8",
+      "symbol": "A8",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39170/large/A8_Token-04_200x200.png?1720798300"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf8ebf4849f1fa4faf0dff2106a173d3a6cb2eb3a",
+      "name": "Troll",
+      "symbol": "TROLL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29897/large/TROLL.jpeg?1696528821"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd795eb12034c2b77d787a22292c26fab5f5c70aa",
+      "name": "Pixelverse",
+      "symbol": "PIXFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38279/large/pixelverse_logo.png?1716993023"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4527a3b4a8a150403090a99b87effc96f2195047",
+      "name": "P2P solutions foundation",
+      "symbol": "P2PS",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2798/large/p2ps.png?1696503565"
+    },
+    {
+      "chainId": 1,
+      "address": "0x91af0fbb28aba7e31403cb457106ce79397fd4e6",
+      "name": "Aergo",
+      "symbol": "AERGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4490/large/aergo.png?1696505079"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e79b51959cf968d87826592f46f819f92466615",
+      "name": "Hoppy",
+      "symbol": "HOPPY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37197/large/Hoppy_200x200_.png?1724175711"
+    },
+    {
+      "chainId": 1,
+      "address": "0xed35af169af46a02ee13b9d79eb57d6d68c1749e",
+      "name": "ECOMI",
+      "symbol": "OMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4428/large/ECOMI.png?1696505023"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbef26bd568e421d6708cca55ad6e35f8bfa0c406",
+      "name": "bitsCrunch Token",
+      "symbol": "BCUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34832/large/logo-256_%281%29.png?1710244462"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8390a1da07e376ef7add4be859ba74fb83aa02d5",
+      "name": "Grok",
+      "symbol": "GROK",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32788/large/GROK.png?1707579427"
+    },
+    {
+      "chainId": 1,
+      "address": "0x52284158e02425290f6b627aeb5fff65edf058ad",
+      "name": "FlappyMoonbird",
+      "symbol": "FMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30659/large/200_%282%29.jpg?1696529529"
+    },
+    {
+      "chainId": 1,
+      "address": "0x701c244b988a513c945973defa05de933b23fe1d",
+      "name": "OAX",
+      "symbol": "OAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/853/large/OAXlogo.png?1696501987"
+    },
+    {
+      "chainId": 1,
+      "address": "0x554fb3b6c1cf4a3cef49779ced321ca51c667d7d",
+      "name": "Arata AGI",
+      "symbol": "ARATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51555/large/500px.png?1731517839"
+    },
+    {
+      "chainId": 1,
+      "address": "0x94a8b4ee5cd64c79d0ee816f467ea73009f51aa0",
+      "name": "Realio Network Token",
+      "symbol": "RIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12206/large/Rio.png?1696512042"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44971abf0251958492fee97da3e5c5ada88b9185",
+      "name": "BasedAI",
+      "symbol": "BASEDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36607/large/1000004475.png?1711964332"
+    },
+    {
+      "chainId": 1,
+      "address": "0x825459139c897d769339f295e962396c4f9e4a4d",
+      "name": "GameBuild",
+      "symbol": "GAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37789/large/Gamebuild-logo-200.png?1715586834"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc328a59e7321747aebbc49fd28d1b32c1af8d3b2",
+      "name": "Phil",
+      "symbol": "PHIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39975/large/yr0kMUrz_400x400.jpg?1724971221"
+    },
+    {
+      "chainId": 1,
+      "address": "0x678e840c640f619e17848045d23072844224dd37",
+      "name": "Cratos",
+      "symbol": "CRTS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17322/large/cratos.png?1696516876"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5026f006b85729a8b14553fae6af249ad16c9aab",
+      "name": "Wojak",
+      "symbol": "WOJAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29856/large/wojak.png?1696528782"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbb7a34bf10169d6d2d0d02a6cbb436cf4381bfa",
+      "name": "Zentry",
+      "symbol": "ZENT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36979/large/Zentry-rebrand-Primary_200px.png?1713743277"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0391d2021f89dc339f60fff84546ea23e337750f",
+      "name": "BarnBridge",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/large/barnbridge.jpg?1696512604"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc555d625828c4527d477e595ff1dd5801b4a600e",
+      "name": "MON Protocol",
+      "symbol": "MON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37395/large/WhatsApp_Image_2024-02-27_at_18.34.45_01762153.jpg?1716261730"
+    },
+    {
+      "chainId": 1,
+      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
+      "name": "Pocket Network",
+      "symbol": "POKT",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17333/thumb/1000097112.png?1727698144"
+      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
     },
     {
       "chainId": 1,
-      "address": "0x3567aa22cd3ab9aef23d7e18ee0d7cf16974d7e6",
-      "name": "Sharpe AI",
-      "symbol": "SAI",
+      "address": "0x865ec58b06bf6305b886793aa20a2da31d034e68",
+      "name": "Mossland",
+      "symbol": "MOC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39385/thumb/Group_48095583.png?1721962174"
+      "logoURI": "https://assets.coingecko.com/coins/images/2374/large/moc.png?1696503240"
     },
     {
       "chainId": 1,
-      "address": "0x5ca381bbfb58f0092df149bd3d243b08b9a8386e",
-      "name": "Moonchain",
-      "symbol": "MXC",
+      "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
+      "name": "Pax Dollar",
+      "symbol": "USDP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4604/thumb/M_1-modified.png?1712206949"
+      "logoURI": "https://assets.coingecko.com/coins/images/6013/large/Pax_Dollar.png?1696506427"
     },
     {
       "chainId": 1,
-      "address": "0x32b77729cd87f1ef2bea4c650c16f89f08472c69",
-      "name": "DeBox",
-      "symbol": "BOX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50224/thumb/v6TSd2dN_400x400.jpg?1726521525"
+      "address": "0xfb19075d77a0f111796fb259819830f4780f1429",
+      "name": "Fenerbah e",
+      "symbol": "FB",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17711/large/FB_Logo.png?1696517238"
     },
     {
       "chainId": 1,
-      "address": "0x943af2ece93118b973c95c2f698ee9d15002e604",
-      "name": "GameGPT",
-      "symbol": "DUEL",
+      "address": "0x908ddb096bfb3acb19e2280aad858186ea4935c4",
+      "name": "Eesee",
+      "symbol": "ESE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34491/thumb/duel.jpeg?1705056819"
+      "logoURI": "https://assets.coingecko.com/coins/images/35182/large/Eesee.jpg?1707796753"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa831a4e181f25d3b35949e582ff27cc44e703f37",
+      "name": "ALEX Lab",
+      "symbol": "ALEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25837/large/ALEX_Token.png?1696524922"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9ff58067bd8d239000010c154c6983a325df138e",
+      "name": "Propchain",
+      "symbol": "PROPC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30451/large/prop_%281%29.png?1702322253"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8802269d1283cdb2a5a329649e5cb4cdcee91ab6",
+      "name": "Fight to MAGA",
+      "symbol": "FIGHT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/39208/large/photo_2024-07-14_03-15-23.jpg?1721101331"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4ec1b60b96193a64acae44778e51f7bff2007831",
+      "name": "Edge",
+      "symbol": "EDGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1848/large/EDGE.png?1696502846"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb2617246d0c6c0087f18703d576831899ca94f01",
+      "name": "Zignaly",
+      "symbol": "ZIG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14796/large/zig.jpg?1731990265"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc9bca88b04581699fab5aa276ccaff7df957cbbf",
+      "name": "Ethervista",
+      "symbol": "VISTA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40014/large/ethervista.jpg?1725289970"
+    },
+    {
+      "chainId": 1,
+      "address": "0x728f30fa2f100742c7949d1961804fa8e0b1387d",
+      "name": "GamerCoin",
+      "symbol": "GHX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14714/large/ghx_icon.png?1696514385"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9aab071b4129b083b01cb5a0cb513ce7eca26fa5",
+      "name": "Hunt",
+      "symbol": "HUNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7989/large/HUNT.png?1696508215"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5dc60c4d5e75d22588fa17ffeb90a63e535efce0",
+      "name": "dKargo",
+      "symbol": "DKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11875/large/DKA_ticker.png?1732553189"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc56c7a0eaa804f854b536a5f3d5f49d2ec4b12b8",
+      "name": "GME  Ethereum ",
+      "symbol": "GME",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37895/large/GME200.jpg?1715847521"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe9689028ede16c2fdfe3d11855d28f8e3fc452a3",
+      "name": "Imaginary Ones",
+      "symbol": "BUBBLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37706/large/imaginary_ones.jpeg?1715255717"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdd3b11ef34cd511a2da159034a05fcb94d806686",
+      "name": "Rekt",
+      "symbol": "REKT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51727/large/rektcion_trans_200px.png?1731910587"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe7c6bf469e97eeb0bfb74c8dbff5bd47d4c1c98a",
+      "name": "HashKey Platform Token",
+      "symbol": "HSK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29779/large/HSKlogo.jpg?1719445510"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9cb1aeafcc8a9406632c5b084246ea72f62d37b6",
+      "name": "LBK",
+      "symbol": "LBK",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/9492/large/lbk.jpeg?1696509578"
+    },
+    {
+      "chainId": 1,
+      "address": "0x69a1e699f562d7af66fc6cc473d99f4430c3acd2",
+      "name": "Param",
+      "symbol": "PARAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37697/large/param200.png?1715234889"
     },
     {
       "chainId": 1,
@@ -3200,15 +3128,63 @@
       "name": "Mantle Restaked ETH",
       "symbol": "CMETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51114/thumb/symbol.png?1730117724"
+      "logoURI": "https://assets.coingecko.com/coins/images/51114/large/symbol.png?1730117724"
     },
     {
       "chainId": 1,
-      "address": "0x9f0c013016e8656bc256f948cd4b79ab25c7b94d",
-      "name": "mETH Protocol",
-      "symbol": "COOK",
+      "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
+      "name": "Cream",
+      "symbol": "CREAM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50969/thumb/Logomark-Gradient_Official.png?1729620221"
+      "logoURI": "https://assets.coingecko.com/coins/images/11976/large/Cream.png?1696511834"
+    },
+    {
+      "chainId": 1,
+      "address": "0x13e4b8cffe704d3de6f19e52b201d92c21ec18bd",
+      "name": "ParallelAI",
+      "symbol": "PAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50394/large/IMG_20240926_230930_523.jpg?1727589698"
+    },
+    {
+      "chainId": 1,
+      "address": "0x823556202e86763853b40e9cde725f412e294689",
+      "name": "Altered State Machine",
+      "symbol": "ASTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24893/large/ASTO-Token.png?1732899741"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
+      "name": "World Mobile Token",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
+    },
+    {
+      "chainId": 1,
+      "address": "0x32b77729cd87f1ef2bea4c650c16f89f08472c69",
+      "name": "DeBox",
+      "symbol": "BOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50224/large/v6TSd2dN_400x400.jpg?1726521525"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5ca381bbfb58f0092df149bd3d243b08b9a8386e",
+      "name": "Moonchain",
+      "symbol": "MXC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4604/large/M_1-modified.png?1712206949"
+    },
+    {
+      "chainId": 1,
+      "address": "0x943af2ece93118b973c95c2f698ee9d15002e604",
+      "name": "GameGPT",
+      "symbol": "DUEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34491/large/duel.jpeg?1705056819"
     },
     {
       "chainId": 1,
@@ -3216,15 +3192,23 @@
       "name": "Empyreal",
       "symbol": "EMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31374/thumb/logomainblacktransparent.png?1719953450"
+      "logoURI": "https://assets.coingecko.com/coins/images/31374/large/logomainblacktransparent.png?1719953450"
     },
     {
       "chainId": 1,
-      "address": "0x441761326490cacf7af299725b6292597ee822c2",
-      "name": "Unifi Protocol DAO",
-      "symbol": "UNFI",
+      "address": "0x3567aa22cd3ab9aef23d7e18ee0d7cf16974d7e6",
+      "name": "Sharpe AI",
+      "symbol": "SAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13152/thumb/logo-2.png?1696512937"
+      "logoURI": "https://assets.coingecko.com/coins/images/39385/large/Group_48095583.png?1721962174"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9f0c013016e8656bc256f948cd4b79ab25c7b94d",
+      "name": "mETH Protocol",
+      "symbol": "COOK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50969/large/Logomark-Gradient_Official.png?1729620221"
     },
     {
       "chainId": 1,
@@ -3232,7 +3216,15 @@
       "name": "Karrat",
       "symbol": "KARRAT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37237/thumb/SmallLogo.png?1714755426"
+      "logoURI": "https://assets.coingecko.com/coins/images/37237/large/SmallLogo.png?1714755426"
+    },
+    {
+      "chainId": 1,
+      "address": "0x441761326490cacf7af299725b6292597ee822c2",
+      "name": "Unifi Protocol DAO",
+      "symbol": "UNFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13152/large/logo-2.png?1696512937"
     },
     {
       "chainId": 1,
@@ -3240,7 +3232,7 @@
       "name": "MAGA",
       "symbol": "TRUMP",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/31498/thumb/Maga-Trump-Logo-200px.png?1696530309"
+      "logoURI": "https://assets.coingecko.com/coins/images/31498/large/Maga-Trump-Logo-200px.png?1696530309"
     },
     {
       "chainId": 1,
@@ -3248,23 +3240,7 @@
       "name": "Kelp DAO Restaked ETH",
       "symbol": "RSETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33800/thumb/Icon___Dark.png?1702991855"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb2492e97a68a6e4b9e9a11b99f6c42e5accd38c7",
-      "name": "Veloce",
-      "symbol": "VEXT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31214/thumb/VEXT_Logo.jpg?1696530041"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
-      "name": "Port3 Network",
-      "symbol": "PORT3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33383/thumb/port3-bc-200x200.png?1710075114"
+      "logoURI": "https://assets.coingecko.com/coins/images/33800/large/Icon___Dark.png?1702991855"
     },
     {
       "chainId": 1,
@@ -3272,15 +3248,23 @@
       "name": "LCX",
       "symbol": "LCX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9985/thumb/zRPSu_0o_400x400.jpg?1696510023"
+      "logoURI": "https://assets.coingecko.com/coins/images/9985/large/zRPSu_0o_400x400.jpg?1696510023"
     },
     {
       "chainId": 1,
-      "address": "0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
-      "name": "Kyber Network Crystal Legacy",
-      "symbol": "KNCL",
+      "address": "0xb2492e97a68a6e4b9e9a11b99f6c42e5accd38c7",
+      "name": "Veloce",
+      "symbol": "VEXT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/947/thumb/logo-kncl.png?1696502063"
+      "logoURI": "https://assets.coingecko.com/coins/images/31214/large/VEXT_Logo.jpg?1696530041"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5e8422345238f34275888049021821e8e08caa1f",
+      "name": "Frax Ether",
+      "symbol": "FRXETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28284/large/frxETH_icon.png?1696527284"
     },
     {
       "chainId": 1,
@@ -3288,7 +3272,23 @@
       "name": "Convex CRV",
       "symbol": "CVXCRV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15586/thumb/convex-crv.png?1696515222"
+      "logoURI": "https://assets.coingecko.com/coins/images/15586/large/convex-crv.png?1696515222"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
+      "name": "Kyber Network Crystal Legacy",
+      "symbol": "KNCL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/947/large/logo-kncl.png?1696502063"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
+      "name": "Port3 Network",
+      "symbol": "PORT3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33383/large/port3-bc-200x200.png?1710075114"
     },
     {
       "chainId": 1,
@@ -3296,7 +3296,7 @@
       "name": "DFI money",
       "symbol": "YFII",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11902/thumb/YFII-logo.78631676.png?1696511768"
+      "logoURI": "https://assets.coingecko.com/coins/images/11902/large/YFII-logo.78631676.png?1696511768"
     },
     {
       "chainId": 1,
@@ -3304,7 +3304,7 @@
       "name": "BOB Token",
       "symbol": "BOB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29929/thumb/bob.png?1696528857"
+      "logoURI": "https://assets.coingecko.com/coins/images/29929/large/bob.png?1696528857"
     },
     {
       "chainId": 1,
@@ -3312,15 +3312,7 @@
       "name": "Ocean Protocol",
       "symbol": "OCEAN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1696504363"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
-      "name": "Keep3rV1",
-      "symbol": "KP3R",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1696512754"
+      "logoURI": "https://assets.coingecko.com/coins/images/3687/large/ocean-protocol-logo.jpg?1696504363"
     },
     {
       "chainId": 1,
@@ -3328,7 +3320,7 @@
       "name": "Ctrl",
       "symbol": "CTRL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50886/thumb/_CTRL_logo_.png?1732678338"
+      "logoURI": "https://assets.coingecko.com/coins/images/50886/large/_CTRL_logo_.png?1732678338"
     },
     {
       "chainId": 1,
@@ -3336,15 +3328,15 @@
       "name": "Assemble Protocol",
       "symbol": "ASM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11605/thumb/ASM_512X512_white.png?1717463859"
+      "logoURI": "https://assets.coingecko.com/coins/images/11605/large/ASM_512X512_white.png?1717463859"
     },
     {
       "chainId": 1,
-      "address": "0x27c70cd1946795b66be9d954418546998b546634",
-      "name": "Doge Killer",
-      "symbol": "LEASH",
+      "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
+      "name": "Keep3rV1",
+      "symbol": "KP3R",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15802/thumb/Leash.png?1696515425"
+      "logoURI": "https://assets.coingecko.com/coins/images/12966/large/kp3r_logo.jpg?1696512754"
     },
     {
       "chainId": 1,
@@ -3352,39 +3344,15 @@
       "name": "Aleph im",
       "symbol": "ALEPH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Aleph-Logo-BW.png?1696511566"
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/large/Aleph-Logo-BW.png?1696511566"
     },
     {
       "chainId": 1,
-      "address": "0x9ce84f6a69986a83d92c324df10bc8e64771030f",
-      "name": "CHEX Token",
-      "symbol": "CHEX",
+      "address": "0x27c70cd1946795b66be9d954418546998b546634",
+      "name": "Doge Killer",
+      "symbol": "LEASH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10349/thumb/logo-white-bg-dark.png?1733475849"
-    },
-    {
-      "chainId": 1,
-      "address": "0x946551dd05c5abd7cc808927480225ce36d8c475",
-      "name": "One",
-      "symbol": "ONE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4960/thumb/Screenshot_39.png?1696505497"
-    },
-    {
-      "chainId": 1,
-      "address": "0x74232704659ef37c08995e386a2e26cc27a8d7b1",
-      "name": "Strike",
-      "symbol": "STRIKE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14607/thumb/Jw-36llq_400x400.jpg?1696514286"
-    },
-    {
-      "chainId": 1,
-      "address": "0xde2f7766c8bf14ca67193128535e5c7454f8387c",
-      "name": "Metadium",
-      "symbol": "META",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5247/thumb/metadium_symbol_black.png?1729148922"
+      "logoURI": "https://assets.coingecko.com/coins/images/15802/large/Leash.png?1696515425"
     },
     {
       "chainId": 1,
@@ -3392,47 +3360,7 @@
       "name": "Artificial Liquid Intelligence",
       "symbol": "ALI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/ALI-v2.webp?1728501978"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcb21311d3b91b5324f6c11b4f5a656fcacbff122",
-      "name": "QuantixAI",
-      "symbol": "QAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36166/thumb/200px_Qai.png?1726228972"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0c90c57aaf95a3a87eadda6ec3974c99d786511f",
-      "name": "HanChain",
-      "symbol": "HAN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27374/thumb/logo_200.png?1696526418"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd46ba6d942050d489dbd938a2c909a5d5039a161",
-      "name": "Ampleforth",
-      "symbol": "AMPL",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/4708/thumb/Ampleforth.png?1696505273"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa9e8acf069c58aec8825542845fd754e41a9489a",
-      "name": "PepeCoin",
-      "symbol": "PEPECOIN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30219/thumb/pepecoin.jpeg?1696529130"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe1bad922f84b198a08292fb600319300ae32471b",
-      "name": "Firmachain",
-      "symbol": "FCT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9892/thumb/6mHcLurm_400x400.jpg?1696509941"
+      "logoURI": "https://assets.coingecko.com/coins/images/22062/large/ALI-v2.webp?1728501978"
     },
     {
       "chainId": 1,
@@ -3440,79 +3368,31 @@
       "name": "NetMind Token",
       "symbol": "NMT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35328/thumb/NMT-logo.png?1708267799"
+      "logoURI": "https://assets.coingecko.com/coins/images/35328/large/NMT-logo.png?1708267799"
     },
     {
       "chainId": 1,
-      "address": "0x6f40d4a6237c257fff2db00fa0510deeecd303eb",
-      "name": "Instadapp",
-      "symbol": "INST",
+      "address": "0x9ce84f6a69986a83d92c324df10bc8e64771030f",
+      "name": "CHEX Token",
+      "symbol": "CHEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14688/thumb/30hFM0-n_400x400.jpg?1696514361"
+      "logoURI": "https://assets.coingecko.com/coins/images/10349/large/logo-white-bg-dark.png?1733475849"
     },
     {
       "chainId": 1,
-      "address": "0xa3d4bee77b05d4a0c943877558ce21a763c4fa29",
-      "name": "The Root Network",
-      "symbol": "ROOT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/33122/thumb/6T1Tapl__400x400.jpg?1700740439"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf8c4a95c92b0d0121d1d20f4575073b37883d663",
-      "name": "Tubes",
-      "symbol": "TUBES",
+      "address": "0x946551dd05c5abd7cc808927480225ce36d8c475",
+      "name": "One",
+      "symbol": "ONE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37984/thumb/TUBES.jpg?1716205639"
+      "logoURI": "https://assets.coingecko.com/coins/images/4960/large/Screenshot_39.png?1696505497"
     },
     {
       "chainId": 1,
-      "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
-      "name": "UniLend Finance",
-      "symbol": "UFT",
+      "address": "0x74232704659ef37c08995e386a2e26cc27a8d7b1",
+      "name": "Strike",
+      "symbol": "STRIKE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12819/thumb/UniLend_Finance_logo_PNG.png?1696512611"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
-      "name": "OX Coin",
-      "symbol": "OX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35365/thumb/9.png?1727331352"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa6c0c097741d55ecd9a3a7def3a8253fd022ceb9",
-      "name": "AVA  Travala ",
-      "symbol": "AVA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3014/thumb/AVA_Logo_160x160px_Black.png?1696503750"
-    },
-    {
-      "chainId": 1,
-      "address": "0xed1167b6dc64e8a366db86f2e952a482d0981ebd",
-      "name": "Lybra",
-      "symbol": "LBR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29958/thumb/New_LBR_V2.png?1696528884"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa0ef786bf476fe0810408caba05e536ac800ff86",
-      "name": "Myria",
-      "symbol": "MYRIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29273/thumb/myria.png?1696528226"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8ab2ff0116a279a99950c66a12298962d152b83c",
-      "name": "Ordiswap",
-      "symbol": "ORDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33910/thumb/IMG-20240113-WA0018.jpg.jpg?1705169306"
+      "logoURI": "https://assets.coingecko.com/coins/images/14607/large/Jw-36llq_400x400.jpg?1696514286"
     },
     {
       "chainId": 1,
@@ -3520,7 +3400,127 @@
       "name": "Propy",
       "symbol": "PRO",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1696502002"
+      "logoURI": "https://assets.coingecko.com/coins/images/869/large/propy.png?1696502002"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa9e8acf069c58aec8825542845fd754e41a9489a",
+      "name": "PepeCoin",
+      "symbol": "PEPECOIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30219/large/pepecoin.jpeg?1696529130"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd46ba6d942050d489dbd938a2c909a5d5039a161",
+      "name": "Ampleforth",
+      "symbol": "AMPL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/4708/large/Ampleforth.png?1696505273"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde2f7766c8bf14ca67193128535e5c7454f8387c",
+      "name": "Metadium",
+      "symbol": "META",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5247/large/metadium_symbol_black.png?1729148922"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6f40d4a6237c257fff2db00fa0510deeecd303eb",
+      "name": "Instadapp",
+      "symbol": "INST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14688/large/30hFM0-n_400x400.jpg?1696514361"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0c90c57aaf95a3a87eadda6ec3974c99d786511f",
+      "name": "HanChain",
+      "symbol": "HAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27374/large/logo_200.png?1696526418"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe1bad922f84b198a08292fb600319300ae32471b",
+      "name": "Firmachain",
+      "symbol": "FCT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9892/large/6mHcLurm_400x400.jpg?1696509941"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa3d4bee77b05d4a0c943877558ce21a763c4fa29",
+      "name": "The Root Network",
+      "symbol": "ROOT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/33122/large/6T1Tapl__400x400.jpg?1700740439"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcb21311d3b91b5324f6c11b4f5a656fcacbff122",
+      "name": "QuantixAI",
+      "symbol": "QAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36166/large/200px_Qai.png?1726228972"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf8c4a95c92b0d0121d1d20f4575073b37883d663",
+      "name": "Tubes",
+      "symbol": "TUBES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37984/large/TUBES.jpg?1716205639"
+    },
+    {
+      "chainId": 1,
+      "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+      "name": "Rocket Pool ETH",
+      "symbol": "RETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20764/large/reth.png?1696520159"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
+      "name": "UniLend Finance",
+      "symbol": "UFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12819/large/UniLend_Finance_logo_PNG.png?1696512611"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa6c0c097741d55ecd9a3a7def3a8253fd022ceb9",
+      "name": "AVA  Travala ",
+      "symbol": "AVA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3014/large/AVA_Logo_160x160px_Black.png?1696503750"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0ef786bf476fe0810408caba05e536ac800ff86",
+      "name": "Myria",
+      "symbol": "MYRIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29273/large/myria.png?1696528226"
+    },
+    {
+      "chainId": 1,
+      "address": "0xed1167b6dc64e8a366db86f2e952a482d0981ebd",
+      "name": "Lybra",
+      "symbol": "LBR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29958/large/New_LBR_V2.png?1696528884"
     },
     {
       "chainId": 1,
@@ -3528,7 +3528,15 @@
       "name": "Choise ai",
       "symbol": "CHO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25935/thumb/CHO_%282%29.png?1721039541"
+      "logoURI": "https://assets.coingecko.com/coins/images/25935/large/CHO_%282%29.png?1721039541"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ab2ff0116a279a99950c66a12298962d152b83c",
+      "name": "Ordiswap",
+      "symbol": "ORDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33910/large/IMG-20240113-WA0018.jpg.jpg?1705169306"
     },
     {
       "chainId": 1,
@@ -3536,7 +3544,7 @@
       "name": "Wilder World",
       "symbol": "WILD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15407/thumb/wld-logo.png?1712273448"
+      "logoURI": "https://assets.coingecko.com/coins/images/15407/large/wld-logo.png?1712273448"
     },
     {
       "chainId": 1,
@@ -3544,7 +3552,7 @@
       "name": "DOLA",
       "symbol": "DOLA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14287/thumb/dola.png?1696513984"
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
     },
     {
       "chainId": 1,
@@ -3552,7 +3560,7 @@
       "name": "Shrub",
       "symbol": "SHRUB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38880/thumb/photo_2024-11-13_23.58.11.png?1731575427"
+      "logoURI": "https://assets.coingecko.com/coins/images/38880/large/photo_2024-11-13_23.58.11.png?1731575427"
     },
     {
       "chainId": 1,
@@ -3560,39 +3568,7 @@
       "name": "TYBENG",
       "symbol": "TYBENG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31022/thumb/NVoa_mZ6_400x400.jpg?1721805735"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
-      "name": "Ignition FBTC",
-      "symbol": "FBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39182/thumb/FBTC_LOGO.png?1720850455"
-    },
-    {
-      "chainId": 1,
-      "address": "0x986ee2b944c42d017f52af21c4c69b84dbea35d8",
-      "name": "BitMart",
-      "symbol": "BMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5236/thumb/bitmart-token.png?1696505741"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaa247c0d81b83812e1abf8bab078e4540d87e3fb",
-      "name": "Meson Network",
-      "symbol": "MSN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34981/thumb/meson-token-icon200.png?1714275908"
-    },
-    {
-      "chainId": 1,
-      "address": "0x42726d074bba68ccc15200442b72afa2d495a783",
-      "name": "Isiklar Coin",
-      "symbol": "ISIKC",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/10992/thumb/logo_%2866%29.png?1696510941"
+      "logoURI": "https://assets.coingecko.com/coins/images/31022/large/NVoa_mZ6_400x400.jpg?1721805735"
     },
     {
       "chainId": 1,
@@ -3600,119 +3576,39 @@
       "name": "Shrapnel",
       "symbol": "SHRAP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32793/thumb/shrapnel.png?1699441661"
+      "logoURI": "https://assets.coingecko.com/coins/images/32793/large/shrapnel.png?1699441661"
     },
     {
       "chainId": 1,
-      "address": "0xfe39c384d702914127a005523f9915addb9bd59b",
-      "name": "Hippocrat",
-      "symbol": "HPO",
+      "address": "0x986ee2b944c42d017f52af21c4c69b84dbea35d8",
+      "name": "BitMart",
+      "symbol": "BMX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4243/thumb/Hippocrat_Token_Logo_ver.1.0.jpg?1707157531"
+      "logoURI": "https://assets.coingecko.com/coins/images/5236/large/bitmart-token.png?1696505741"
     },
     {
       "chainId": 1,
-      "address": "0x2a414884a549ef5716bc1a4e648d3dc03f08b2cf",
-      "name": "PERQ",
-      "symbol": "PERQ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51486/thumb/coin-gecko-200.png?1731405387"
-    },
-    {
-      "chainId": 1,
-      "address": "0x549020a9cb845220d66d3e9c6d9f9ef61c981102",
-      "name": "Sidus",
-      "symbol": "SIDUS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21401/thumb/SIDUS_coin_logo.png?1696520765"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4123a133ae3c521fd134d7b13a2dec35b56c2463",
-      "name": "Open Custody Protocol",
-      "symbol": "OPEN",
+      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
+      "name": "Ignition FBTC",
+      "symbol": "FBTC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/17541/thumb/OPEN-Token-Black.png?1712837762"
+      "logoURI": "https://assets.coingecko.com/coins/images/39182/large/FBTC_LOGO.png?1720850455"
     },
     {
       "chainId": 1,
-      "address": "0xb31ef9e52d94d4120eb44fe1ddfde5b4654a6515",
-      "name": "DOSE",
-      "symbol": "DOSE",
+      "address": "0xaa247c0d81b83812e1abf8bab078e4540d87e3fb",
+      "name": "Meson Network",
+      "symbol": "MSN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18847/thumb/dose.PNG?1696518308"
+      "logoURI": "https://assets.coingecko.com/coins/images/34981/large/meson-token-icon200.png?1714275908"
     },
     {
       "chainId": 1,
-      "address": "0x33349b282065b0284d756f0577fb39c158f935e6",
-      "name": "Maple",
-      "symbol": "MPL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14097/thumb/Maple_Logo_Mark_Maple_Orange.png?1696513819"
-    },
-    {
-      "chainId": 1,
-      "address": "0x15700b564ca08d9439c58ca5053166e8317aa138",
-      "name": "Elixir deUSD",
-      "symbol": "DEUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39494/thumb/deUSD_Logo_%281%29.png?1723689002"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdab396ccf3d84cf2d07c4454e10c8a6f5b008d2b",
-      "name": "Goldfinch",
-      "symbol": "GFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19081/thumb/GOLDFINCH.png?1696518531"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd0a6053f087e87a25dc60701ba6e663b1a548e85",
-      "name": "BLOCKLORDS",
-      "symbol": "LRDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34775/thumb/LRDS_PNG.png?1706001771"
-    },
-    {
-      "chainId": 1,
-      "address": "0x839e71613f9aa06e5701cf6de63e303616b0dde3",
-      "name": "VVS Finance",
-      "symbol": "VVS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20210/thumb/8glAYOTM_400x400.jpg?1696519620"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb6667b04cb61aa16b59617f90ffa068722cf21da",
-      "name": "Worldwide USD",
-      "symbol": "WUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35358/thumb/WUSD%282%29.png?1715042139"
-    },
-    {
-      "chainId": 1,
-      "address": "0x68bbed6a47194eff1cf514b50ea91895597fc91e",
-      "name": "ANDY ETH",
-      "symbol": "ANDY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35910/thumb/IMG_20240309_044840_797.jpg?1710179397"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa469b7ee9ee773642b3e93e842e5d9b5baa10067",
-      "name": "Anzen USDz",
-      "symbol": "USDZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38039/thumb/usdz-image-200x200.png?1716334412"
-    },
-    {
-      "chainId": 1,
-      "address": "0x64d0f55cd8c7133a9d7102b13987235f486f2224",
-      "name": "SwissBorg",
-      "symbol": "BORG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2117/thumb/YJUrRy7r_400x400.png?1696503083"
+      "address": "0x42726d074bba68ccc15200442b72afa2d495a783",
+      "name": "Isiklar Coin",
+      "symbol": "ISIKC",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/10992/large/logo_%2866%29.png?1696510941"
     },
     {
       "chainId": 1,
@@ -3720,231 +3616,111 @@
       "name": "Sweat Economy",
       "symbol": "SWEAT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25057/thumb/fhD9Xs16_400x400.jpg?1696524208"
+      "logoURI": "https://assets.coingecko.com/coins/images/25057/large/fhD9Xs16_400x400.jpg?1696524208"
     },
     {
       "chainId": 1,
-      "address": "0xd7efb00d12c2c13131fd319336fdf952525da2af",
-      "name": "XPR Network",
-      "symbol": "XPR",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/10941/thumb/XPR.jpg?1696510891"
-    },
-    {
-      "chainId": 1,
-      "address": "0x89d584a1edb3a70b3b07963f9a3ea5399e38b136",
-      "name": "AIT Protocol",
-      "symbol": "AIT",
+      "address": "0xfe39c384d702914127a005523f9915addb9bd59b",
+      "name": "Hippocrat",
+      "symbol": "HPO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33962/thumb/ait-logo-200x200.png?1703567800"
+      "logoURI": "https://assets.coingecko.com/coins/images/4243/large/Hippocrat_Token_Logo_ver.1.0.jpg?1707157531"
     },
     {
       "chainId": 1,
-      "address": "0x046eee2cc3188071c02bfc1745a6b17c656e3f3d",
-      "name": "Rollbit Coin",
-      "symbol": "RLB",
+      "address": "0x2a414884a549ef5716bc1a4e648d3dc03f08b2cf",
+      "name": "PERQ",
+      "symbol": "PERQ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24552/thumb/unziL6wO_400x400.jpg?1696523729"
+      "logoURI": "https://assets.coingecko.com/coins/images/51486/large/coin-gecko-200.png?1731405387"
     },
     {
       "chainId": 1,
-      "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
-      "name": "Harvest Finance",
-      "symbol": "FARM",
+      "address": "0x549020a9cb845220d66d3e9c6d9f9ef61c981102",
+      "name": "Sidus",
+      "symbol": "SIDUS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/FARM_200x200.png?1696512134"
+      "logoURI": "https://assets.coingecko.com/coins/images/21401/large/SIDUS_coin_logo.png?1696520765"
     },
     {
       "chainId": 1,
-      "address": "0x2c974b2d0ba1716e644c1fc59982a89ddd2ff724",
-      "name": "Viberate",
-      "symbol": "VIB",
+      "address": "0xb31ef9e52d94d4120eb44fe1ddfde5b4654a6515",
+      "name": "DOSE",
+      "symbol": "DOSE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/983/thumb/Viberate.png?1696502096"
+      "logoURI": "https://assets.coingecko.com/coins/images/18847/large/dose.PNG?1696518308"
     },
     {
       "chainId": 1,
-      "address": "0x44709a920fccf795fbc57baa433cc3dd53c44dbe",
-      "name": "DappRadar",
-      "symbol": "RADAR",
+      "address": "0x4123a133ae3c521fd134d7b13a2dec35b56c2463",
+      "name": "Open Custody Protocol",
+      "symbol": "OPEN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17541/large/OPEN-Token-Black.png?1712837762"
+    },
+    {
+      "chainId": 1,
+      "address": "0x33349b282065b0284d756f0577fb39c158f935e6",
+      "name": "Maple",
+      "symbol": "MPL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20894/thumb/radar.png?1696520286"
+      "logoURI": "https://assets.coingecko.com/coins/images/14097/large/Maple_Logo_Mark_Maple_Orange.png?1696513819"
     },
     {
       "chainId": 1,
-      "address": "0x525a8f6f3ba4752868cde25164382bfbae3990e1",
-      "name": "Nym",
-      "symbol": "NYM",
+      "address": "0x15700b564ca08d9439c58ca5053166e8317aa138",
+      "name": "Elixir deUSD",
+      "symbol": "DEUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39494/large/deUSD_Logo_%281%29.png?1723689002"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd0a6053f087e87a25dc60701ba6e663b1a548e85",
+      "name": "BLOCKLORDS",
+      "symbol": "LRDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34775/large/LRDS_PNG.png?1706001771"
+    },
+    {
+      "chainId": 1,
+      "address": "0x839e71613f9aa06e5701cf6de63e303616b0dde3",
+      "name": "VVS Finance",
+      "symbol": "VVS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20210/large/8glAYOTM_400x400.jpg?1696519620"
+    },
+    {
+      "chainId": 1,
+      "address": "0x68bbed6a47194eff1cf514b50ea91895597fc91e",
+      "name": "ANDY ETH",
+      "symbol": "ANDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35910/large/IMG_20240309_044840_797.jpg?1710179397"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb6667b04cb61aa16b59617f90ffa068722cf21da",
+      "name": "Worldwide USD",
+      "symbol": "WUSD",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/24488/thumb/NYM_Token.png?1696523668"
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
     },
     {
       "chainId": 1,
-      "address": "0x0763fdccf1ae541a5961815c0872a8c5bc6de4d7",
-      "name": "SUKU",
-      "symbol": "SUKU",
+      "address": "0x64d0f55cd8c7133a9d7102b13987235f486f2224",
+      "name": "SwissBorg",
+      "symbol": "BORG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/suku-200.png?1696511828"
+      "logoURI": "https://assets.coingecko.com/coins/images/2117/large/YJUrRy7r_400x400.png?1696503083"
     },
     {
       "chainId": 1,
-      "address": "0xc52c326331e9ce41f04484d3b5e5648158028804",
-      "name": "Unizen",
-      "symbol": "ZCX",
+      "address": "0xa469b7ee9ee773642b3e93e842e5d9b5baa10067",
+      "name": "Anzen USDz",
+      "symbol": "USDZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14830/thumb/logo128px.png?1700169101"
-    },
-    {
-      "chainId": 1,
-      "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
-      "name": "dForce",
-      "symbol": "DF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9709/thumb/xlGxxIjI_400x400.jpg?1696509776"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb4a3b0faf0ab53df58001804dda5bfc6a3d59008",
-      "name": "Sperax",
-      "symbol": "SPA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12232/thumb/sperax_logo.jpg?1696512065"
-    },
-    {
-      "chainId": 1,
-      "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
-      "name": "Gemini Dollar",
-      "symbol": "GUSD",
-      "decimals": 2,
-      "logoURI": "https://assets.coingecko.com/coins/images/5992/thumb/gemini-dollar-gusd.png?1696506408"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf951e335afb289353dc249e82926178eac7ded78",
-      "name": "Swell Ethereum",
-      "symbol": "SWETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30326/thumb/_lB7zEtS_400x400.jpg?1696529227"
-    },
-    {
-      "chainId": 1,
-      "address": "0x590f820444fa3638e022776752c5eef34e2f89a6",
-      "name": "Alephium",
-      "symbol": "ALPH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21598/thumb/Alephium-Logo_200x200_listing.png?1696520959"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf19308f923582a6f7c465e5ce7a9dc1bec6665b1",
-      "name": "TitanX",
-      "symbol": "TITANX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32762/thumb/TitanXpng_%281%29.png?1704456654"
-    },
-    {
-      "chainId": 1,
-      "address": "0x174c47d6a4e548ed2b7d369dc0ffb2e60a6ac0f8",
-      "name": "Amulet Protocol",
-      "symbol": "AMU",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/34716/thumb/AMT200x200.png?1705904544"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0305f515fa978cf87226cf8a9776d25bcfb2cc0b",
-      "name": "Pepe 2 0",
-      "symbol": "PEPE20",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30853/thumb/PEPE_2.0.png?1707684909"
-    },
-    {
-      "chainId": 1,
-      "address": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
-      "name": "Staked USD0",
-      "symbol": "USD0++",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39169/thumb/0x35d8949372d46b7a3d5a56006ae77b215fc69bc0.png?1720798057"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8be3460a480c80728a8c4d7a5d5303c85ba7b3b9",
-      "name": "Ethena Staked ENA",
-      "symbol": "SENA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50235/thumb/ena.png?1726630994"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3a856d4effa670c54585a5d523e96513e148e95d",
-      "name": "TriasLab",
-      "symbol": "TRIAS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13963/thumb/5ELqtwp__400x400_%281%29.jpg?1696513699"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfc4b4ec763722b71eb1d729749b447a9645f5f30",
-      "name": "DumbMoney",
-      "symbol": "GME",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/32058/thumb/DumbMoney_-_GME_-_Official_Logo_200x200px.png?1696530855"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc581b735a1688071a1746c968e0798d642ede491",
-      "name": "Euro Tether",
-      "symbol": "EURT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17385/thumb/Tether_new.png?1696516934"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbb6cf73a00f480d0951ba979a7606857cdde626b",
-      "name": "Arix",
-      "symbol": "ARIX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13485/thumb/ARIX.png?1696513245"
-    },
-    {
-      "chainId": 1,
-      "address": "0xccc8cb5229b0ac8069c51fd58367fd1e622afd97",
-      "name": "Gods Unchained",
-      "symbol": "GODS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17139/thumb/10631.png?1696516698"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0921799cb1d702148131024d18fcde022129dc73",
-      "name": "LightLink",
-      "symbol": "LL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35357/thumb/lightlink-ticker-200.png?1708362303"
-    },
-    {
-      "chainId": 1,
-      "address": "0xda987c655ebc38c801db64a8608bc1aa56cd9a31",
-      "name": "Synternet",
-      "symbol": "SYNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38888/thumb/_SYNT.png?1719380207"
-    },
-    {
-      "chainId": 1,
-      "address": "0x046bad07658f3b6cad9a396cfcbc1243af452ec1",
-      "name": "ArchLoot",
-      "symbol": "AL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28919/thumb/7.png?1696527894"
-    },
-    {
-      "chainId": 1,
-      "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
-      "name": "AirSwap",
-      "symbol": "AST",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1696502130"
+      "logoURI": "https://assets.coingecko.com/coins/images/38039/large/usdz-image-200x200.png?1716334412"
     },
     {
       "chainId": 1,
@@ -3952,7 +3728,239 @@
       "name": "Coupon Assets",
       "symbol": "CA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32202/thumb/ca.jpg?1696746380"
+      "logoURI": "https://assets.coingecko.com/coins/images/32202/large/ca.jpg?1696746380"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd7efb00d12c2c13131fd319336fdf952525da2af",
+      "name": "XPR Network",
+      "symbol": "XPR",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/10941/large/XPR.jpg?1696510891"
+    },
+    {
+      "chainId": 1,
+      "address": "0x89d584a1edb3a70b3b07963f9a3ea5399e38b136",
+      "name": "AIT Protocol",
+      "symbol": "AIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33962/large/ait-logo-200x200.png?1703567800"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdab396ccf3d84cf2d07c4454e10c8a6f5b008d2b",
+      "name": "Goldfinch",
+      "symbol": "GFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19081/large/GOLDFINCH.png?1696518531"
+    },
+    {
+      "chainId": 1,
+      "address": "0x046eee2cc3188071c02bfc1745a6b17c656e3f3d",
+      "name": "Rollbit Coin",
+      "symbol": "RLB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24552/large/unziL6wO_400x400.jpg?1696523729"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2c974b2d0ba1716e644c1fc59982a89ddd2ff724",
+      "name": "Viberate",
+      "symbol": "VIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/983/large/Viberate.png?1696502096"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
+      "name": "Harvest Finance",
+      "symbol": "FARM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12304/large/FARM_200x200.png?1696512134"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44709a920fccf795fbc57baa433cc3dd53c44dbe",
+      "name": "DappRadar",
+      "symbol": "RADAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20894/large/radar.png?1696520286"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0763fdccf1ae541a5961815c0872a8c5bc6de4d7",
+      "name": "SUKU",
+      "symbol": "SUKU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11969/large/suku-200.png?1696511828"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc52c326331e9ce41f04484d3b5e5648158028804",
+      "name": "Unizen",
+      "symbol": "ZCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14830/large/logo128px.png?1700169101"
+    },
+    {
+      "chainId": 1,
+      "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
+      "name": "dForce",
+      "symbol": "DF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9709/large/xlGxxIjI_400x400.jpg?1696509776"
+    },
+    {
+      "chainId": 1,
+      "address": "0x590f820444fa3638e022776752c5eef34e2f89a6",
+      "name": "Alephium",
+      "symbol": "ALPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21598/large/Alephium-Logo_200x200_listing.png?1696520959"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb4a3b0faf0ab53df58001804dda5bfc6a3d59008",
+      "name": "Sperax",
+      "symbol": "SPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12232/large/sperax_logo.jpg?1696512065"
+    },
+    {
+      "chainId": 1,
+      "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
+      "name": "Gemini Dollar",
+      "symbol": "GUSD",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/5992/large/gemini-dollar-gusd.png?1696506408"
+    },
+    {
+      "chainId": 1,
+      "address": "0x525a8f6f3ba4752868cde25164382bfbae3990e1",
+      "name": "Nym",
+      "symbol": "NYM",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24488/large/NYM_Token.png?1696523668"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf951e335afb289353dc249e82926178eac7ded78",
+      "name": "Swell Ethereum",
+      "symbol": "SWETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30326/large/_lB7zEtS_400x400.jpg?1696529227"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf19308f923582a6f7c465e5ce7a9dc1bec6665b1",
+      "name": "TitanX",
+      "symbol": "TITANX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32762/large/TitanXpng_%281%29.png?1704456654"
+    },
+    {
+      "chainId": 1,
+      "address": "0x174c47d6a4e548ed2b7d369dc0ffb2e60a6ac0f8",
+      "name": "Amulet Protocol",
+      "symbol": "AMU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/34716/large/AMT200x200.png?1705904544"
+    },
+    {
+      "chainId": 1,
+      "address": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
+      "name": "Staked USD0",
+      "symbol": "USD0++",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39169/large/0x35d8949372d46b7a3d5a56006ae77b215fc69bc0.png?1720798057"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0305f515fa978cf87226cf8a9776d25bcfb2cc0b",
+      "name": "Pepe 2 0",
+      "symbol": "PEPE20",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30853/large/PEPE_2.0.png?1707684909"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3a856d4effa670c54585a5d523e96513e148e95d",
+      "name": "TriasLab",
+      "symbol": "TRIAS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13963/large/5ELqtwp__400x400_%281%29.jpg?1696513699"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8be3460a480c80728a8c4d7a5d5303c85ba7b3b9",
+      "name": "Ethena Staked ENA",
+      "symbol": "SENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50235/large/ena.png?1726630994"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc581b735a1688071a1746c968e0798d642ede491",
+      "name": "Euro Tether",
+      "symbol": "EURT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17385/large/Tether_new.png?1696516934"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0921799cb1d702148131024d18fcde022129dc73",
+      "name": "LightLink",
+      "symbol": "LL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35357/large/lightlink-ticker-200.png?1708362303"
+    },
+    {
+      "chainId": 1,
+      "address": "0xccc8cb5229b0ac8069c51fd58367fd1e622afd97",
+      "name": "Gods Unchained",
+      "symbol": "GODS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17139/large/10631.png?1696516698"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbb6cf73a00f480d0951ba979a7606857cdde626b",
+      "name": "Arix",
+      "symbol": "ARIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13485/large/ARIX.png?1696513245"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfc4b4ec763722b71eb1d729749b447a9645f5f30",
+      "name": "DumbMoney",
+      "symbol": "GME",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32058/large/DumbMoney_-_GME_-_Official_Logo_200x200px.png?1696530855"
+    },
+    {
+      "chainId": 1,
+      "address": "0xda987c655ebc38c801db64a8608bc1aa56cd9a31",
+      "name": "Synternet",
+      "symbol": "SYNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38888/large/_SYNT.png?1719380207"
+    },
+    {
+      "chainId": 1,
+      "address": "0x046bad07658f3b6cad9a396cfcbc1243af452ec1",
+      "name": "ArchLoot",
+      "symbol": "AL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28919/large/7.png?1696527894"
+    },
+    {
+      "chainId": 1,
+      "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
+      "name": "AirSwap",
+      "symbol": "AST",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/1019/large/Airswap.png?1696502130"
     },
     {
       "chainId": 1,
@@ -3960,7 +3968,7 @@
       "name": "UPCX",
       "symbol": "UPC",
       "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/33308/thumb/02_UPC_logo_RGB_black_200_200.png?1701409035"
+      "logoURI": "https://assets.coingecko.com/coins/images/33308/large/02_UPC_logo_RGB_black_200_200.png?1701409035"
     },
     {
       "chainId": 1,
@@ -3968,7 +3976,7 @@
       "name": "Seedify fund",
       "symbol": "SFUND",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14614/thumb/Favicon_Icon.png?1696514292"
+      "logoURI": "https://assets.coingecko.com/coins/images/14614/large/Favicon_Icon.png?1696514292"
     },
     {
       "chainId": 1,
@@ -3976,31 +3984,7 @@
       "name": "MongCoin",
       "symbol": "MONG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30051/thumb/BrandMark.png?1721838570"
-    },
-    {
-      "chainId": 1,
-      "address": "0x939069722d568b5498ccba4356e800eaefefd2a5",
-      "name": "Finanx AI",
-      "symbol": "FNXAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51119/thumb/200x200.png?1730126766"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7fd4d7737597e7b4ee22acbf8d94362343ae0a79",
-      "name": "Wrapped MistCoin",
-      "symbol": "WMC",
-      "decimals": 2,
-      "logoURI": "https://assets.coingecko.com/coins/images/32490/thumb/355966EE-F4AD-4023-A38E-59B9DEF1C6C3.jpeg?1732678326"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6a9b3fdb4a3296ecba1ebfa2cf4a8b16032a769c",
-      "name": "bitSmiley",
-      "symbol": "SMILE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51309/thumb/Copy_of_Token_icon_White_background.png?1730635535"
+      "logoURI": "https://assets.coingecko.com/coins/images/30051/large/BrandMark.png?1721838570"
     },
     {
       "chainId": 1,
@@ -4008,8 +3992,24 @@
       "name": "Boson Protocol",
       "symbol": "BOSON",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14710/thumb/boson_logo.png?1696514381"
+      "logoURI": "https://assets.coingecko.com/coins/images/14710/large/boson_logo.png?1696514381"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0b7f0e51cd1739d6c96982d55ad8fa634dd43a9c",
+      "name": "Dream Machine Token",
+      "symbol": "DMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30505/large/dmt.png?1696529391"
+    },
+    {
+      "chainId": 1,
+      "address": "0x939069722d568b5498ccba4356e800eaefefd2a5",
+      "name": "Finanx AI",
+      "symbol": "FNXAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51119/large/200x200.png?1730126766"
     }
   ],
-  "timestamp": "2024-12-06T16:10:22.555Z"
+  "timestamp": "2024-12-06T16:14:59.826Z"
 }

--- a/src/public/CoinGecko.1.json
+++ b/src/public/CoinGecko.1.json
@@ -1,0 +1,4015 @@
+{
+  "name": "Coingecko top 500 on ethereum",
+  "logoURI": "https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png",
+  "keywords": [
+    "defi"
+  ],
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 1,
+      "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      "name": "Tether",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/325/thumb/Tether.png?1696501661"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "name": "USDC",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/6319/thumb/usdc.png?1696506694"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc5f0f7b66764f6ec8c8dff7ba683102295e16409",
+      "name": "First Digital USD",
+      "symbol": "FDUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31079/thumb/FDUSD_icon_black.png?1731097953"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6982508145454ce325ddbe47a25d4ec3d2311933",
+      "name": "Pepe",
+      "symbol": "PEPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29850/thumb/pepe-token.jpeg?1696528776"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb8c77482e45f1f44de1745f52c74426c631bdd52",
+      "name": "BNB",
+      "symbol": "BNB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/825/thumb/bnb-icon2_2x.png?1696501970"
+    },
+    {
+      "chainId": 1,
+      "address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+      "name": "Shiba Inu",
+      "symbol": "SHIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1696511800"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7420b4b9a0110cdc71fb720908340c03f9bc03ec",
+      "name": "JasmyCoin",
+      "symbol": "JASMY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1696513620"
+    },
+    {
+      "chainId": 1,
+      "address": "0x163f8c2467924be0ae7b5347228cabf260318753",
+      "name": "Worldcoin",
+      "symbol": "WLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31069/thumb/worldcoin.jpeg?1696529903"
+    },
+    {
+      "chainId": 1,
+      "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+      "name": "Chainlink",
+      "symbol": "LINK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/877/thumb/chainlink-new-logo.png?1696502009"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+      "name": "Curve DAO",
+      "symbol": "CRV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12124/thumb/Curve.png?1696511967"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "name": "WETH",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2518/thumb/weth.png?1696503332"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      "name": "Uniswap",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12504/thumb/uniswap-logo.png?1720676669"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaea46a60368a7bd060eec7df8cba43b7ef41ad85",
+      "name": "Artificial Superintelligence Alliance",
+      "symbol": "FET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/ASI.png?1719827289"
+    },
+    {
+      "chainId": 1,
+      "address": "0x85f17cf997934a597031b2e18a9ab6ebd4b9f6a4",
+      "name": "NEAR Protocol",
+      "symbol": "NEAR",
+      "decimals": 24,
+      "logoURI": "https://assets.coingecko.com/coins/images/10365/thumb/near.jpg?1696510367"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1",
+      "name": "Arbitrum",
+      "symbol": "ARB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16547/thumb/arb.jpg?1721358242"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa3ee21c306a700e682abcdfe9baa6a08f3820419",
+      "name": "Creditcoin",
+      "symbol": "CTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10569/thumb/ctc.png?1696510552"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+      "name": "0x Protocol",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/863/thumb/0x.png?1696501996"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+      "name": "The Sandbox",
+      "symbol": "SAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1696511971"
+    },
+    {
+      "chainId": 1,
+      "address": "0x57e114b691db790c35207b2e685d4a43181e6061",
+      "name": "Ethena",
+      "symbol": "ENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36530/thumb/ethena.png?1711701436"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
+      "name": "Render",
+      "symbol": "RENDER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1696511529"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd1d2eb1b1e90b638588728b4130137d262c87cae",
+      "name": "GALA",
+      "symbol": "GALA",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12493/thumb/GALA_token_image_-_200PNG.png?1709725869"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+      "name": "Aave",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/aave-token-round.png?1720472354"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "name": "LayerZero",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/thumb/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1151cb3d861920e07a38e03eead12c32178567f6",
+      "name": "Bonk",
+      "symbol": "BONK",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28600/thumb/bonk.jpg?1696527587"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+      "name": "Ethereum Name Service",
+      "symbol": "ENS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/ENS.jpg?1727872989"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      "name": "Wrapped Bitcoin",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/7598/thumb/wrapped_bitcoin_wbtc.png?1696507857"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+      "name": "Coinbase Wrapped BTC",
+      "symbol": "CBBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/thumb/cbbtc.webp?1726136727"
+    },
+    {
+      "chainId": 1,
+      "address": "0x582d872a1b094fc48f5de31d3b73f2d9be47def1",
+      "name": "Toncoin",
+      "symbol": "TON",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17980/thumb/photo_2024-09-10_17.09.00.jpeg?1725963446"
+    },
+    {
+      "chainId": 1,
+      "address": "0x92d6c1e31e14520e676a687f0a93788b716beff5",
+      "name": "dYdX",
+      "symbol": "ETHDYDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1696517040"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe28b3b32b6c345a34ff64674606124dd5aceca30",
+      "name": "Injective",
+      "symbol": "INJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1696512670"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
+      "name": "FLOKI",
+      "symbol": "FLOKI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16746/thumb/PNG_image.png?1696516318"
+    },
+    {
+      "chainId": 1,
+      "address": "0x58b6a8a3302369daec383334672404ee733ab239",
+      "name": "Livepeer",
+      "symbol": "LPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/badge-logo-circuit-green.png?1719357686"
+    },
+    {
+      "chainId": 1,
+      "address": "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
+      "name": "POL  ex MATIC ",
+      "symbol": "POL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32440/thumb/polygon.png?1698233684"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfe0c30065b384f05761f15d0cc899d4f9f9cc0eb",
+      "name": "Ether fi",
+      "symbol": "ETHFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35958/thumb/etherfi.jpeg?1710254562"
+    },
+    {
+      "chainId": 1,
+      "address": "0x579cea1889991f68acc35ff5c3dd0621ff29b0c9",
+      "name": "IQ",
+      "symbol": "IQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5010/thumb/YAIS3fUh.png?1696505542"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfaba6f8e4a5e8ab82f62fe7c39859fa577269be3",
+      "name": "Ondo",
+      "symbol": "ONDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26580/thumb/ONDO.png?1696525656"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+      "name": "Lido DAO",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1696513326"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4d224452801aced8b2f0aebe155379bb5d594381",
+      "name": "ApeCoin",
+      "symbol": "APE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24383/thumb/apecoin.jpg?1696523566"
+    },
+    {
+      "chainId": 1,
+      "address": "0x812ba41e071c7b7fa4ebcfb62df5f45f6fa853ee",
+      "name": "Neiro",
+      "symbol": "NEIRO",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/39488/thumb/neiro.jpg?1731449567"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
+      "name": "Eigenlayer",
+      "symbol": "EIGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37441/thumb/eigen.jpg?1728023974"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+      "name": "Decentraland",
+      "symbol": "MANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1696502010"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e2a43be0b1d33b726f0ca3b8de60b3482b8b050",
+      "name": "Arkham",
+      "symbol": "ARKM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30929/thumb/Arkham_Logo_CG.png?1696529771"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3506424f91fd33084466f402d5d97f05f8e3b4af",
+      "name": "Chiliz",
+      "symbol": "CHZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8834/thumb/CHZ_Token_updated.png?1696508986"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+      "name": "The Graph",
+      "symbol": "GRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1696513159"
+    },
+    {
+      "chainId": 1,
+      "address": "0x320623b8e4ff03373931769a31fc52a4e78b5d70",
+      "name": "Reserve Rights",
+      "symbol": "RSR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8365/thumb/RSR_Blue_Circle_1000.png?1721777856"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaaee1a9723aadb7afa2810263653a34ba2c21c7a",
+      "name": "Mog Coin",
+      "symbol": "MOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31059/thumb/MOG_LOGO_200x200.png?1696529893"
+    },
+    {
+      "chainId": 1,
+      "address": "0x58d97b57bb95320f9a05dc918aef65434969c2b2",
+      "name": "Morpho",
+      "symbol": "MORPHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29837/thumb/Morpho-token-icon.png?1726771230"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb0ffa8000886e57f86dd5264b9582b2ad87b2b91",
+      "name": "Wormhole",
+      "symbol": "W",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35087/thumb/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
+    },
+    {
+      "chainId": 1,
+      "address": "0xca14007eff0db1f8135f4c25b34de49ab0d42766",
+      "name": "Starknet",
+      "symbol": "STRK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26433/thumb/starknet.png?1696525507"
+    },
+    {
+      "chainId": 1,
+      "address": "0x152649ea73beab28c5b49b26eb48f7ead6d4c898",
+      "name": "PancakeSwap",
+      "symbol": "CAKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12632/thumb/pancakeswap-cake-logo_%281%29.png?1696512440"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+      "name": "Compound",
+      "symbol": "COMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10775/thumb/COMP.png?1696510737"
+    },
+    {
+      "chainId": 1,
+      "address": "0x50327c6c5a14dcade707abad2e27eb517df87ab5",
+      "name": "Wrapped Tron",
+      "symbol": "WTRX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22471/thumb/xOesRfpN_400x400.jpg?1696521795"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb528edbef013aff855ac3c50b381f253af13b997",
+      "name": "Aevo",
+      "symbol": "AEVO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35893/thumb/aevo.png?1710138340"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44ff8620b8ca30902395a7bd3f2407e1a091bf73",
+      "name": "Virtuals Protocol",
+      "symbol": "VIRTUAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34057/thumb/LOGOMARK.png?1708356054"
+    },
+    {
+      "chainId": 1,
+      "address": "0x808507121b80c02388fad14726482e061b8da827",
+      "name": "Pendle",
+      "symbol": "PENDLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15069/thumb/Pendle_Logo_Normal-03.png?1696514728"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
+      "name": "Ethena USDe",
+      "symbol": "USDE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33613/thumb/USDE.png?1716355685"
+    },
+    {
+      "chainId": 1,
+      "address": "0x54d2252757e1672eead234d27b1270728ff90581",
+      "name": "Bitget Token",
+      "symbol": "BGB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11610/thumb/icon_colour.png?1696511504"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1f57da732a77636d913c9a75d685b26cc85dcc3a",
+      "name": "OPENLOOT",
+      "symbol": "OL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51801/thumb/_OPENLOOT_token-icon_black_%282%29.png?1731989426"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+      "name": "Across Protocol",
+      "symbol": "ACX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/thumb/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+      "name": "Sushi",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1696512101"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3c3a81e81dc49a522a592e7622a7e711c06bf354",
+      "name": "Mantle",
+      "symbol": "MNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30980/thumb/token-logo.png?1696529819"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7a58c0be72be218b41c608b7fe7c5bb630736c71",
+      "name": "ConstitutionDAO",
+      "symbol": "PEOPLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20612/thumb/GN_UVm3d_400x400.jpg?1696520017"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa35923162c49cf95e6bf26623385eb431ad920d3",
+      "name": "Turbo",
+      "symbol": "TURBO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30117/thumb/TurboMark-QL_200.png?1708079597"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8290333cef9e6d528dd5618fb97a76f268f3edd4",
+      "name": "Ankr Network",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1696504928"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+      "name": "Axie Infinity",
+      "symbol": "AXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1696512817"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+      "name": "Maker",
+      "symbol": "MKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1364/thumb/Mark_Maker.png?1696502423"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb131f4a55907b10d1f0a50d8ab8fa09ec342cd74",
+      "name": "Memecoin",
+      "symbol": "MEME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32528/thumb/memecoin_%282%29.png?1698912168"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+      "name": "yearn finance",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yearn.jpg?1696511720"
+    },
+    {
+      "chainId": 1,
+      "address": "0x69af81e73a73b40adf4f3d4223cd9b1ece623074",
+      "name": "Mask Network",
+      "symbol": "MASK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1696513776"
+    },
+    {
+      "chainId": 1,
+      "address": "0x111111111117dc0aa78b770fa6a738034120c302",
+      "name": "1inch",
+      "symbol": "1INCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1696513230"
+    },
+    {
+      "chainId": 1,
+      "address": "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9",
+      "name": "FTX",
+      "symbol": "FTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9026/thumb/F.png?1696509161"
+    },
+    {
+      "chainId": 1,
+      "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
+      "name": "Tellor Tributes",
+      "symbol": "TRB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1696509713"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+      "name": "Dai",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9956/thumb/Badge_Dai.png?1696509996"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf57e7e7c23978c3caec3c3548e3d615c346e79ff",
+      "name": "Immutable",
+      "symbol": "IMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/immutableX-symbol-BLK-RGB.png?1696516787"
+    },
+    {
+      "chainId": 1,
+      "address": "0xff20817765cb7f73d4bde2e66e067e58d11095c2",
+      "name": "Amp",
+      "symbol": "AMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1696512231"
+    },
+    {
+      "chainId": 1,
+      "address": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
+      "name": "Yield Guild Games",
+      "symbol": "YGG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5283d291dbcf85356a21ba090e6db59121208b44",
+      "name": "Blur",
+      "symbol": "BLUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28453/thumb/blur.png?1696527448"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2dff88a56767223a5529ea5960da7a3f5f766406",
+      "name": "SPACE ID",
+      "symbol": "ID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29468/thumb/sid_token_logo_%28green2%29.png?1696528413"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+      "name": "Synthetix Network",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3406/thumb/SNX.png?1696504103"
+    },
+    {
+      "chainId": 1,
+      "address": "0x62d0a8458ed7719fdaf978fe5929c6d342b0bfce",
+      "name": "Beam",
+      "symbol": "BEAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32417/thumb/chain-logo.png?1698114384"
+    },
+    {
+      "chainId": 1,
+      "address": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
+      "name": "Lido Staked Ether",
+      "symbol": "STETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13442/thumb/steth_logo.png?1696513206"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9d65ff81a3c488d585bbfb0bfe3c7707c7917f54",
+      "name": "SSV Network",
+      "symbol": "SSV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19155/thumb/ssv.png?1696518606"
+    },
+    {
+      "chainId": 1,
+      "address": "0x10dea67478c5f8c5e2d90e5e9b26dbe60c54d800",
+      "name": "Taiko",
+      "symbol": "TAIKO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38058/thumb/icon.png?1717626867"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+      "name": "Basic Attention",
+      "symbol": "BAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1696501867"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3593d125a4f7849a1b059e64f4517a86dd60c95d",
+      "name": "MANTRA",
+      "symbol": "OM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12151/thumb/OM_Token.png?1696511991"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4d1c297d39c5c1277964d0e3f8aa901493664530",
+      "name": "Puffer",
+      "symbol": "PUFFER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50630/thumb/PUFFER_token_Logo.png?1729574024"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1bbe973bef3a977fc51cbed703e8ffdefe001fed",
+      "name": "Portal",
+      "symbol": "PORTAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35436/thumb/portal.jpeg?1708590254"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8457ca5040ad67fdebbcc8edce889a335bc0fbfb",
+      "name": "AltLayer",
+      "symbol": "ALT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34608/thumb/Logomark_200x200.png?1715107868"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+      "name": "Wrapped stETH",
+      "symbol": "WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18834/thumb/wstETH.png?1696518295"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaedf386b755465871ff874e3e37af5976e247064",
+      "name": "Fasttoken",
+      "symbol": "FTN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28478/thumb/lightenicon_200x200.png?1696527472"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
+      "name": "Quant",
+      "symbol": "QNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1696504070"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
+      "name": "Convex Finance",
+      "symbol": "CVX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1696515221"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+      "name": "Loopring",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/913/thumb/LRC.png?1696502034"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe3c408bd53c31c085a1746af401a4042954ff740",
+      "name": "GMT",
+      "symbol": "GMT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/23597/thumb/token-gmt-200x200.png?1703153841"
+    },
+    {
+      "chainId": 1,
+      "address": "0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7",
+      "name": "SKALE",
+      "symbol": "SKL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13245/thumb/SKALE_token_300x300.png?1696513021"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfd418e42783382e86ae91e445406600ba144d162",
+      "name": "Zircuit",
+      "symbol": "ZRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35960/thumb/zircuit_token_icon_2.png?1732502352"
+    },
+    {
+      "chainId": 1,
+      "address": "0x11eef04c884e24d9b7b4760e7476d06ddf797f36",
+      "name": "MX",
+      "symbol": "MX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8545/thumb/MEXC_GLOBAL_LOGO.jpeg?1696508719"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5afe3855358e112b5647b952709e6165e1c1eeee",
+      "name": "Safe",
+      "symbol": "SAFE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27032/thumb/Artboard_1_copy_8circle-1.png?1696526084"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3429d03c6f7521aec737a0bbf2e5ddcef2c3ae31",
+      "name": "Pixels",
+      "symbol": "PIXEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35100/thumb/pixel-icon.png?1708339519"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfee293840d23b0b2de8c55e1cf7a9f01c157767c",
+      "name": "Degen  Base ",
+      "symbol": "DEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34515/thumb/android-chrome-512x512.png?1706198225"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
+      "name": "Enjin Coin",
+      "symbol": "ENJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/Symbol_Only_-_Purple.png?1709725966"
+    },
+    {
+      "chainId": 1,
+      "address": "0xed04915c23f00a313a544955524eb7dbd823143d",
+      "name": "Alchemy Pay",
+      "symbol": "ACH",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12390/thumb/ACH_%281%29.png?1696512213"
+    },
+    {
+      "chainId": 1,
+      "address": "0xddb3422497e61e13543bea06989c0789117555c5",
+      "name": "COTI",
+      "symbol": "COTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1696503705"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6fb3e0a217407efff7ca062d46c26e5d60a14d69",
+      "name": "IoTeX",
+      "symbol": "IOTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3334/thumb/Token_Icon_Token_Icon.png?1727899869"
+    },
+    {
+      "chainId": 1,
+      "address": "0xae12c5930881c53715b369cec7606b70d8eb229f",
+      "name": "Coin98",
+      "symbol": "C98",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17117/thumb/logo.png?1696516677"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9c7beba8f6ef6643abd725e45a4e8387ef260649",
+      "name": "Gravity",
+      "symbol": "G",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39200/thumb/gravity.jpg?1721020647"
+    },
+    {
+      "chainId": 1,
+      "address": "0x64bc2ca1be492be7185faa2c8835d9b824c8a194",
+      "name": "Big Time",
+      "symbol": "BIGTIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32251/thumb/-6136155493475923781_121.jpg?1696998691"
+    },
+    {
+      "chainId": 1,
+      "address": "0x32353a6c91143bfd6c7d363b546e62a9a2489a20",
+      "name": "Adventure Gold",
+      "symbol": "AGLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1696517628"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe0ed4138121ecfc5c0e56b40517da27e6c5226b",
+      "name": "Aethir",
+      "symbol": "ATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36179/thumb/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf091867ec603a6628ed83d274e835539d82e9cc8",
+      "name": "ZetaChain",
+      "symbol": "ZETA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26718/thumb/Twitter_icon.png?1696525788"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa9b1eb5908cfc3cdf91f9b8b3a74108598009096",
+      "name": "Bounce",
+      "symbol": "AUCTION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13860/thumb/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1696513606"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7dd9c5cba05e151c895fde1cf355c9a1d5da6429",
+      "name": "Golem",
+      "symbol": "GLM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/542/thumb/Golem_Submark_Positive_RGB.png?1696501761"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc669928185dbce49d2230cc9b0979be6dc797957",
+      "name": "BitTorrent",
+      "symbol": "BTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22457/thumb/btt_logo.png?1696521780"
+    },
+    {
+      "chainId": 1,
+      "address": "0x767fe9edc9e0df98e07454847909b5e959d7ca0e",
+      "name": "Illuvium",
+      "symbol": "ILV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14468/thumb/logo-200x200.png?1696514154"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
+      "name": "Holo",
+      "symbol": "HOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3348/thumb/Holologo_Profile.png?1696504052"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e15a54b5ecac17e58dadeddbe8506a7560252f9",
+      "name": "SynFutures",
+      "symbol": "F",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52186/thumb/synfutures_f_token_light_200.png?1732722899"
+    },
+    {
+      "chainId": 1,
+      "address": "0x80c62fe4487e1351b47ba49809ebd60ed085bf52",
+      "name": "Clover Finance",
+      "symbol": "CLV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15278/thumb/photo_2022-03-24_10-22-33.jpg?1696514930"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
+      "name": "WOO",
+      "symbol": "WOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+      "name": "Frax Share",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/Frax_Shares_icon.png?1696513183"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
+      "name": "Stargate Finance",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1696523595"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+      "name": "Liquity",
+      "symbol": "LQTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/logo_V2.png?1725437146"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b",
+      "name": "Cronos",
+      "symbol": "CRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/cro_token_logo.png?1696507599"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
+      "name": "TrueFi",
+      "symbol": "TRU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1696512963"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb0c7a3ba49c7a6eaba6cd4a96c55a1391070ac9a",
+      "name": "Treasure",
+      "symbol": "MAGIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18623/thumb/magic.png?1696518095"
+    },
+    {
+      "chainId": 1,
+      "address": "0x61ec85ab89377db65762e234c946b5c25a56e99e",
+      "name": "HTX DAO",
+      "symbol": "HTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35491/thumb/Frame_1321318576.png?1708908626"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe53ec727dbdeb9e2d5456c3be40cff031ab40a55",
+      "name": "SuperVerse",
+      "symbol": "SUPER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/SV-Logo-200x200.png?1706880312"
+    },
+    {
+      "chainId": 1,
+      "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
+      "name": "Status",
+      "symbol": "SNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1696501931"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+      "name": "CARV",
+      "symbol": "CARV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/thumb/CARV_%281%29.png?1728418485"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0a6e7ba5042b38349e437ec6db6214aec7b35676",
+      "name": "Swell",
+      "symbol": "SWELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28777/thumb/swell1.png?1727899715"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
+      "name": "TrueUSD",
+      "symbol": "TUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3449/thumb/tusd.png?1696504140"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8a2279d4a90b6fe1c4b30fa660cc9f926797baa2",
+      "name": "Chromia",
+      "symbol": "CHR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1696505533"
+    },
+    {
+      "chainId": 1,
+      "address": "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
+      "name": "Civic",
+      "symbol": "CVC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic-orange.png?1696501939"
+    },
+    {
+      "chainId": 1,
+      "address": "0x03dde9e5bb31ee40a471476e2fccf75c67921062",
+      "name": "EML Protocol",
+      "symbol": "EML",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30950/thumb/EML_LOGO.png?1696529788"
+    },
+    {
+      "chainId": 1,
+      "address": "0x467719ad09025fcc6cf6f8311755809d45a5e5f3",
+      "name": "Axelar",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/thumb/V-65_xQ1_400x400.jpeg?1696526329"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb23d80f5fefcddaa212212f028021b41ded428cf",
+      "name": "Echelon Prime",
+      "symbol": "PRIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/thumb/prime-logo-small-border_%282%29.png?1696528020"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcc8fa225d80b9c7d42f96e9570156c65d6caaa25",
+      "name": "Smooth Love Potion",
+      "symbol": "SLP",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/10366/thumb/SLP.png?1696510368"
+    },
+    {
+      "chainId": 1,
+      "address": "0x198d14f2ad9ce69e76ea330b374de4957c3f850a",
+      "name": "APENFT",
+      "symbol": "NFT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/15687/thumb/apenft.jpg?1696515316"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf4fb9bf10e489ea3edb03e094939341399587b0c",
+      "name": "AirDAO",
+      "symbol": "AMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1041/thumb/amb.png?1696502148"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8de5b80a0c1b02fe4976851d030b36122dbb8624",
+      "name": "Vanar Chain",
+      "symbol": "VANRY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33466/thumb/apple-touch-icon.png?1701942541"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a79324c19ef2b89ea98b23bc669b7e7c9f8a517",
+      "name": "WAX",
+      "symbol": "WAXP",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/1372/thumb/WAX_Coin_Tickers_P_512px.png?1696502430"
+    },
+    {
+      "chainId": 1,
+      "address": "0x14778860e937f509e651192a90589de711fb88a9",
+      "name": "CYBER",
+      "symbol": "CYBER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31274/thumb/token.png?1715826754"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4be10da47a07716af28ad199fbe020501bddd7af",
+      "name": "XT com",
+      "symbol": "XT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8391/thumb/20240701-155217.jpeg?1719895785"
+    },
+    {
+      "chainId": 1,
+      "address": "0x888888848b652b3e3a0f34c96e00eec0f3a23f72",
+      "name": "Alien Worlds",
+      "symbol": "TLM",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/14676/thumb/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1696514350"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
+      "name": "PayPal USD",
+      "symbol": "PYUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31212/thumb/PYUSD_Logo_%282%29.png?1696530039"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
+      "name": "EURC",
+      "symbol": "EURC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro.png?1696525125"
+    },
+    {
+      "chainId": 1,
+      "address": "0x626e8036deb333b408be468f951bdb42433cbf18",
+      "name": "AIOZ Network",
+      "symbol": "AIOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz-logo-200.png?1696514309"
+    },
+    {
+      "chainId": 1,
+      "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+      "name": "UMA",
+      "symbol": "UMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10951/thumb/UMA.png?1696510900"
+    },
+    {
+      "chainId": 1,
+      "address": "0x52a8845df664d76c69d2eea607cd793565af42b8",
+      "name": "ApeX",
+      "symbol": "APEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25266/thumb/CxpMECpk_400x400_%281%29.png?1696524406"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
+      "name": "Threshold Network",
+      "symbol": "T",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22228/thumb/nFPNiSbL_400x400.jpg?1696521570"
+    },
+    {
+      "chainId": 1,
+      "address": "0x38e68a37e401f7271568cecaac63c6b1e19130b4",
+      "name": "Banana Gun",
+      "symbol": "BANANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31744/thumb/bg-logo-coingecko-200.png?1716971024"
+    },
+    {
+      "chainId": 1,
+      "address": "0x57b946008913b82e4df85f501cbaed910e58d26c",
+      "name": "Marlin",
+      "symbol": "POND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/200x200.png?1706115827"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3b50805453023a91a8bf641e279401a0b23fa6f9",
+      "name": "Renzo",
+      "symbol": "REZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37327/thumb/renzo_200x200.png?1714025012"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
+      "name": "Numeraire",
+      "symbol": "NMR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/752/thumb/numeraire.png?1696501906"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
+      "name": "Solar",
+      "symbol": "SXP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1696509466"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6033f7f88332b8db6ad452b7c6d5bb643990ae3f",
+      "name": "Lisk",
+      "symbol": "LSK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/385/thumb/Lisk_logo.png?1722338450"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+      "name": "CoW Protocol",
+      "symbol": "COW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/thumb/CoW-token_logo.png?1719524382"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9e32b13ce7f2e80a01932b42553652e053d6ed8e",
+      "name": "Metis",
+      "symbol": "METIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/Metis_Black_Bg.png?1702968192"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
+      "name": "Storj",
+      "symbol": "STORJ",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/949/thumb/storj.png?1696502065"
+    },
+    {
+      "chainId": 1,
+      "address": "0x137ddb47ee24eaa998a535ab00378d6bfa84f893",
+      "name": "Radiant Capital",
+      "symbol": "RDNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26536/thumb/Radiant-Logo-200x200.png?1696525610"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
+      "name": "Wrapped eETH",
+      "symbol": "WEETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33033/thumb/weETH.png?1701438396"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+      "name": "Ethena Staked USDe",
+      "symbol": "SUSDE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33669/thumb/sUSDe-Symbol-Color.png?1716307680"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+      "name": "Perpetual Protocol",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
+      "name": "API3",
+      "symbol": "API3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1696513031"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa62cc35625b0c8dc1faea39d33625bb4c15bd71c",
+      "name": "StormX",
+      "symbol": "STMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1369/thumb/StormX.png?1696502427"
+    },
+    {
+      "chainId": 1,
+      "address": "0x090185f2135308bad17527004364ebcc2d37e5f6",
+      "name": "Spell",
+      "symbol": "SPELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1696515477"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
+      "name": "Biconomy",
+      "symbol": "BICO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1696520444"
+    },
+    {
+      "chainId": 1,
+      "address": "0xac51066d7bec65dc4589368da368b212745d63e8",
+      "name": "My Neighbor Alice",
+      "symbol": "ALICE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1696514067"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+      "name": "Badger",
+      "symbol": "BADGER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1696513059"
+    },
+    {
+      "chainId": 1,
+      "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+      "name": "Audius",
+      "symbol": "AUDIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1696512701"
+    },
+    {
+      "chainId": 1,
+      "address": "0xadf7c35560035944e805d98ff17d58cde2449389",
+      "name": "Spectral",
+      "symbol": "SPEC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36138/thumb/ls7wS7vf_400x400.jpg?1724975224"
+    },
+    {
+      "chainId": 1,
+      "address": "0x83f20f44975d03b1b09e64809b757c47f942beea",
+      "name": "Savings Dai",
+      "symbol": "SDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32254/thumb/sdai.png?1697015278"
+    },
+    {
+      "chainId": 1,
+      "address": "0x430ef9263e76dae63c84292c3409d61c598e9682",
+      "name": "Vulcan Forged",
+      "symbol": "PYR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14770/thumb/1617088937196.png?1696514439"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba11d00c5f74255f56a5e366f4f77f5a186d7f55",
+      "name": "Band Protocol",
+      "symbol": "BAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/Band_token_blue_violet_token.png?1696509627"
+    },
+    {
+      "chainId": 1,
+      "address": "0x940a2db1b7008b6c776d4faaca729d6d4a4aa551",
+      "name": "Dusk",
+      "symbol": "DUSK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5217/thumb/image_widget_biddfvxd454b1.png?1696505726"
+    },
+    {
+      "chainId": 1,
+      "address": "0x24fcfc492c1393274b6bcd568ac9e225bec93584",
+      "name": "Heroes of Mavia",
+      "symbol": "MAVIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33895/thumb/2023-12-20_21.21.41_%281%29.jpg?1703230771"
+    },
+    {
+      "chainId": 1,
+      "address": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd",
+      "name": "DODO",
+      "symbol": "DODO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12651/thumb/dodo_logo.png?1696512458"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
+      "name": "Celer Network",
+      "symbol": "CELR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1696504978"
+    },
+    {
+      "chainId": 1,
+      "address": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
+      "name": "AUSD",
+      "symbol": "AUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39284/thumb/Circle_Agora_White_on_Olive_1080px.png?1722961274"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdefa4e8a7bcba345f687a2f1456f5edd9ce97202",
+      "name": "Kyber Network Crystal",
+      "symbol": "KNC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14899/thumb/RwdVsGcw_400x400.jpg?1696514562"
+    },
+    {
+      "chainId": 1,
+      "address": "0x595832f8fc6bf59c85c527fec3740a1b7a361269",
+      "name": "Powerledger",
+      "symbol": "POWR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/Powerledger_Northstar_colour_digital_%282%29.png?1706702222"
+    },
+    {
+      "chainId": 1,
+      "address": "0x925206b8a707096ed26ae47c84747fe0bb734f59",
+      "name": "WhiteBIT Coin",
+      "symbol": "WBT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/27045/thumb/wbt_token.png?1696526096"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa1faa113cbe53436df28ff0aee54275c13b40975",
+      "name": "Stella",
+      "symbol": "ALPHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/Stella200x200-06.png?1696512537"
+    },
+    {
+      "chainId": 1,
+      "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
+      "name": "Radworks",
+      "symbol": "RAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1696513741"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
+      "name": "Origin Token",
+      "symbol": "OGN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1696504006"
+    },
+    {
+      "chainId": 1,
+      "address": "0x491604c0fdf08347dd1fa4ee062a822a5dd06b5d",
+      "name": "Cartesi",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/Cartesi_Logo.png?1696510982"
+    },
+    {
+      "chainId": 1,
+      "address": "0x14fee680690900ba0cccfc76ad70fd1b95d10e16",
+      "name": "PAAL AI",
+      "symbol": "PAAL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/30815/thumb/Paal_New_Logo_%281%29.png?1718160584"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
+      "name": "USDS",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39926/thumb/usds.webp?1726666683"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb3999f658c0391d94a37f7ff328f3fec942bcadc",
+      "name": "Hashflow",
+      "symbol": "HFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26136/thumb/200x200_360.png?1728551257"
+    },
+    {
+      "chainId": 1,
+      "address": "0x71ab77b7dbb4fa7e017bc15090b2163221420282",
+      "name": "Highstreet",
+      "symbol": "HIGH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18973/thumb/logosq200200Coingecko.png?1696518427"
+    },
+    {
+      "chainId": 1,
+      "address": "0xabd4c63d2616a5201454168269031355f4764337",
+      "name": "Orderly Network",
+      "symbol": "ORDER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38501/thumb/Orderly_Network_Coingecko_200*200.png?1717751359"
+    },
+    {
+      "chainId": 1,
+      "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
+      "name": "iExec RLC",
+      "symbol": "RLC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1696501840"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba50933c268f567bdc86e1ac131be072c6b0b71a",
+      "name": "ARPA",
+      "symbol": "ARPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1696508685"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd5f7838f5c461feff7fe49ea5ebaf7728bb0adfa",
+      "name": "Mantle Staked Ether",
+      "symbol": "METH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33345/thumb/symbol_transparent_bg.png?1701697066"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2e3356610840701bdf5611a53974510ae27e2e1",
+      "name": "Wrapped Beacon ETH",
+      "symbol": "WBETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30061/thumb/wbeth-icon.png?1696528983"
+    },
+    {
+      "chainId": 1,
+      "address": "0x26aad156ba8efa501b32b42ffcdc8413f90e9c99",
+      "name": "Open Campus",
+      "symbol": "EDU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29948/thumb/EDU_Logo.png?1696528874"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7da2641000cbb407c329310c461b2cb9c70c3046",
+      "name": "Delysium",
+      "symbol": "AGI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29299/thumb/AGI_logo_200.png?1696528251"
+    },
+    {
+      "chainId": 1,
+      "address": "0x55296f69f40ea6d20e478533c15a6b08b654e758",
+      "name": "XYO Network",
+      "symbol": "XYO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1696505103"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f3a12b78fee11ee088e454a0547bdbc5a253a6d",
+      "name": "Merlin Chain",
+      "symbol": "MERL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37118/thumb/merlin.jpeg?1713352230"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5cf04716ba20127f1e2297addcf4b5035000c9eb",
+      "name": "NKN",
+      "symbol": "NKN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3375/thumb/nkn.png?1696504074"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
+      "name": "Aavegotchi",
+      "symbol": "GHST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/GHST.png?1696512286"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
+      "name": "Dent",
+      "symbol": "DENT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/1152/thumb/DENT_Token.png?1718837065"
+    },
+    {
+      "chainId": 1,
+      "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
+      "name": "tBTC",
+      "symbol": "TBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4575f41308ec1483f3d399aa9a2826d74da13deb",
+      "name": "Orchid Protocol",
+      "symbol": "OXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3916/thumb/download_%285%29.png?1696504574"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+      "name": "Balancer",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1696511572"
+    },
+    {
+      "chainId": 1,
+      "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
+      "name": "OKB",
+      "symbol": "OKB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4463/thumb/WeChat_Image_20220118095654.png?1696505053"
+    },
+    {
+      "chainId": 1,
+      "address": "0x45804880de22913dafe09f4980848ece6ecbaf78",
+      "name": "PAX Gold",
+      "symbol": "PAXG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxgold.png?1696509604"
+    },
+    {
+      "chainId": 1,
+      "address": "0xac57de9c1a09fec648e93eb98875b212db0d460b",
+      "name": "Baby Doge Coin",
+      "symbol": "BABYDOGE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16125/thumb/babydoge.jpg?1696515731"
+    },
+    {
+      "chainId": 1,
+      "address": "0x081131434f93063751813c619ecca9c4dc7862a3",
+      "name": "Mines of Dalarnia",
+      "symbol": "DAR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/19837/thumb/dar.png?1696519259"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3da932456d082cba208feb0b096d49b202bf89c8",
+      "name": "Dego Finance",
+      "symbol": "DEGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12503/thumb/Token.png?1733381203"
+    },
+    {
+      "chainId": 1,
+      "address": "0x12e2b8033420270db2f3b328e32370cb5b2ca134",
+      "name": "SafePal",
+      "symbol": "SFP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13905/thumb/sfp.png?1696513647"
+    },
+    {
+      "chainId": 1,
+      "address": "0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419",
+      "name": "DIA",
+      "symbol": "DIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/Token_Logo.png?1696511815"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
+      "name": "Synapse",
+      "symbol": "SYN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/synapse_social_icon.png?1696517540"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+      "name": "Polygon",
+      "symbol": "MATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/polygon.png?1698233745"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb7109df1a93f8fe2b8162c6207c9b846c1c68090",
+      "name": "Matr1x",
+      "symbol": "MAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39481/thumb/t05.png?1722465175"
+    },
+    {
+      "chainId": 1,
+      "address": "0x408e41876cccdc0f92210600ef50372656052a38",
+      "name": "Ren",
+      "symbol": "REN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3139/thumb/REN.png?1696503862"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf2b2f7b47715256ce4ea43363a867fdce9353e3a",
+      "name": "Bitgert",
+      "symbol": "BRISE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17388/thumb/200x200.png?1696516937"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe0f63a424a4439cbe457d80e4f4b51ad25b2c56c",
+      "name": "SPX6900",
+      "symbol": "SPX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/31401/thumb/sticker_%281%29.jpg?1702371083"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+      "name": "Rocket Pool",
+      "symbol": "RPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2090/thumb/rocket_pool_%28RPL%29.png?1696503058"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7448c7456a97769f6cd04f1e83a4a23ccdc46abd",
+      "name": "Maverick Protocol",
+      "symbol": "MAV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30850/thumb/MAV_Logo.png?1696529701"
+    },
+    {
+      "chainId": 1,
+      "address": "0x12bb890508c125661e03b09ec06e404bc9289040",
+      "name": "Radio Caca",
+      "symbol": "RACA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17841/thumb/ez44_BSs_400x400.jpg?1696517365"
+    },
+    {
+      "chainId": 1,
+      "address": "0x853d955acef822db058eb8505911ed77f175b99e",
+      "name": "Frax",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/FRAX_icon.png?1696513182"
+    },
+    {
+      "chainId": 1,
+      "address": "0xade00c28244d5ce17d72e40330b1c318cd12b7c3",
+      "name": "AdEx",
+      "symbol": "ADX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/847/thumb/adex.jpeg?1696501984"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1cf4592ebffd730c7dc92c1bdffdfc3b9efcf29a",
+      "name": "Waves",
+      "symbol": "WAVES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/425/thumb/waves.png?1696501700"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
+      "name": "Linear",
+      "symbol": "LINA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12509/thumb/1649227343-linalogo200px.png?1696512324"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbf2179859fc6d5bee9bf9158632dc51678a4100e",
+      "name": "aelf",
+      "symbol": "ELF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1371/thumb/aelf-logo.png?1696502429"
+    },
+    {
+      "chainId": 1,
+      "address": "0xff56cc6b1e6ded347aa0b7676c85ab0b3d08b0fa",
+      "name": "Orbs",
+      "symbol": "ORBS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4630/thumb/Orbs.jpg?1696505200"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf411903cbc70a74d22900a5de66a2dda66507255",
+      "name": "Verasity",
+      "symbol": "VRA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14025/thumb/logo_%281%29.png?1716968890"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4385328cc4d643ca98dfea734360c0f596c83449",
+      "name": "tomiNet",
+      "symbol": "TOMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28730/thumb/logo_for_token.png?1696527710"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd3cc9d8f3689b83c91b7b59cab4946b063eb894a",
+      "name": "Venus",
+      "symbol": "XVS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12677/thumb/XVS_Token.jpg?1727454303"
+    },
+    {
+      "chainId": 1,
+      "address": "0x168e209d7b2f58f1f24b8ae7b7d35e662bbf11cc",
+      "name": "LayerAI",
+      "symbol": "LAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29223/thumb/Favicon_200x200px.png?1696528181"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
+      "name": "NEXO",
+      "symbol": "NEXO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3695/thumb/CG-nexo-token-200x200_2x.png?1730414360"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c5ba91642f10282b576d91922ae6448c9d52f4e",
+      "name": "PHALA",
+      "symbol": "PHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12451/thumb/phala.png?1696512270"
+    },
+    {
+      "chainId": 1,
+      "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
+      "name": "XSGD",
+      "symbol": "XSGD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/12832/thumb/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcf3c8be2e2c42331da80ef210e9b1b307c03d36a",
+      "name": "Bepro",
+      "symbol": "BEPRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10251/thumb/bepro_logo_200x200.png?1718012232"
+    },
+    {
+      "chainId": 1,
+      "address": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
+      "name": "Stader",
+      "symbol": "SD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20658/thumb/SD_Token_Logo.png?1696520060"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4507cef57c46789ef8d1a19ea45f4216bae2b528",
+      "name": "TokenFi",
+      "symbol": "TOKEN",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32507/thumb/MAIN_TokenFi_logo_icon.png?1698918427"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0bb217e40f8a5cb79adf04e1aab60e5abd0dfc1e",
+      "name": "SWFTCOIN",
+      "symbol": "SWFTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2346/thumb/SWFTCoin.jpg?1696503223"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8971f9fd7196e5cee2c1032b50f656855af7dd26",
+      "name": "Lambda",
+      "symbol": "LAMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4703/thumb/lambda_200.png?1696505268"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
+      "name": "Bluzelle",
+      "symbol": "BLZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1696503607"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba41ddf06b7ffd89d1267b5a93bfef2424eb2003",
+      "name": "Mythos",
+      "symbol": "MYTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28045/thumb/Mythos_Logos_200x200.png?1696527059"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+      "name": "Gnosis",
+      "symbol": "GNO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/662/thumb/logo_square_simple_300px.png?1696501854"
+    },
+    {
+      "chainId": 1,
+      "address": "0xee2a03aa6dacf51c18679c516ad5283d8e7c2637",
+      "name": "Neiro on ETH",
+      "symbol": "NEIRO",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/39438/thumb/Neiro.png?1722915026"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3be7bf1a5f23bd8336787d0289b70602f1940875",
+      "name": "VIDT DAO",
+      "symbol": "VIDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27552/thumb/VIDTDAO_logo.png?1696526588"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf4d2888d29d722226fafa5d9b24f9164c092421e",
+      "name": "LooksRare",
+      "symbol": "LOOKS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22173/thumb/circle-black-256.png?1696521517"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf944e35f95e819e752f3ccb5faf40957d311e8c5",
+      "name": "Moca Coin",
+      "symbol": "MOCA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37812/thumb/moca.jpg?1720693068"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
+      "name": "Kaon",
+      "symbol": "AKRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3328/thumb/kaon.jpg?1730712283"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4b9278b94a1112cad404048903b8d343a810b07e",
+      "name": "Hifi Finance",
+      "symbol": "HIFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28712/thumb/hft.png?1696527693"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd26114cd6ee289accf82350c8d8487fedb8a0c07",
+      "name": "OMG Network",
+      "symbol": "OMG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1696501928"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba5bde662c17e2adff1075610382b9b691296350",
+      "name": "SuperRare",
+      "symbol": "RARE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17753/thumb/RARE.png?1709598473"
+    },
+    {
+      "chainId": 1,
+      "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
+      "name": "FUNToken",
+      "symbol": "FUN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/761/thumb/FUN.png?1696501914"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4b5f49487ea7b3609b1ad05459be420548789f1f",
+      "name": "LeverFi",
+      "symbol": "LEVER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26205/thumb/WI72SpBl_400x400.jpeg?1696525291"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e",
+      "name": "crvUSD",
+      "symbol": "CRVUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/thumb/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1121acc14c63f3c872bfca497d10926a6098aac5",
+      "name": "Department Of Government Efficiency",
+      "symbol": "DOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39841/thumb/IMG_9775.PNG?1729771739"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44",
+      "name": "Wrapped TAO",
+      "symbol": "WTAO",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/29087/thumb/wtao.png?1696528051"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd29da236dd4aac627346e1bba06a619e8c22d7c5",
+      "name": "MAGA Hat",
+      "symbol": "MAGA",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37988/thumb/MAGA200.jpg?1716223291"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1a4b46696b2bb4794eb3d4c26f1c55f9170fa4c5",
+      "name": "BitDAO",
+      "symbol": "BIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1696517158"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0d3cbed3f69ee050668adf3d9ea57241cba33a2b",
+      "name": "PlayDapp",
+      "symbol": "PDA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14316/thumb/PDA-symbol.png?1710234068"
+    },
+    {
+      "chainId": 1,
+      "address": "0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5",
+      "name": "Usual USD",
+      "symbol": "USD0",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38272/thumb/USD0LOGO.png?1716962811"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa849eaae994fb86afa73382e9bd88c2b6b18dc71",
+      "name": "MVL",
+      "symbol": "MVL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3476/thumb/CoinGecko.png?1711620384"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec12ba5ac0f259e9ac6fc9a3bc23a76ad2fde5d9",
+      "name": "HugeWin",
+      "symbol": "HUGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35923/thumb/2024-03-01_17.49.27_%281%29.png?1710221459"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
+      "name": "Coinbase Wrapped Staked ETH",
+      "symbol": "CBETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/thumb/cbeth.png?1709186989"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+      "name": "Gitcoin",
+      "symbol": "GTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1696515429"
+    },
+    {
+      "chainId": 1,
+      "address": "0x572975ff6d5136c81c8d7448b6361ef9eefe1ab0",
+      "name": "Wrapped Staked USDT",
+      "symbol": "WSTUSDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31160/thumb/wstusdt.jpeg?1696529988"
+    },
+    {
+      "chainId": 1,
+      "address": "0x61e90a50137e1f645c9ef4a0d3a4f01477738406",
+      "name": "League of Kingdoms",
+      "symbol": "LOKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22572/thumb/loka_64pix.png?1696521891"
+    },
+    {
+      "chainId": 1,
+      "address": "0x814e0908b12a99fecf5bc101bb5d0b8b5cdf7d26",
+      "name": "Measurable Data",
+      "symbol": "MDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2441/thumb/mdt_icon_120x120.png?1711452723"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc71b5f631354be6853efe9c3ab6b9590f8302e81",
+      "name": "Polyhedra Network",
+      "symbol": "ZKJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36198/thumb/ZK.jpg?1710812518"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4cc19356f2d37338b9802aa8e8fc58b0373296e7",
+      "name": "SelfKey",
+      "symbol": "KEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2034/thumb/selfkey.png?1696503004"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc03fbf20a586fa89c2a5f6f941458e1fbc40c661",
+      "name": "COMBO",
+      "symbol": "COMBO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4932/thumb/COMBO.jpg?1696505472"
+    },
+    {
+      "chainId": 1,
+      "address": "0x66761fa41377003622aee3c7675fc7b5c1c2fac5",
+      "name": "Clearpool",
+      "symbol": "CPOOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19252/thumb/photo_2022-08-31_12.45.02.jpeg?1696518697"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0fd10b9899882a6f2fcb5c371e17e70fdee00c38",
+      "name": "Pundi X",
+      "symbol": "PUNDIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14571/thumb/vDyefsXq_400x400.jpg?1696514252"
+    },
+    {
+      "chainId": 1,
+      "address": "0x42476f744292107e34519f9c357927074ea3f75d",
+      "name": "Loom Network  NEW ",
+      "symbol": "LOOM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14735/thumb/LOOM.png?1696514405"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd433138d12beb9929ff6fd583dc83663eea6aaa5",
+      "name": "Bitrue Coin",
+      "symbol": "BTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8873/thumb/Bittrue_logo.png?1696509025"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd31a59c85ae9d8edefec411d448f90841571b89c",
+      "name": "SOL  Wormhole ",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1696522175"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbbc2ae13b23d715c30720f079fcd9b4a74093505",
+      "name": "Ethernity Chain",
+      "symbol": "ERN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/logo_black.png?1715198164"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3010ccb5419f1ef26d40a7cd3f0d707a0fa127dc",
+      "name": "Gems VIP",
+      "symbol": "GEMS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38725/thumb/200x200.png?1718478016"
+    },
+    {
+      "chainId": 1,
+      "address": "0x944824290cc12f31ae18ef51216a223ba4063092",
+      "name": "Masa",
+      "symbol": "MASA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35538/thumb/masa.png?1712635899"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbf5495efe5db9ce00f80364c8b423567e58d2110",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/thumb/Ezeth_logo_circle.png?1713496404"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+      "name": "Alchemix",
+      "symbol": "ALCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1696513834"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a9bdcff37ab68b95a53435adfd8892e86084f93",
+      "name": "Alpha Quark",
+      "symbol": "AQT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12872/thumb/alpha_quark_logo.png?1696512660"
+    },
+    {
+      "chainId": 1,
+      "address": "0xef3a930e1ffffacd2fc13434ac81bd278b0ecc8d",
+      "name": "Stafi",
+      "symbol": "FIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/FIS.png?1696512244"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfe3e6a25e6b192a42a44ecddcd13796471735acf",
+      "name": "Reef",
+      "symbol": "REEF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13504/thumb/Group_10572.png?1696513266"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe66747a101bff2dba3697199dcce5b743b454759",
+      "name": "Gate",
+      "symbol": "GT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8183/thumb/gate.png?1696508395"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb056c38f6b7dc4064367403e26424cd2c60655e1",
+      "name": "CEEK Smart VR",
+      "symbol": "CEEK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2581/thumb/ceek-smart-vr-token-logo.png?1696503385"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb59490ab09a0f526cc7305822ac65f2ab12f9723",
+      "name": "Litentry",
+      "symbol": "LIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13825/thumb/logo_200x200.png?1696513568"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd2ba23de8a19316a638dc1e7a9adda1d74233368",
+      "name": "Quickswap",
+      "symbol": "QUICK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25393/thumb/quickswap.png?1696524525"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ed97a637a790be1feff5e888d43629dc05408f6",
+      "name": "Non Playable Coin",
+      "symbol": "NPC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31193/thumb/NPC_200x200.png?1696530021"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77777feddddffc19ff86db637967013e6c6a116c",
+      "name": "Tornado Cash",
+      "symbol": "TORN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13496/thumb/ZINt8NSB_400x400.jpg?1696513257"
+    },
+    {
+      "chainId": 1,
+      "address": "0x56072c95faa701256059aa122697b133aded9279",
+      "name": "Sky",
+      "symbol": "SKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39925/thumb/sky.jpg?1724827980"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec67005c4e498ec7f55e092bd1d35cbc47c91892",
+      "name": "Enzyme",
+      "symbol": "MLN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/Enzyme_Icon_Secondary.png?1696501803"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9d1a7a3191102e9f900faa10540837ba84dcbae7",
+      "name": "Eurite",
+      "symbol": "EURI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39952/thumb/EURI.jpg?1724902829"
+    },
+    {
+      "chainId": 1,
+      "address": "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
+      "name": "Boba Network",
+      "symbol": "BOBA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/Boba-200x200---white.png?1696519690"
+    },
+    {
+      "chainId": 1,
+      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
+      "name": "Telos",
+      "symbol": "TLOS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7588/thumb/tlos_png.png?1722391289"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2cd3d43c775978a96bdbf12d733d5a1ed94fb18",
+      "name": "Onyxcoin",
+      "symbol": "XCN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/onyxlogo.jpg?1696523397"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe1a001fe942f96eea22ba08783140b9dcc09d28",
+      "name": "Beta Finance",
+      "symbol": "BETA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18715/thumb/beta_finance.jpg?1696518183"
+    },
+    {
+      "chainId": 1,
+      "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
+      "name": "Telcoin",
+      "symbol": "TEL",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/1899/thumb/tel.png?1696502892"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
+      "name": "Bone ShibaSwap",
+      "symbol": "BONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16916/thumb/bone_icon.png?1696516487"
+    },
+    {
+      "chainId": 1,
+      "address": "0x826180541412d574cf1336d22c0c0a287822678a",
+      "name": "Chainflip",
+      "symbol": "FLIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25576/thumb/kdt_AgmT_400x400.png?1696524709"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7ddc52c4de30e94be3a6a0a2b259b2850f421989",
+      "name": "Gomining Token",
+      "symbol": "GOMINING",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15662/thumb/GoMining_Logo.png?1714757256"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfc385a1df85660a7e041423db512f779070fcede",
+      "name": "zkLink",
+      "symbol": "ZKL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34982/thumb/Logo1.png?1714980729"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf94e7d0710709388bce3161c32b4eea56d3f91cc",
+      "name": "Destra Network",
+      "symbol": "DSYNC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35996/thumb/Destra_Network.png?1710316001"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc98d64da73a6616c42117b582e832812e7b8d57f",
+      "name": "RSS3",
+      "symbol": "RSS3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23575/thumb/rss3.jpeg?1718351333"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2120b9e674d3fc3875f415a7df52e382f141225",
+      "name": "Automata",
+      "symbol": "ATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA_Icon_%28Profile_2%29.png?1720487988"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8642a849d0dcb7a15a974794668adcfbe4794b56",
+      "name": "Prosper",
+      "symbol": "PROS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13668/thumb/PFP_Visual_CG.png?1727714135"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd01409314acb3b245cea9500ece3f6fd4d70ea30",
+      "name": "LTO Network",
+      "symbol": "LTO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/6068/thumb/lto.png?1696506473"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
+      "name": "IDEX",
+      "symbol": "IDEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2565/thumb/idexlogo.png?1696503371"
+    },
+    {
+      "chainId": 1,
+      "address": "0x594daad7d77592a2b97b725a7ad59d7e188b5bfa",
+      "name": "Apu Apustaja",
+      "symbol": "APU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35986/thumb/200x200.png?1710308147"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
+      "name": "Wrapped Fantom",
+      "symbol": "WFTM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16036/thumb/Fantom.png?1696515646"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1495bc9e44af1f8bcb62278d2bec4540cf0c05ea",
+      "name": "Zero1 Labs",
+      "symbol": "DEAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36315/thumb/512x512-xion-ava03.png?1711092111"
+    },
+    {
+      "chainId": 1,
+      "address": "0x667102bd3413bfeaa3dffb48fa8288819e480a88",
+      "name": "Tokenize Xchange",
+      "symbol": "TKX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/4984/thumb/TKX_-_Logo_-_RGB-15.png?1696505519"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdc9ac3c20d1ed0b540df9b1fedc10039df13f99c",
+      "name": "xMoney",
+      "symbol": "UTK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1824/thumb/200x200.png?1696723239"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7abc8a5768e6be61a6c693a6e4eacb5b60602c4d",
+      "name": "Covalent X Token",
+      "symbol": "CXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39177/thumb/CXT_Ticker.png?1720829918"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa91ac63d040deb1b7a5e4d4134ad23eb0ba07e14",
+      "name": "Bella Protocol",
+      "symbol": "BEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12478/thumb/Bella.png?1696512296"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
+      "name": "OriginTrail",
+      "symbol": "TRAC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1696502873"
+    },
+    {
+      "chainId": 1,
+      "address": "0xadd5e881984783dd432f80381fb52f45b53f3e70",
+      "name": "Vite",
+      "symbol": "VITE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4513/thumb/VITE_new_logo_200px.png?1709175957"
+    },
+    {
+      "chainId": 1,
+      "address": "0x67466be17df832165f8c80a5a120ccc652bd7e69",
+      "name": "LandWolf",
+      "symbol": "WOLF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37403/thumb/wolf_200x200.png?1715222165"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfc82bb4ba86045af6f327323a46e80412b91b27d",
+      "name": "Prom",
+      "symbol": "PROM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8825/thumb/Ticker.png?1696508978"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9e9fbde7c7a83c43913bddc8779158f1368f0413",
+      "name": "Pandora",
+      "symbol": "PANDORA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34996/thumb/PandoraToken.png?1706954340"
+    },
+    {
+      "chainId": 1,
+      "address": "0x25931894a86d47441213199621f1f2994e1c39aa",
+      "name": "ChainGPT",
+      "symbol": "CGPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29306/thumb/200x200.png?1696528257"
+    },
+    {
+      "chainId": 1,
+      "address": "0x68749665ff8d2d112fa859aa293f07a622782f38",
+      "name": "Tether Gold",
+      "symbol": "XAUT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/10481/thumb/Tether_Gold.png?1696510471"
+    },
+    {
+      "chainId": 1,
+      "address": "0x79f05c263055ba20ee0e814acd117c20caa10e0c",
+      "name": "Ice Open Network",
+      "symbol": "ICE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34674/thumb/ion-coingecko-200w.png?1714009819"
+    },
+    {
+      "chainId": 1,
+      "address": "0x28561b8a2360f463011c16b6cc0b0cbef8dbbcad",
+      "name": "MOO DENG",
+      "symbol": "MOODENG",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/50348/thumb/1000000612.jpg?1727248974"
+    },
+    {
+      "chainId": 1,
+      "address": "0x97a9a15168c22b3c137e6381037e1499c8ad0978",
+      "name": "Data Ownership Protocol",
+      "symbol": "DOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36706/thumb/DOP-Round-200x200.png?1720836160"
+    },
+    {
+      "chainId": 1,
+      "address": "0x12970e6868f88f6557b76120662c1b3e50a646bf",
+      "name": "Milady Meme Coin",
+      "symbol": "LADYS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30194/thumb/LADYS_Clean.png?1725897475"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c11249814f11b9346808179cf06e71ac328c1b5",
+      "name": "Oraichain",
+      "symbol": "ORAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12931/thumb/orai.png?1696512718"
+    },
+    {
+      "chainId": 1,
+      "address": "0x761d38e5ddf6ccf6cf7c55759d5210750b5d60f3",
+      "name": "Dogelon Mars",
+      "symbol": "ELON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1696514622"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde7d85157d9714eadf595045cc12ca4a5f3e2adb",
+      "name": "STP",
+      "symbol": "STPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8713/thumb/STP.png?1696508875"
+    },
+    {
+      "chainId": 1,
+      "address": "0xea26c4ac16d4a5a106820bc8aee85fd0b7b2b664",
+      "name": "QuarkChain",
+      "symbol": "QKC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3849/thumb/QuarkChain.jpg?1730964236"
+    },
+    {
+      "chainId": 1,
+      "address": "0x48b847cf774a5710f36f594b11fc10e2e59bba72",
+      "name": "Unit0",
+      "symbol": "UNIT0",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51237/thumb/200%D1%85200.png?1730448085"
+    },
+    {
+      "chainId": 1,
+      "address": "0x38e382f74dfb84608f3c1f10187f6bef5951de93",
+      "name": "Multibit",
+      "symbol": "MUBI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33051/thumb/multi.jpg?1700473994"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde4ee8057785a7e8e800db58f9784845a5c2cbd6",
+      "name": "DeXe",
+      "symbol": "DEXE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12713/thumb/DEXE_token_logo.png?1696512514"
+    },
+    {
+      "chainId": 1,
+      "address": "0x508e00d5cef397b02d260d035e5ee80775e4c821",
+      "name": "Bitcoin Cats",
+      "symbol": "1CAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34059/thumb/779e5404024bcd3cec3db54370ea66c.jpg?1703752231"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7613c48e0cd50e42dd9bf0f6c235063145f6f8dc",
+      "name": "Pirate Nation Token",
+      "symbol": "PIRATE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38524/thumb/_Pirate_Transparent_200x200.png?1717947813"
+    },
+    {
+      "chainId": 1,
+      "address": "0x96f6ef951840721adbf46ac996b59e0235cb985c",
+      "name": "Ondo US Dollar Yield",
+      "symbol": "USDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31700/thumb/usdy_%281%29.png?1696530524"
+    },
+    {
+      "chainId": 1,
+      "address": "0xeeb4d8400aeefafc1b2953e0094134a887c76bd8",
+      "name": "Avail",
+      "symbol": "AVAIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37372/thumb/avail-logo.png?1714145201"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1e053d89e08c24aa2ce5c5b4206744dc2d7bd8f5",
+      "name": "ThunderCore",
+      "symbol": "TT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4375/thumb/ThunderCore_Logo_Mark_Gradient_%283%29.png?1696504974"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3ffeea07a27fab7ad1df5297fa75e77a43cb5790",
+      "name": "PeiPei",
+      "symbol": "PEIPEI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38512/thumb/PeiPei.png?1718315778"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0c7d5ae016f806603cb1782bea29ac69471cab9c",
+      "name": "Bifrost",
+      "symbol": "BFC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4639/thumb/BFC_Symbol.png?1696505208"
+    },
+    {
+      "chainId": 1,
+      "address": "0x06450dee7fd2fb8e39061434babcfc05599a6fb8",
+      "name": "XEN Crypto",
+      "symbol": "XEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27713/thumb/Xen.jpeg?1696526739"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8f693ca8d21b157107184d29d398a8d082b38b76",
+      "name": "Streamr",
+      "symbol": "DATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17869/thumb/DATA_new_symbol_3x.png?1696517392"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
+      "name": "Request",
+      "symbol": "REQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1696502140"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8236a87084f8b84306f72007f36f2618a5634494",
+      "name": "Lombard Staked BTC",
+      "symbol": "LBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39969/thumb/LBTC_Logo.png?1724959872"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaaaaaa20d9e0e2461697782ef11675f668207961",
+      "name": "Aurora",
+      "symbol": "AURORA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20582/thumb/aurora.jpeg?1696519989"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f51bb10119727a7e5ea3538074fb341f56b09ad",
+      "name": "DAO Maker",
+      "symbol": "DAO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13915/thumb/4.jpg?1727532864"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2be5e8c109e2197d077d13a82daead6a9b3433c5",
+      "name": "Tokamak Network",
+      "symbol": "TON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12260/thumb/D919x5-s_400x400.png?1696512091"
+    },
+    {
+      "chainId": 1,
+      "address": "0x628a3b2e302c7e896acc432d2d0dd22b6cb9bc88",
+      "name": "LimeWire",
+      "symbol": "LMWR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30356/thumb/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
+    },
+    {
+      "chainId": 1,
+      "address": "0x72e4f9f808c49a2a61de9c5896298920dc4eeea9",
+      "name": "HarryPotterObamaSonic10Inu  ETH ",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/30323/thumb/hpos10i_logo_casino_night-dexview.png?1696529224"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3e5a19c91266ad8ce2477b91585d1856b84062df",
+      "name": "Ancient8",
+      "symbol": "A8",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39170/thumb/A8_Token-04_200x200.png?1720798300"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77fba179c79de5b7653f68b5039af940ada60ce0",
+      "name": "Ampleforth Governance",
+      "symbol": "FORTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1696514579"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8390a1da07e376ef7add4be859ba74fb83aa02d5",
+      "name": "Grok",
+      "symbol": "GROK",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32788/thumb/GROK.png?1707579427"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd795eb12034c2b77d787a22292c26fab5f5c70aa",
+      "name": "Pixelverse",
+      "symbol": "PIXFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38279/thumb/pixelverse_logo.png?1716993023"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbef26bd568e421d6708cca55ad6e35f8bfa0c406",
+      "name": "bitsCrunch Token",
+      "symbol": "BCUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34832/thumb/logo-256_%281%29.png?1710244462"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf8ebf4849f1fa4faf0dff2106a173d3a6cb2eb3a",
+      "name": "Troll",
+      "symbol": "TROLL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29897/thumb/TROLL.jpeg?1696528821"
+    },
+    {
+      "chainId": 1,
+      "address": "0x91af0fbb28aba7e31403cb457106ce79397fd4e6",
+      "name": "Aergo",
+      "symbol": "AERGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4490/thumb/aergo.png?1696505079"
+    },
+    {
+      "chainId": 1,
+      "address": "0xed35af169af46a02ee13b9d79eb57d6d68c1749e",
+      "name": "ECOMI",
+      "symbol": "OMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4428/thumb/ECOMI.png?1696505023"
+    },
+    {
+      "chainId": 1,
+      "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+      "name": "Rocket Pool ETH",
+      "symbol": "RETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20764/thumb/reth.png?1696520159"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4527a3b4a8a150403090a99b87effc96f2195047",
+      "name": "P2P solutions foundation",
+      "symbol": "P2PS",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2798/thumb/p2ps.png?1696503565"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e79b51959cf968d87826592f46f819f92466615",
+      "name": "Hoppy",
+      "symbol": "HOPPY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37197/thumb/Hoppy_200x200_.png?1724175711"
+    },
+    {
+      "chainId": 1,
+      "address": "0x52284158e02425290f6b627aeb5fff65edf058ad",
+      "name": "FlappyMoonbird",
+      "symbol": "FMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30659/thumb/200_%282%29.jpg?1696529529"
+    },
+    {
+      "chainId": 1,
+      "address": "0x701c244b988a513c945973defa05de933b23fe1d",
+      "name": "OAX",
+      "symbol": "OAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/853/thumb/OAXlogo.png?1696501987"
+    },
+    {
+      "chainId": 1,
+      "address": "0x554fb3b6c1cf4a3cef49779ced321ca51c667d7d",
+      "name": "Arata AGI",
+      "symbol": "ARATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51555/thumb/500px.png?1731517839"
+    },
+    {
+      "chainId": 1,
+      "address": "0x94a8b4ee5cd64c79d0ee816f467ea73009f51aa0",
+      "name": "Realio Network Token",
+      "symbol": "RIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12206/thumb/Rio.png?1696512042"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44971abf0251958492fee97da3e5c5ada88b9185",
+      "name": "BasedAI",
+      "symbol": "BASEDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36607/thumb/1000004475.png?1711964332"
+    },
+    {
+      "chainId": 1,
+      "address": "0x825459139c897d769339f295e962396c4f9e4a4d",
+      "name": "GameBuild",
+      "symbol": "GAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37789/thumb/Gamebuild-logo-200.png?1715586834"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc328a59e7321747aebbc49fd28d1b32c1af8d3b2",
+      "name": "Phil",
+      "symbol": "PHIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39975/thumb/yr0kMUrz_400x400.jpg?1724971221"
+    },
+    {
+      "chainId": 1,
+      "address": "0x678e840c640f619e17848045d23072844224dd37",
+      "name": "Cratos",
+      "symbol": "CRTS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17322/thumb/cratos.png?1696516876"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5026f006b85729a8b14553fae6af249ad16c9aab",
+      "name": "Wojak",
+      "symbol": "WOJAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29856/thumb/wojak.png?1696528782"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0391d2021f89dc339f60fff84546ea23e337750f",
+      "name": "BarnBridge",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1696512604"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbb7a34bf10169d6d2d0d02a6cbb436cf4381bfa",
+      "name": "Zentry",
+      "symbol": "ZENT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36979/thumb/Zentry-rebrand-Primary_200px.png?1713743277"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc555d625828c4527d477e595ff1dd5801b4a600e",
+      "name": "MON Protocol",
+      "symbol": "MON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37395/thumb/WhatsApp_Image_2024-02-27_at_18.34.45_01762153.jpg?1716261730"
+    },
+    {
+      "chainId": 1,
+      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
+      "name": "Pocket Network",
+      "symbol": "POKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22506/thumb/POKT.jpg?1703257310"
+    },
+    {
+      "chainId": 1,
+      "address": "0x865ec58b06bf6305b886793aa20a2da31d034e68",
+      "name": "Mossland",
+      "symbol": "MOC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2374/thumb/moc.png?1696503240"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
+      "name": "Pax Dollar",
+      "symbol": "USDP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6013/thumb/Pax_Dollar.png?1696506427"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb2617246d0c6c0087f18703d576831899ca94f01",
+      "name": "Zignaly",
+      "symbol": "ZIG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14796/thumb/zig.jpg?1731990265"
+    },
+    {
+      "chainId": 1,
+      "address": "0x908ddb096bfb3acb19e2280aad858186ea4935c4",
+      "name": "Eesee",
+      "symbol": "ESE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35182/thumb/Eesee.jpg?1707796753"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfb19075d77a0f111796fb259819830f4780f1429",
+      "name": "Fenerbah e",
+      "symbol": "FB",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17711/thumb/FB_Logo.png?1696517238"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa831a4e181f25d3b35949e582ff27cc44e703f37",
+      "name": "ALEX Lab",
+      "symbol": "ALEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25837/thumb/ALEX_Token.png?1696524922"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9ff58067bd8d239000010c154c6983a325df138e",
+      "name": "Propchain",
+      "symbol": "PROPC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30451/thumb/prop_%281%29.png?1702322253"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8802269d1283cdb2a5a329649e5cb4cdcee91ab6",
+      "name": "Fight to MAGA",
+      "symbol": "FIGHT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/39208/thumb/photo_2024-07-14_03-15-23.jpg?1721101331"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4ec1b60b96193a64acae44778e51f7bff2007831",
+      "name": "Edge",
+      "symbol": "EDGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1848/thumb/EDGE.png?1696502846"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc9bca88b04581699fab5aa276ccaff7df957cbbf",
+      "name": "Ethervista",
+      "symbol": "VISTA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40014/thumb/ethervista.jpg?1725289970"
+    },
+    {
+      "chainId": 1,
+      "address": "0x728f30fa2f100742c7949d1961804fa8e0b1387d",
+      "name": "GamerCoin",
+      "symbol": "GHX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14714/thumb/ghx_icon.png?1696514385"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9aab071b4129b083b01cb5a0cb513ce7eca26fa5",
+      "name": "Hunt",
+      "symbol": "HUNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7989/thumb/HUNT.png?1696508215"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5dc60c4d5e75d22588fa17ffeb90a63e535efce0",
+      "name": "dKargo",
+      "symbol": "DKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11875/thumb/DKA_ticker.png?1732553189"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc56c7a0eaa804f854b536a5f3d5f49d2ec4b12b8",
+      "name": "GME  Ethereum ",
+      "symbol": "GME",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37895/thumb/GME200.jpg?1715847521"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe9689028ede16c2fdfe3d11855d28f8e3fc452a3",
+      "name": "Imaginary Ones",
+      "symbol": "BUBBLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37706/thumb/imaginary_ones.jpeg?1715255717"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe7c6bf469e97eeb0bfb74c8dbff5bd47d4c1c98a",
+      "name": "HashKey Platform Token",
+      "symbol": "HSK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29779/thumb/HSKlogo.jpg?1719445510"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdd3b11ef34cd511a2da159034a05fcb94d806686",
+      "name": "Rekt",
+      "symbol": "REKT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51727/thumb/rektcion_trans_200px.png?1731910587"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9cb1aeafcc8a9406632c5b084246ea72f62d37b6",
+      "name": "LBK",
+      "symbol": "LBK",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/9492/thumb/lbk.jpeg?1696509578"
+    },
+    {
+      "chainId": 1,
+      "address": "0x69a1e699f562d7af66fc6cc473d99f4430c3acd2",
+      "name": "Param",
+      "symbol": "PARAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37697/thumb/param200.png?1715234889"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
+      "name": "Cream",
+      "symbol": "CREAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11976/thumb/Cream.png?1696511834"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7a56e1c57c7475ccf742a1832b028f0456652f97",
+      "name": "Solv Protocol SolvBTC",
+      "symbol": "SOLVBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36800/thumb/solvBTC.png?1719810684"
+    },
+    {
+      "chainId": 1,
+      "address": "0x13e4b8cffe704d3de6f19e52b201d92c21ec18bd",
+      "name": "ParallelAI",
+      "symbol": "PAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50394/thumb/IMG_20240926_230930_523.jpg?1727589698"
+    },
+    {
+      "chainId": 1,
+      "address": "0x823556202e86763853b40e9cde725f412e294689",
+      "name": "Altered State Machine",
+      "symbol": "ASTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24893/thumb/ASTO-Token.png?1732899741"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
+      "name": "World Mobile Token",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/thumb/1000097112.png?1727698144"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3567aa22cd3ab9aef23d7e18ee0d7cf16974d7e6",
+      "name": "Sharpe AI",
+      "symbol": "SAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39385/thumb/Group_48095583.png?1721962174"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5ca381bbfb58f0092df149bd3d243b08b9a8386e",
+      "name": "Moonchain",
+      "symbol": "MXC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4604/thumb/M_1-modified.png?1712206949"
+    },
+    {
+      "chainId": 1,
+      "address": "0x32b77729cd87f1ef2bea4c650c16f89f08472c69",
+      "name": "DeBox",
+      "symbol": "BOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50224/thumb/v6TSd2dN_400x400.jpg?1726521525"
+    },
+    {
+      "chainId": 1,
+      "address": "0x943af2ece93118b973c95c2f698ee9d15002e604",
+      "name": "GameGPT",
+      "symbol": "DUEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34491/thumb/duel.jpeg?1705056819"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe6829d9a7ee3040e1276fa75293bde931859e8fa",
+      "name": "Mantle Restaked ETH",
+      "symbol": "CMETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51114/thumb/symbol.png?1730117724"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9f0c013016e8656bc256f948cd4b79ab25c7b94d",
+      "name": "mETH Protocol",
+      "symbol": "COOK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50969/thumb/Logomark-Gradient_Official.png?1729620221"
+    },
+    {
+      "chainId": 1,
+      "address": "0x39d5313c3750140e5042887413ba8aa6145a9bd2",
+      "name": "Empyreal",
+      "symbol": "EMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31374/thumb/logomainblacktransparent.png?1719953450"
+    },
+    {
+      "chainId": 1,
+      "address": "0x441761326490cacf7af299725b6292597ee822c2",
+      "name": "Unifi Protocol DAO",
+      "symbol": "UNFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13152/thumb/logo-2.png?1696512937"
+    },
+    {
+      "chainId": 1,
+      "address": "0xacd2c239012d17beb128b0944d49015104113650",
+      "name": "Karrat",
+      "symbol": "KARRAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37237/thumb/SmallLogo.png?1714755426"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6aa56e1d98b3805921c170eb4b3fe7d4fda6d89b",
+      "name": "MAGA",
+      "symbol": "TRUMP",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/31498/thumb/Maga-Trump-Logo-200px.png?1696530309"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa1290d69c65a6fe4df752f95823fae25cb99e5a7",
+      "name": "Kelp DAO Restaked ETH",
+      "symbol": "RSETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33800/thumb/Icon___Dark.png?1702991855"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb2492e97a68a6e4b9e9a11b99f6c42e5accd38c7",
+      "name": "Veloce",
+      "symbol": "VEXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31214/thumb/VEXT_Logo.jpg?1696530041"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
+      "name": "Port3 Network",
+      "symbol": "PORT3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33383/thumb/port3-bc-200x200.png?1710075114"
+    },
+    {
+      "chainId": 1,
+      "address": "0x037a54aab062628c9bbae1fdb1583c195585fe41",
+      "name": "LCX",
+      "symbol": "LCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9985/thumb/zRPSu_0o_400x400.jpg?1696510023"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
+      "name": "Kyber Network Crystal Legacy",
+      "symbol": "KNCL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/947/thumb/logo-kncl.png?1696502063"
+    },
+    {
+      "chainId": 1,
+      "address": "0x62b9c7356a2dc64a1969e19c23e4f579f9810aa7",
+      "name": "Convex CRV",
+      "symbol": "CVXCRV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15586/thumb/convex-crv.png?1696515222"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
+      "name": "DFI money",
+      "symbol": "YFII",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11902/thumb/YFII-logo.78631676.png?1696511768"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7d8146cf21e8d7cbe46054e01588207b51198729",
+      "name": "BOB Token",
+      "symbol": "BOB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29929/thumb/bob.png?1696528857"
+    },
+    {
+      "chainId": 1,
+      "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
+      "name": "Ocean Protocol",
+      "symbol": "OCEAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1696504363"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
+      "name": "Keep3rV1",
+      "symbol": "KP3R",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1696512754"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe50e009ddb1a4d8ec668eac9d8b2df1f96348707",
+      "name": "Ctrl",
+      "symbol": "CTRL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50886/thumb/_CTRL_logo_.png?1732678338"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2565ae0385659badcada1031db704442e1b69982",
+      "name": "Assemble Protocol",
+      "symbol": "ASM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11605/thumb/ASM_512X512_white.png?1717463859"
+    },
+    {
+      "chainId": 1,
+      "address": "0x27c70cd1946795b66be9d954418546998b546634",
+      "name": "Doge Killer",
+      "symbol": "LEASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15802/thumb/Leash.png?1696515425"
+    },
+    {
+      "chainId": 1,
+      "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
+      "name": "Aleph im",
+      "symbol": "ALEPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Aleph-Logo-BW.png?1696511566"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9ce84f6a69986a83d92c324df10bc8e64771030f",
+      "name": "CHEX Token",
+      "symbol": "CHEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10349/thumb/logo-white-bg-dark.png?1733475849"
+    },
+    {
+      "chainId": 1,
+      "address": "0x946551dd05c5abd7cc808927480225ce36d8c475",
+      "name": "One",
+      "symbol": "ONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4960/thumb/Screenshot_39.png?1696505497"
+    },
+    {
+      "chainId": 1,
+      "address": "0x74232704659ef37c08995e386a2e26cc27a8d7b1",
+      "name": "Strike",
+      "symbol": "STRIKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14607/thumb/Jw-36llq_400x400.jpg?1696514286"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde2f7766c8bf14ca67193128535e5c7454f8387c",
+      "name": "Metadium",
+      "symbol": "META",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5247/thumb/metadium_symbol_black.png?1729148922"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6b0b3a982b4634ac68dd83a4dbf02311ce324181",
+      "name": "Artificial Liquid Intelligence",
+      "symbol": "ALI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/ALI-v2.webp?1728501978"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcb21311d3b91b5324f6c11b4f5a656fcacbff122",
+      "name": "QuantixAI",
+      "symbol": "QAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36166/thumb/200px_Qai.png?1726228972"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0c90c57aaf95a3a87eadda6ec3974c99d786511f",
+      "name": "HanChain",
+      "symbol": "HAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27374/thumb/logo_200.png?1696526418"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd46ba6d942050d489dbd938a2c909a5d5039a161",
+      "name": "Ampleforth",
+      "symbol": "AMPL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/4708/thumb/Ampleforth.png?1696505273"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa9e8acf069c58aec8825542845fd754e41a9489a",
+      "name": "PepeCoin",
+      "symbol": "PEPECOIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30219/thumb/pepecoin.jpeg?1696529130"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe1bad922f84b198a08292fb600319300ae32471b",
+      "name": "Firmachain",
+      "symbol": "FCT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9892/thumb/6mHcLurm_400x400.jpg?1696509941"
+    },
+    {
+      "chainId": 1,
+      "address": "0x03aa6298f1370642642415edc0db8b957783e8d6",
+      "name": "NetMind Token",
+      "symbol": "NMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35328/thumb/NMT-logo.png?1708267799"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6f40d4a6237c257fff2db00fa0510deeecd303eb",
+      "name": "Instadapp",
+      "symbol": "INST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14688/thumb/30hFM0-n_400x400.jpg?1696514361"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa3d4bee77b05d4a0c943877558ce21a763c4fa29",
+      "name": "The Root Network",
+      "symbol": "ROOT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/33122/thumb/6T1Tapl__400x400.jpg?1700740439"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf8c4a95c92b0d0121d1d20f4575073b37883d663",
+      "name": "Tubes",
+      "symbol": "TUBES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37984/thumb/TUBES.jpg?1716205639"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
+      "name": "UniLend Finance",
+      "symbol": "UFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12819/thumb/UniLend_Finance_logo_PNG.png?1696512611"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/thumb/9.png?1727331352"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa6c0c097741d55ecd9a3a7def3a8253fd022ceb9",
+      "name": "AVA  Travala ",
+      "symbol": "AVA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3014/thumb/AVA_Logo_160x160px_Black.png?1696503750"
+    },
+    {
+      "chainId": 1,
+      "address": "0xed1167b6dc64e8a366db86f2e952a482d0981ebd",
+      "name": "Lybra",
+      "symbol": "LBR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29958/thumb/New_LBR_V2.png?1696528884"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0ef786bf476fe0810408caba05e536ac800ff86",
+      "name": "Myria",
+      "symbol": "MYRIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29273/thumb/myria.png?1696528226"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ab2ff0116a279a99950c66a12298962d152b83c",
+      "name": "Ordiswap",
+      "symbol": "ORDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33910/thumb/IMG-20240113-WA0018.jpg.jpg?1705169306"
+    },
+    {
+      "chainId": 1,
+      "address": "0x226bb599a12c826476e3a771454697ea52e9e220",
+      "name": "Propy",
+      "symbol": "PRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1696502002"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbba39fd2935d5769116ce38d46a71bde9cf03099",
+      "name": "Choise ai",
+      "symbol": "CHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25935/thumb/CHO_%282%29.png?1721039541"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a3bff78b79a009976eea096a51a948a3dc00e34",
+      "name": "Wilder World",
+      "symbol": "WILD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15407/thumb/wld-logo.png?1712273448"
+    },
+    {
+      "chainId": 1,
+      "address": "0x865377367054516e17014ccded1e7d814edc9ce4",
+      "name": "DOLA",
+      "symbol": "DOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/thumb/dola.png?1696513984"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3b991130eae3cca364406d718da22fa1c3e7c256",
+      "name": "Shrub",
+      "symbol": "SHRUB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38880/thumb/photo_2024-11-13_23.58.11.png?1731575427"
+    },
+    {
+      "chainId": 1,
+      "address": "0xca5b0ae1d104030a9b8f879523508efd86c14483",
+      "name": "TYBENG",
+      "symbol": "TYBENG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31022/thumb/NVoa_mZ6_400x400.jpg?1721805735"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
+      "name": "Ignition FBTC",
+      "symbol": "FBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39182/thumb/FBTC_LOGO.png?1720850455"
+    },
+    {
+      "chainId": 1,
+      "address": "0x986ee2b944c42d017f52af21c4c69b84dbea35d8",
+      "name": "BitMart",
+      "symbol": "BMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5236/thumb/bitmart-token.png?1696505741"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaa247c0d81b83812e1abf8bab078e4540d87e3fb",
+      "name": "Meson Network",
+      "symbol": "MSN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34981/thumb/meson-token-icon200.png?1714275908"
+    },
+    {
+      "chainId": 1,
+      "address": "0x42726d074bba68ccc15200442b72afa2d495a783",
+      "name": "Isiklar Coin",
+      "symbol": "ISIKC",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/10992/thumb/logo_%2866%29.png?1696510941"
+    },
+    {
+      "chainId": 1,
+      "address": "0x31e4efe290973ebe91b3a875a7994f650942d28f",
+      "name": "Shrapnel",
+      "symbol": "SHRAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32793/thumb/shrapnel.png?1699441661"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfe39c384d702914127a005523f9915addb9bd59b",
+      "name": "Hippocrat",
+      "symbol": "HPO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4243/thumb/Hippocrat_Token_Logo_ver.1.0.jpg?1707157531"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a414884a549ef5716bc1a4e648d3dc03f08b2cf",
+      "name": "PERQ",
+      "symbol": "PERQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51486/thumb/coin-gecko-200.png?1731405387"
+    },
+    {
+      "chainId": 1,
+      "address": "0x549020a9cb845220d66d3e9c6d9f9ef61c981102",
+      "name": "Sidus",
+      "symbol": "SIDUS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21401/thumb/SIDUS_coin_logo.png?1696520765"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4123a133ae3c521fd134d7b13a2dec35b56c2463",
+      "name": "Open Custody Protocol",
+      "symbol": "OPEN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17541/thumb/OPEN-Token-Black.png?1712837762"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb31ef9e52d94d4120eb44fe1ddfde5b4654a6515",
+      "name": "DOSE",
+      "symbol": "DOSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18847/thumb/dose.PNG?1696518308"
+    },
+    {
+      "chainId": 1,
+      "address": "0x33349b282065b0284d756f0577fb39c158f935e6",
+      "name": "Maple",
+      "symbol": "MPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14097/thumb/Maple_Logo_Mark_Maple_Orange.png?1696513819"
+    },
+    {
+      "chainId": 1,
+      "address": "0x15700b564ca08d9439c58ca5053166e8317aa138",
+      "name": "Elixir deUSD",
+      "symbol": "DEUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39494/thumb/deUSD_Logo_%281%29.png?1723689002"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdab396ccf3d84cf2d07c4454e10c8a6f5b008d2b",
+      "name": "Goldfinch",
+      "symbol": "GFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19081/thumb/GOLDFINCH.png?1696518531"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd0a6053f087e87a25dc60701ba6e663b1a548e85",
+      "name": "BLOCKLORDS",
+      "symbol": "LRDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34775/thumb/LRDS_PNG.png?1706001771"
+    },
+    {
+      "chainId": 1,
+      "address": "0x839e71613f9aa06e5701cf6de63e303616b0dde3",
+      "name": "VVS Finance",
+      "symbol": "VVS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20210/thumb/8glAYOTM_400x400.jpg?1696519620"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb6667b04cb61aa16b59617f90ffa068722cf21da",
+      "name": "Worldwide USD",
+      "symbol": "WUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/thumb/WUSD%282%29.png?1715042139"
+    },
+    {
+      "chainId": 1,
+      "address": "0x68bbed6a47194eff1cf514b50ea91895597fc91e",
+      "name": "ANDY ETH",
+      "symbol": "ANDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35910/thumb/IMG_20240309_044840_797.jpg?1710179397"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa469b7ee9ee773642b3e93e842e5d9b5baa10067",
+      "name": "Anzen USDz",
+      "symbol": "USDZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38039/thumb/usdz-image-200x200.png?1716334412"
+    },
+    {
+      "chainId": 1,
+      "address": "0x64d0f55cd8c7133a9d7102b13987235f486f2224",
+      "name": "SwissBorg",
+      "symbol": "BORG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2117/thumb/YJUrRy7r_400x400.png?1696503083"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb4b9dc1c77bdbb135ea907fd5a08094d98883a35",
+      "name": "Sweat Economy",
+      "symbol": "SWEAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25057/thumb/fhD9Xs16_400x400.jpg?1696524208"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd7efb00d12c2c13131fd319336fdf952525da2af",
+      "name": "XPR Network",
+      "symbol": "XPR",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/10941/thumb/XPR.jpg?1696510891"
+    },
+    {
+      "chainId": 1,
+      "address": "0x89d584a1edb3a70b3b07963f9a3ea5399e38b136",
+      "name": "AIT Protocol",
+      "symbol": "AIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33962/thumb/ait-logo-200x200.png?1703567800"
+    },
+    {
+      "chainId": 1,
+      "address": "0x046eee2cc3188071c02bfc1745a6b17c656e3f3d",
+      "name": "Rollbit Coin",
+      "symbol": "RLB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24552/thumb/unziL6wO_400x400.jpg?1696523729"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
+      "name": "Harvest Finance",
+      "symbol": "FARM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/FARM_200x200.png?1696512134"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2c974b2d0ba1716e644c1fc59982a89ddd2ff724",
+      "name": "Viberate",
+      "symbol": "VIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/983/thumb/Viberate.png?1696502096"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44709a920fccf795fbc57baa433cc3dd53c44dbe",
+      "name": "DappRadar",
+      "symbol": "RADAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20894/thumb/radar.png?1696520286"
+    },
+    {
+      "chainId": 1,
+      "address": "0x525a8f6f3ba4752868cde25164382bfbae3990e1",
+      "name": "Nym",
+      "symbol": "NYM",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24488/thumb/NYM_Token.png?1696523668"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0763fdccf1ae541a5961815c0872a8c5bc6de4d7",
+      "name": "SUKU",
+      "symbol": "SUKU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/suku-200.png?1696511828"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc52c326331e9ce41f04484d3b5e5648158028804",
+      "name": "Unizen",
+      "symbol": "ZCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14830/thumb/logo128px.png?1700169101"
+    },
+    {
+      "chainId": 1,
+      "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
+      "name": "dForce",
+      "symbol": "DF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9709/thumb/xlGxxIjI_400x400.jpg?1696509776"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb4a3b0faf0ab53df58001804dda5bfc6a3d59008",
+      "name": "Sperax",
+      "symbol": "SPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12232/thumb/sperax_logo.jpg?1696512065"
+    },
+    {
+      "chainId": 1,
+      "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
+      "name": "Gemini Dollar",
+      "symbol": "GUSD",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/5992/thumb/gemini-dollar-gusd.png?1696506408"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf951e335afb289353dc249e82926178eac7ded78",
+      "name": "Swell Ethereum",
+      "symbol": "SWETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30326/thumb/_lB7zEtS_400x400.jpg?1696529227"
+    },
+    {
+      "chainId": 1,
+      "address": "0x590f820444fa3638e022776752c5eef34e2f89a6",
+      "name": "Alephium",
+      "symbol": "ALPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21598/thumb/Alephium-Logo_200x200_listing.png?1696520959"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf19308f923582a6f7c465e5ce7a9dc1bec6665b1",
+      "name": "TitanX",
+      "symbol": "TITANX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32762/thumb/TitanXpng_%281%29.png?1704456654"
+    },
+    {
+      "chainId": 1,
+      "address": "0x174c47d6a4e548ed2b7d369dc0ffb2e60a6ac0f8",
+      "name": "Amulet Protocol",
+      "symbol": "AMU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/34716/thumb/AMT200x200.png?1705904544"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0305f515fa978cf87226cf8a9776d25bcfb2cc0b",
+      "name": "Pepe 2 0",
+      "symbol": "PEPE20",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30853/thumb/PEPE_2.0.png?1707684909"
+    },
+    {
+      "chainId": 1,
+      "address": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
+      "name": "Staked USD0",
+      "symbol": "USD0++",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39169/thumb/0x35d8949372d46b7a3d5a56006ae77b215fc69bc0.png?1720798057"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8be3460a480c80728a8c4d7a5d5303c85ba7b3b9",
+      "name": "Ethena Staked ENA",
+      "symbol": "SENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50235/thumb/ena.png?1726630994"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3a856d4effa670c54585a5d523e96513e148e95d",
+      "name": "TriasLab",
+      "symbol": "TRIAS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13963/thumb/5ELqtwp__400x400_%281%29.jpg?1696513699"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfc4b4ec763722b71eb1d729749b447a9645f5f30",
+      "name": "DumbMoney",
+      "symbol": "GME",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32058/thumb/DumbMoney_-_GME_-_Official_Logo_200x200px.png?1696530855"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc581b735a1688071a1746c968e0798d642ede491",
+      "name": "Euro Tether",
+      "symbol": "EURT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17385/thumb/Tether_new.png?1696516934"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbb6cf73a00f480d0951ba979a7606857cdde626b",
+      "name": "Arix",
+      "symbol": "ARIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13485/thumb/ARIX.png?1696513245"
+    },
+    {
+      "chainId": 1,
+      "address": "0xccc8cb5229b0ac8069c51fd58367fd1e622afd97",
+      "name": "Gods Unchained",
+      "symbol": "GODS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17139/thumb/10631.png?1696516698"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0921799cb1d702148131024d18fcde022129dc73",
+      "name": "LightLink",
+      "symbol": "LL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35357/thumb/lightlink-ticker-200.png?1708362303"
+    },
+    {
+      "chainId": 1,
+      "address": "0xda987c655ebc38c801db64a8608bc1aa56cd9a31",
+      "name": "Synternet",
+      "symbol": "SYNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38888/thumb/_SYNT.png?1719380207"
+    },
+    {
+      "chainId": 1,
+      "address": "0x046bad07658f3b6cad9a396cfcbc1243af452ec1",
+      "name": "ArchLoot",
+      "symbol": "AL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28919/thumb/7.png?1696527894"
+    },
+    {
+      "chainId": 1,
+      "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
+      "name": "AirSwap",
+      "symbol": "AST",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1696502130"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9ee8c380e1926730ad89e91665ff27063b13c90a",
+      "name": "Coupon Assets",
+      "symbol": "CA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32202/thumb/ca.jpg?1696746380"
+    },
+    {
+      "chainId": 1,
+      "address": "0x487d62468282bd04ddf976631c23128a425555ee",
+      "name": "UPCX",
+      "symbol": "UPC",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/33308/thumb/02_UPC_logo_RGB_black_200_200.png?1701409035"
+    },
+    {
+      "chainId": 1,
+      "address": "0x560363bda52bc6a44ca6c8c9b4a5fadbda32fa60",
+      "name": "Seedify fund",
+      "symbol": "SFUND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14614/thumb/Favicon_Icon.png?1696514292"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1ce270557c1f68cfb577b856766310bf8b47fd9c",
+      "name": "MongCoin",
+      "symbol": "MONG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30051/thumb/BrandMark.png?1721838570"
+    },
+    {
+      "chainId": 1,
+      "address": "0x939069722d568b5498ccba4356e800eaefefd2a5",
+      "name": "Finanx AI",
+      "symbol": "FNXAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51119/thumb/200x200.png?1730126766"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7fd4d7737597e7b4ee22acbf8d94362343ae0a79",
+      "name": "Wrapped MistCoin",
+      "symbol": "WMC",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/32490/thumb/355966EE-F4AD-4023-A38E-59B9DEF1C6C3.jpeg?1732678326"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6a9b3fdb4a3296ecba1ebfa2cf4a8b16032a769c",
+      "name": "bitSmiley",
+      "symbol": "SMILE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51309/thumb/Copy_of_Token_icon_White_background.png?1730635535"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc477d038d5420c6a9e0b031712f61c5120090de9",
+      "name": "Boson Protocol",
+      "symbol": "BOSON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14710/thumb/boson_logo.png?1696514381"
+    }
+  ],
+  "timestamp": "2024-12-06T16:10:22.555Z"
+}

--- a/src/public/CoinGecko.100.json
+++ b/src/public/CoinGecko.100.json
@@ -1,5 +1,5 @@
 {
-  "name": "Coingecko top 500 on xdai",
+  "name": "Coingecko top 80 on Gnosis chain",
   "logoURI": "https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png",
   "keywords": [
     "defi"
@@ -16,7 +16,7 @@
       "name": "Chainlink",
       "symbol": "LINK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/877/thumb/chainlink-new-logo.png?1696502009"
+      "logoURI": "https://assets.coingecko.com/coins/images/877/large/chainlink-new-logo.png?1696502009"
     },
     {
       "chainId": 100,
@@ -24,15 +24,7 @@
       "name": "Uniswap",
       "symbol": "UNI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12504/thumb/uniswap-logo.png?1720676669"
-    },
-    {
-      "chainId": 100,
-      "address": "0xbf65bfcb5da067446cee6a706ba3fe2fb1a9fdfd",
-      "name": "yearn finance",
-      "symbol": "YFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yearn.jpg?1696511720"
+      "logoURI": "https://assets.coingecko.com/coins/images/12504/large/uniswap-logo.png?1720676669"
     },
     {
       "chainId": 100,
@@ -40,7 +32,15 @@
       "name": "Tellor Tributes",
       "symbol": "TRB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1696509713"
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/large/Blk_icon_current.png?1696509713"
+    },
+    {
+      "chainId": 100,
+      "address": "0xbf65bfcb5da067446cee6a706ba3fe2fb1a9fdfd",
+      "name": "yearn finance",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/large/yearn.jpg?1696511720"
     },
     {
       "chainId": 100,
@@ -48,7 +48,7 @@
       "name": "Safe",
       "symbol": "SAFE",
       "decimals": 15,
-      "logoURI": "https://assets.coingecko.com/coins/images/27032/thumb/Artboard_1_copy_8circle-1.png?1696526084"
+      "logoURI": "https://assets.coingecko.com/coins/images/27032/large/Artboard_1_copy_8circle-1.png?1696526084"
     },
     {
       "chainId": 100,
@@ -56,15 +56,7 @@
       "name": "CoW Protocol",
       "symbol": "COW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24384/thumb/CoW-token_logo.png?1719524382"
-    },
-    {
-      "chainId": 100,
-      "address": "0x7ecf26cd9a36990b8ea477853663092333f59979",
-      "name": "Perpetual Protocol",
-      "symbol": "PERP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
     },
     {
       "chainId": 100,
@@ -72,7 +64,7 @@
       "name": "Badger",
       "symbol": "BADGER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1696513059"
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1696513059"
     },
     {
       "chainId": 100,
@@ -80,7 +72,15 @@
       "name": "Balancer",
       "symbol": "BAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1696511572"
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
+    },
+    {
+      "chainId": 100,
+      "address": "0x7ecf26cd9a36990b8ea477853663092333f59979",
+      "name": "Perpetual Protocol",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
     },
     {
       "chainId": 100,
@@ -88,7 +88,7 @@
       "name": "Gnosis",
       "symbol": "GNO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/662/thumb/logo_square_simple_300px.png?1696501854"
+      "logoURI": "https://assets.coingecko.com/coins/images/662/large/logo_square_simple_300px.png?1696501854"
     },
     {
       "chainId": 100,
@@ -96,7 +96,7 @@
       "name": "crvUSD",
       "symbol": "CRVUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30118/thumb/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/large/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
     },
     {
       "chainId": 100,
@@ -104,7 +104,7 @@
       "name": "Streamr",
       "symbol": "DATA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17869/thumb/DATA_new_symbol_3x.png?1696517392"
+      "logoURI": "https://assets.coingecko.com/coins/images/17869/large/DATA_new_symbol_3x.png?1696517392"
     },
     {
       "chainId": 100,
@@ -112,39 +112,7 @@
       "name": "Savings xDAI",
       "symbol": "SDAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32066/thumb/sDAI_Logo_%281%29.png?1696530863"
-    },
-    {
-      "chainId": 100,
-      "address": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
-      "name": "Monerium EUR emoney",
-      "symbol": "EURE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23354/thumb/eur.png?1696522569"
-    },
-    {
-      "chainId": 100,
-      "address": "0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f",
-      "name": "Autonolas",
-      "symbol": "OLAS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31099/thumb/OLAS-token.png?1696529930"
-    },
-    {
-      "chainId": 100,
-      "address": "0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8",
-      "name": "Everclear",
-      "symbol": "NEXT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31293/thumb/photo_2024-06-03_12-14-59.png?1717638614"
-    },
-    {
-      "chainId": 100,
-      "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
-      "name": "Gnosis xDai Bridged WETH  Gnosis Chain ",
-      "symbol": "WETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39731/thumb/weth.png?1723759168"
+      "logoURI": "https://assets.coingecko.com/coins/images/32066/large/sDAI_Logo_%281%29.png?1696530863"
     },
     {
       "chainId": 100,
@@ -152,31 +120,15 @@
       "name": "Bridged Wrapped stETH  Gnosis ",
       "symbol": "WSTETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33017/thumb/wStETH.png?1700190250"
+      "logoURI": "https://assets.coingecko.com/coins/images/33017/large/wStETH.png?1700190250"
     },
     {
       "chainId": 100,
-      "address": "0xd589f00fa2eb83367f732ab3cda92ee0940389cf",
-      "name": "Fuse",
-      "symbol": "FUSE",
+      "address": "0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8",
+      "name": "Everclear",
+      "symbol": "NEXT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10347/thumb/fuse.png?1696510348"
-    },
-    {
-      "chainId": 100,
-      "address": "0xdbf3ea6f5bee45c02255b2c26a16f300502f68da",
-      "name": "Swarm",
-      "symbol": "BZZ",
-      "decimals": 16,
-      "logoURI": "https://assets.coingecko.com/coins/images/16509/thumb/Circle_Orange_onWhite.png?1696516071"
-    },
-    {
-      "chainId": 100,
-      "address": "0x6a8cb6714b1ee5b471a7d2ec4302cb4f5ff25ec2",
-      "name": "Energy Web",
-      "symbol": "EWT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10886/thumb/R9gQTJV__400x400.png?1696510839"
+      "logoURI": "https://assets.coingecko.com/coins/images/31293/large/photo_2024-06-03_12-14-59.png?1717638614"
     },
     {
       "chainId": 100,
@@ -184,7 +136,23 @@
       "name": "ShapeShift FOX",
       "symbol": "FOX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/fox_token.png?1728373561"
+      "logoURI": "https://assets.coingecko.com/coins/images/9988/large/fox_token.png?1728373561"
+    },
+    {
+      "chainId": 100,
+      "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
+      "name": "Gnosis xDai Bridged WETH  Gnosis Chain ",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39731/large/weth.png?1723759168"
+    },
+    {
+      "chainId": 100,
+      "address": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
+      "name": "Monerium EUR emoney",
+      "symbol": "EURE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23354/large/eur.png?1696522569"
     },
     {
       "chainId": 100,
@@ -192,23 +160,7 @@
       "name": "HOPR",
       "symbol": "HOPR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1696513786"
-    },
-    {
-      "chainId": 100,
-      "address": "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
-      "name": "Gnosis xDAI Bridged USDC  Gnosis ",
-      "symbol": "USDC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35300/thumb/USDC_Icon.png?1708083625"
-    },
-    {
-      "chainId": 100,
-      "address": "0xfecb3f7c54e2caae9dc6ac9060a822d47e053760",
-      "name": "BRLA Digital BRLA",
-      "symbol": "BRLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40062/thumb/IconGreen400.png?1725459580"
+      "logoURI": "https://assets.coingecko.com/coins/images/14061/large/Shared_HOPR_logo_512px.png?1696513786"
     },
     {
       "chainId": 100,
@@ -216,15 +168,7 @@
       "name": "Gyroscope GYD",
       "symbol": "GYD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33428/thumb/GYD-gradient_resized_transparent.png?1702316822"
-    },
-    {
-      "chainId": 100,
-      "address": "0x37b60f4e9a31a64ccc0024dce7d0fd07eaa0f7b3",
-      "name": "Kleros",
-      "symbol": "PNK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3833/thumb/kleros.png?1696504500"
+      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
     },
     {
       "chainId": 100,
@@ -232,31 +176,31 @@
       "name": "Gnosis xDai Bridged USDT  Gnosis ",
       "symbol": "USDT",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35072/thumb/logo.png?1707292488"
+      "logoURI": "https://assets.coingecko.com/coins/images/35072/large/logo.png?1707292488"
     },
     {
       "chainId": 100,
-      "address": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
-      "name": "XDAI",
-      "symbol": "XDAI",
+      "address": "0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f",
+      "name": "Autonolas",
+      "symbol": "OLAS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11062/thumb/Identity-Primary-DarkBG.png?1696511004"
+      "logoURI": "https://assets.coingecko.com/coins/images/31099/large/OLAS-token.png?1696529930"
     },
     {
       "chainId": 100,
-      "address": "0x4b1e2c2762667331bc91648052f646d1b0d35984",
-      "name": "EURA",
-      "symbol": "EURA",
+      "address": "0xd589f00fa2eb83367f732ab3cda92ee0940389cf",
+      "name": "Fuse",
+      "symbol": "FUSE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19479/thumb/agEUR-4.png?1710726218"
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
     },
     {
       "chainId": 100,
-      "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
-      "name": "Aura Finance",
-      "symbol": "AURA",
+      "address": "0x6a8cb6714b1ee5b471a7d2ec4302cb4f5ff25ec2",
+      "name": "Energy Web",
+      "symbol": "EWT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25942/thumb/logo.png?1696525021"
+      "logoURI": "https://assets.coingecko.com/coins/images/10886/large/R9gQTJV__400x400.png?1696510839"
     },
     {
       "chainId": 100,
@@ -264,47 +208,47 @@
       "name": "Gnosis xDAI Bridged USDC  Gnosis ",
       "symbol": "USDCE",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/38775/thumb/USDC_Icon.webp?1718798033"
+      "logoURI": "https://assets.coingecko.com/coins/images/38775/large/USDC_Icon.webp?1718798033"
     },
     {
       "chainId": 100,
-      "address": "0x8e5bbbb09ed1ebde8674cda39a0c169401db4252",
-      "name": "Gnosis xDai Bridged WBTC  Gnosis Chain ",
-      "symbol": "WBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39595/thumb/wbtc.png?1723016785"
+      "address": "0xdbf3ea6f5bee45c02255b2c26a16f300502f68da",
+      "name": "Swarm",
+      "symbol": "BZZ",
+      "decimals": 16,
+      "logoURI": "https://assets.coingecko.com/coins/images/16509/large/Circle_Orange_onWhite.png?1696516071"
     },
     {
       "chainId": 100,
-      "address": "0x8b8407c6184f1f0fd1082e83d6a3b8349caced12",
-      "name": "Circuits of Value",
-      "symbol": "COVAL",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/588/thumb/coval-logo.png?1696501792"
+      "address": "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+      "name": "Gnosis xDAI Bridged USDC  Gnosis ",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35300/large/USDC_Icon.png?1708083625"
     },
     {
       "chainId": 100,
-      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-      "name": "Hop Protocol",
-      "symbol": "HOP",
+      "address": "0x4b1e2c2762667331bc91648052f646d1b0d35984",
+      "name": "EURA",
+      "symbol": "EURA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25445/thumb/hop.png?1696524577"
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/large/agEUR-4.png?1710726218"
     },
     {
       "chainId": 100,
-      "address": "0x84e2c67cbefae6b5148fca7d02b341b12ff4b5bb",
-      "name": "Swash",
-      "symbol": "SWASH",
+      "address": "0xfecb3f7c54e2caae9dc6ac9060a822d47e053760",
+      "name": "BRLA Digital BRLA",
+      "symbol": "BRLA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18774/thumb/Swash_icon_GP.png?1712869197"
+      "logoURI": "https://assets.coingecko.com/coins/images/40062/large/IconGreen400.png?1725459580"
     },
     {
       "chainId": 100,
-      "address": "0x3f56e0c36d275367b8c502090edf38289b3dea0d",
-      "name": "MAI",
-      "symbol": "MIMATIC",
+      "address": "0x37b60f4e9a31a64ccc0024dce7d0fd07eaa0f7b3",
+      "name": "Kleros",
+      "symbol": "PNK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15264/thumb/mimatic-red.png?1696514916"
+      "logoURI": "https://assets.coingecko.com/coins/images/3833/large/kleros.png?1696504500"
     },
     {
       "chainId": 100,
@@ -312,47 +256,7 @@
       "name": "USDA",
       "symbol": "USDA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34510/thumb/agUSD-coingecko.png?1705288392"
-    },
-    {
-      "chainId": 100,
-      "address": "0x48b1b0d077b4919b65b4e4114806dd803901e1d9",
-      "name": "Etherisc DIP",
-      "symbol": "DIP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4586/thumb/dip.png?1696505164"
-    },
-    {
-      "chainId": 100,
-      "address": "0xeeeeeb57642040be42185f49c52f7e9b38f8eeee",
-      "name": "Elk Finance",
-      "symbol": "ELK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17813/thumb/elk.png?1696517333"
-    },
-    {
-      "chainId": 100,
-      "address": "0x5cb9073902f2035222b9749f8fb0c9bfe5527108",
-      "name": "Monerium GBP emoney",
-      "symbol": "GBPE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39004/thumb/gbp.png?1719840784"
-    },
-    {
-      "chainId": 100,
-      "address": "0x9fb1d52596c44603198fb0aee434fac3a679f702",
-      "name": "Jarvis Synthetic Euro",
-      "symbol": "JEUR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15725/thumb/jEUR.png?1696515352"
-    },
-    {
-      "chainId": 100,
-      "address": "0x431d5dff03120afa4bdf332c61a6e1766ef37bdb",
-      "name": "JPY Coin",
-      "symbol": "JPYC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25971/thumb/2023jpyc.png?1696525049"
+      "logoURI": "https://assets.coingecko.com/coins/images/34510/large/agUSD-coingecko.png?1705288392"
     },
     {
       "chainId": 100,
@@ -360,55 +264,7 @@
       "name": "DeFi Pulse Index",
       "symbol": "DPI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1696512284"
-    },
-    {
-      "chainId": 100,
-      "address": "0x1d1498166ddceee616a6d99868e1e0677300056f",
-      "name": "Space Token",
-      "symbol": "SPACE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20676/thumb/jYw3kgsY_400x400.png?1696520076"
-    },
-    {
-      "chainId": 100,
-      "address": "0x2086f52651837600180de173b09470f54ef74910",
-      "name": "Balancer Stable USD",
-      "symbol": "STABAL3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32112/thumb/bal3.png?1696561317"
-    },
-    {
-      "chainId": 100,
-      "address": "0x524b969793a64a602342d89bc2789d43a016b13a",
-      "name": "Donut",
-      "symbol": "DONUT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7538/thumb/Donut.png?1696507804"
-    },
-    {
-      "chainId": 100,
-      "address": "0x2d5563da42b06fbbf9c67b7dc073cf6a7842239e",
-      "name": "Jarvis Synthetic Swiss Franc",
-      "symbol": "JCHF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15727/thumb/jCHF.png?1696515353"
-    },
-    {
-      "chainId": 100,
-      "address": "0xd0dd6cef72143e22cced4867eb0d5f2328715533",
-      "name": "Aave v3 DAI",
-      "symbol": "ADAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32886/thumb/dai.png?1699769446"
-    },
-    {
-      "chainId": 100,
-      "address": "0xf490c80aae5f2616d3e3bda2483e30c4cb21d1a0",
-      "name": "StakeWise Staked GNO",
-      "symbol": "OSGNO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39458/thumb/stakewiseosgno_32.webp?1722390395"
+      "logoURI": "https://assets.coingecko.com/coins/images/12465/large/defi_pulse_index_set.png?1696512284"
     },
     {
       "chainId": 100,
@@ -416,39 +272,119 @@
       "name": "Giveth",
       "symbol": "GIV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21792/thumb/GIVToken_200x200.png?1722577147"
+      "logoURI": "https://assets.coingecko.com/coins/images/21792/large/GIVToken_200x200.png?1722577147"
     },
     {
       "chainId": 100,
-      "address": "0xec3f3e6d7907acda3a7431abd230196cda3fbb19",
-      "name": "Ethix",
-      "symbol": "ETHIX",
+      "address": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
+      "name": "XDAI",
+      "symbol": "XDAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3031/thumb/ETHIX_icon_256x256-256.png?1696503766"
+      "logoURI": "https://assets.coingecko.com/coins/images/11062/large/Identity-Primary-DarkBG.png?1696511004"
     },
     {
       "chainId": 100,
-      "address": "0x3a97704a1b25f08aa230ae53b352e2e72ef52843",
-      "name": "Agave",
-      "symbol": "AGVE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14146/thumb/agve.png?1696513865"
+      "address": "0x8e5bbbb09ed1ebde8674cda39a0c169401db4252",
+      "name": "Gnosis xDai Bridged WBTC  Gnosis Chain ",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39595/large/wbtc.png?1723016785"
     },
     {
       "chainId": 100,
-      "address": "0x44fa8e6f47987339850636f88629646662444217",
-      "name": "OmniBridge Bridged DAI  Gnosis Chain ",
-      "symbol": "DAI",
+      "address": "0x84e2c67cbefae6b5148fca7d02b341b12ff4b5bb",
+      "name": "Swash",
+      "symbol": "SWASH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39808/thumb/dai.png?1724126705"
+      "logoURI": "https://assets.coingecko.com/coins/images/18774/large/Swash_icon_GP.png?1712869197"
     },
     {
       "chainId": 100,
-      "address": "0x71850b7e9ee3f13ab46d67167341e4bdc905eef9",
-      "name": "Honey",
-      "symbol": "HNY",
+      "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
+      "name": "Aura Finance",
+      "symbol": "AURA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12895/thumb/hnys.png?1696512683"
+      "logoURI": "https://assets.coingecko.com/coins/images/25942/large/logo.png?1696525021"
+    },
+    {
+      "chainId": 100,
+      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "name": "Hop Protocol",
+      "symbol": "HOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25445/large/hop.png?1696524577"
+    },
+    {
+      "chainId": 100,
+      "address": "0x8b8407c6184f1f0fd1082e83d6a3b8349caced12",
+      "name": "Circuits of Value",
+      "symbol": "COVAL",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/588/large/coval-logo.png?1696501792"
+    },
+    {
+      "chainId": 100,
+      "address": "0x5cb9073902f2035222b9749f8fb0c9bfe5527108",
+      "name": "Monerium GBP emoney",
+      "symbol": "GBPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39004/large/gbp.png?1719840784"
+    },
+    {
+      "chainId": 100,
+      "address": "0x3f56e0c36d275367b8c502090edf38289b3dea0d",
+      "name": "MAI",
+      "symbol": "MIMATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15264/large/mimatic-red.png?1696514916"
+    },
+    {
+      "chainId": 100,
+      "address": "0xeeeeeb57642040be42185f49c52f7e9b38f8eeee",
+      "name": "Elk Finance",
+      "symbol": "ELK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17813/large/elk.png?1696517333"
+    },
+    {
+      "chainId": 100,
+      "address": "0x431d5dff03120afa4bdf332c61a6e1766ef37bdb",
+      "name": "JPY Coin",
+      "symbol": "JPYC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25971/large/2023jpyc.png?1696525049"
+    },
+    {
+      "chainId": 100,
+      "address": "0x9fb1d52596c44603198fb0aee434fac3a679f702",
+      "name": "Jarvis Synthetic Euro",
+      "symbol": "JEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15725/large/jEUR.png?1696515352"
+    },
+    {
+      "chainId": 100,
+      "address": "0x2d5563da42b06fbbf9c67b7dc073cf6a7842239e",
+      "name": "Jarvis Synthetic Swiss Franc",
+      "symbol": "JCHF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15727/large/jCHF.png?1696515353"
+    },
+    {
+      "chainId": 100,
+      "address": "0xd0dd6cef72143e22cced4867eb0d5f2328715533",
+      "name": "Aave v3 DAI",
+      "symbol": "ADAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32886/large/dai.png?1699769446"
+    },
+    {
+      "chainId": 100,
+      "address": "0x2086f52651837600180de173b09470f54ef74910",
+      "name": "Balancer Stable USD",
+      "symbol": "STABAL3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32112/large/bal3.png?1696561317"
     },
     {
       "chainId": 100,
@@ -456,47 +392,15 @@
       "name": "Angle Staked EURA",
       "symbol": "STEUR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32036/thumb/stEUR-x4.png?1696530832"
+      "logoURI": "https://assets.coingecko.com/coins/images/32036/large/stEUR-x4.png?1696530832"
     },
     {
       "chainId": 100,
-      "address": "0x0aa1e96d2a46ec6beb2923de1e61addf5f5f1dce",
-      "name": "RealToken Ecosystem Governance",
-      "symbol": "REG",
+      "address": "0x1d1498166ddceee616a6d99868e1e0677300056f",
+      "name": "Space Token",
+      "symbol": "SPACE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37785/thumb/realt.jpeg?1715586329"
-    },
-    {
-      "chainId": 100,
-      "address": "0xfbdd194376de19a88118e84e279b977f165d01b8",
-      "name": "DeHive",
-      "symbol": "DHV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14926/thumb/logo_200x200.png?1696514587"
-    },
-    {
-      "chainId": 100,
-      "address": "0x83ff60e2f93f8edd0637ef669c69d5fb4f64ca8e",
-      "name": "BrightID",
-      "symbol": "BRIGHT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18415/thumb/bright.PNG?1696517905"
-    },
-    {
-      "chainId": 100,
-      "address": "0x417602f4fbdd471a431ae29fb5fe0a681964c11b",
-      "name": "JPY Coin v1",
-      "symbol": "JPYC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17277/thumb/WoZ8rruL_400x400.png?1696516831"
-    },
-    {
-      "chainId": 100,
-      "address": "0xfa57aa7beed63d03aaf85ffd1753f5f6242588fb",
-      "name": "Mt Pelerin Shares",
-      "symbol": "MPS",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/11471/thumb/MPS.png?1696511378"
+      "logoURI": "https://assets.coingecko.com/coins/images/20676/large/jYw3kgsY_400x400.png?1696520076"
     },
     {
       "chainId": 100,
@@ -504,7 +408,63 @@
       "name": "1Hive Water",
       "symbol": "WATER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26089/thumb/water_logo.png?1696525180"
+      "logoURI": "https://assets.coingecko.com/coins/images/26089/large/water_logo.png?1696525180"
+    },
+    {
+      "chainId": 100,
+      "address": "0x71850b7e9ee3f13ab46d67167341e4bdc905eef9",
+      "name": "Honey",
+      "symbol": "HNY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12895/large/hnys.png?1696512683"
+    },
+    {
+      "chainId": 100,
+      "address": "0xec3f3e6d7907acda3a7431abd230196cda3fbb19",
+      "name": "Ethix",
+      "symbol": "ETHIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3031/large/ETHIX_icon_256x256-256.png?1696503766"
+    },
+    {
+      "chainId": 100,
+      "address": "0x48b1b0d077b4919b65b4e4114806dd803901e1d9",
+      "name": "Etherisc DIP",
+      "symbol": "DIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4586/large/dip.png?1696505164"
+    },
+    {
+      "chainId": 100,
+      "address": "0x83ff60e2f93f8edd0637ef669c69d5fb4f64ca8e",
+      "name": "BrightID",
+      "symbol": "BRIGHT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18415/large/bright.PNG?1696517905"
+    },
+    {
+      "chainId": 100,
+      "address": "0xf490c80aae5f2616d3e3bda2483e30c4cb21d1a0",
+      "name": "StakeWise Staked GNO",
+      "symbol": "OSGNO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39458/large/stakewiseosgno_32.webp?1722390395"
+    },
+    {
+      "chainId": 100,
+      "address": "0x3a3e9715018d80916740e8ac300713fdf6614d19",
+      "name": "hiveWater",
+      "symbol": "HIVEWATER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30424/large/hivewater_transparent.png?1696529312"
+    },
+    {
+      "chainId": 100,
+      "address": "0x3a97704a1b25f08aa230ae53b352e2e72ef52843",
+      "name": "Agave",
+      "symbol": "AGVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14146/large/agve.png?1696513865"
     },
     {
       "chainId": 100,
@@ -515,27 +475,43 @@
     },
     {
       "chainId": 100,
-      "address": "0xb0c5f3100a4d9d9532a4cfd68c55f1ae8da987eb",
-      "name": "DAOhaus",
-      "symbol": "HAUS",
-      "decimals": 35,
-      "logoURI": "https://assets.coingecko.com/coins/images/14551/thumb/jN3kkqke_400x400.png?1696514234"
-    },
-    {
-      "chainId": 100,
       "address": "0x97edc0e345fbbbd8460847fcfa3bc2a13bf8641f",
       "name": "DAOSquare",
       "symbol": "RICE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19084/thumb/tw5gu1dW_400x400.jpeg?1696518537"
+      "logoURI": "https://assets.coingecko.com/coins/images/19084/large/tw5gu1dW_400x400.jpeg?1696518537"
     },
     {
       "chainId": 100,
-      "address": "0x3a3e9715018d80916740e8ac300713fdf6614d19",
-      "name": "hiveWater",
-      "symbol": "HIVEWATER",
+      "address": "0x524b969793a64a602342d89bc2789d43a016b13a",
+      "name": "Donut",
+      "symbol": "DONUT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30424/thumb/hivewater_transparent.png?1696529312"
+      "logoURI": "https://assets.coingecko.com/coins/images/7538/large/Donut.png?1696507804"
+    },
+    {
+      "chainId": 100,
+      "address": "0xfbdd194376de19a88118e84e279b977f165d01b8",
+      "name": "DeHive",
+      "symbol": "DHV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14926/large/logo_200x200.png?1696514587"
+    },
+    {
+      "chainId": 100,
+      "address": "0x0aa1e96d2a46ec6beb2923de1e61addf5f5f1dce",
+      "name": "RealToken Ecosystem Governance",
+      "symbol": "REG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37785/large/realt.jpeg?1715586329"
+    },
+    {
+      "chainId": 100,
+      "address": "0xb0c5f3100a4d9d9532a4cfd68c55f1ae8da987eb",
+      "name": "DAOhaus",
+      "symbol": "HAUS",
+      "decimals": 35,
+      "logoURI": "https://assets.coingecko.com/coins/images/14551/large/jN3kkqke_400x400.png?1696514234"
     },
     {
       "chainId": 100,
@@ -543,7 +519,15 @@
       "name": "Swapr",
       "symbol": "SWPR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18740/thumb/swapr.jpg?1696518206"
+      "logoURI": "https://assets.coingecko.com/coins/images/18740/large/swapr.jpg?1696518206"
+    },
+    {
+      "chainId": 100,
+      "address": "0xfa57aa7beed63d03aaf85ffd1753f5f6242588fb",
+      "name": "Mt Pelerin Shares",
+      "symbol": "MPS",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/11471/large/MPS.png?1696511378"
     },
     {
       "chainId": 100,
@@ -551,7 +535,15 @@
       "name": "Backed Coinbase Global",
       "symbol": "BCOIN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31872/thumb/b-COIN-200x200.png?1696530684"
+      "logoURI": "https://assets.coingecko.com/coins/images/31872/large/b-COIN-200x200.png?1696530684"
+    },
+    {
+      "chainId": 100,
+      "address": "0x417602f4fbdd471a431ae29fb5fe0a681964c11b",
+      "name": "JPY Coin v1",
+      "symbol": "JPYC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17277/large/WoZ8rruL_400x400.png?1696516831"
     },
     {
       "chainId": 100,
@@ -559,7 +551,7 @@
       "name": "0xMonero",
       "symbol": "0XMR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11035/thumb/0xmnr.PNG?1696510979"
+      "logoURI": "https://assets.coingecko.com/coins/images/11035/large/0xmnr.PNG?1696510979"
     },
     {
       "chainId": 100,
@@ -567,7 +559,15 @@
       "name": "Zenland",
       "symbol": "ZENF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29477/thumb/tokenicon200px.png?1696528421"
+      "logoURI": "https://assets.coingecko.com/coins/images/29477/large/tokenicon200px.png?1696528421"
+    },
+    {
+      "chainId": 100,
+      "address": "0x44fa8e6f47987339850636f88629646662444217",
+      "name": "OmniBridge Bridged DAI  Gnosis Chain ",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39808/large/dai.png?1724126705"
     },
     {
       "chainId": 100,
@@ -575,23 +575,7 @@
       "name": "DXdao",
       "symbol": "DXD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11148/thumb/dxdao.png?1696511083"
-    },
-    {
-      "chainId": 100,
-      "address": "0x18e9262e68cc6c6004db93105cc7c001bb103e49",
-      "name": "Raid",
-      "symbol": "RAID",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18133/thumb/raid_200_oswlvz.png?1696517636"
-    },
-    {
-      "chainId": 100,
-      "address": "0x364b5975385b4de226cf450df82d7ed69902ac5a",
-      "name": "TORG",
-      "symbol": "TORG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17596/thumb/TORG_Logo_200x200.png?1696517129"
+      "logoURI": "https://assets.coingecko.com/coins/images/11148/large/dxdao.png?1696511083"
     },
     {
       "chainId": 100,
@@ -599,7 +583,15 @@
       "name": "STAKE",
       "symbol": "STAKE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11061/thumb/xdai.png?1696511003"
+      "logoURI": "https://assets.coingecko.com/coins/images/11061/large/xdai.png?1696511003"
+    },
+    {
+      "chainId": 100,
+      "address": "0x18e9262e68cc6c6004db93105cc7c001bb103e49",
+      "name": "Raid",
+      "symbol": "RAID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18133/large/raid_200_oswlvz.png?1696517636"
     },
     {
       "chainId": 100,
@@ -607,15 +599,15 @@
       "name": "Minerva Wallet",
       "symbol": "MIVA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14732/thumb/MIVA-Token_200x200.png?1696514401"
+      "logoURI": "https://assets.coingecko.com/coins/images/14732/large/MIVA-Token_200x200.png?1696514401"
     },
     {
       "chainId": 100,
-      "address": "0x1e2c4fb7ede391d116e6b41cd0608260e8801d59",
-      "name": "Backed CSPX Core S P 500",
-      "symbol": "BCSPX",
+      "address": "0x364b5975385b4de226cf450df82d7ed69902ac5a",
+      "name": "TORG",
+      "symbol": "TORG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31891/thumb/b-CSPX-200x200.png?1696530702"
+      "logoURI": "https://assets.coingecko.com/coins/images/17596/large/TORG_Logo_200x200.png?1696517129"
     },
     {
       "chainId": 100,
@@ -623,7 +615,7 @@
       "name": "Particle",
       "symbol": "PRTCLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14395/thumb/unknown.png?1696514085"
+      "logoURI": "https://assets.coingecko.com/coins/images/14395/large/unknown.png?1696514085"
     },
     {
       "chainId": 100,
@@ -631,7 +623,23 @@
       "name": "xDai Native Comb",
       "symbol": "XCOMB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16012/thumb/logo.png?1696515623"
+      "logoURI": "https://assets.coingecko.com/coins/images/16012/large/logo.png?1696515623"
+    },
+    {
+      "chainId": 100,
+      "address": "0x1e2c4fb7ede391d116e6b41cd0608260e8801d59",
+      "name": "Backed CSPX Core S P 500",
+      "symbol": "BCSPX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31891/large/b-CSPX-200x200.png?1696530702"
+    },
+    {
+      "chainId": 100,
+      "address": "0xa818f1b57c201e092c4a2017a91815034326efd1",
+      "name": "Aave v3 WETH",
+      "symbol": "AWETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32882/large/WETH_%281%29.png?1699716492"
     },
     {
       "chainId": 100,
@@ -639,8 +647,8 @@
       "name": "Aave v3 USDC",
       "symbol": "AUSDC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/32847/thumb/usdc_%281%29.png?1699619355"
+      "logoURI": "https://assets.coingecko.com/coins/images/32847/large/usdc_%281%29.png?1699619355"
     }
   ],
-  "timestamp": "2024-12-06T16:12:22.702Z"
+  "timestamp": "2024-12-10T17:05:15.190Z"
 }

--- a/src/public/CoinGecko.100.json
+++ b/src/public/CoinGecko.100.json
@@ -1,0 +1,646 @@
+{
+  "name": "Coingecko top 500 on xdai",
+  "logoURI": "https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png",
+  "keywords": [
+    "defi"
+  ],
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 100,
+      "address": "0xe2e73a1c69ecf83f464efce6a5be353a37ca09b2",
+      "name": "Chainlink",
+      "symbol": "LINK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/877/thumb/chainlink-new-logo.png?1696502009"
+    },
+    {
+      "chainId": 100,
+      "address": "0x4537e328bf7e4efa29d05caea260d7fe26af9d74",
+      "name": "Uniswap",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12504/thumb/uniswap-logo.png?1720676669"
+    },
+    {
+      "chainId": 100,
+      "address": "0xbf65bfcb5da067446cee6a706ba3fe2fb1a9fdfd",
+      "name": "yearn finance",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yearn.jpg?1696511720"
+    },
+    {
+      "chainId": 100,
+      "address": "0xaad66432d27737ecf6ed183160adc5ef36ab99f2",
+      "name": "Tellor Tributes",
+      "symbol": "TRB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1696509713"
+    },
+    {
+      "chainId": 100,
+      "address": "0x4d18815d14fe5c3304e87b3fa18318baa5c23820",
+      "name": "Safe",
+      "symbol": "SAFE",
+      "decimals": 15,
+      "logoURI": "https://assets.coingecko.com/coins/images/27032/thumb/Artboard_1_copy_8circle-1.png?1696526084"
+    },
+    {
+      "chainId": 100,
+      "address": "0x177127622c4a00f3d409b75571e12cb3c8973d3c",
+      "name": "CoW Protocol",
+      "symbol": "COW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/thumb/CoW-token_logo.png?1719524382"
+    },
+    {
+      "chainId": 100,
+      "address": "0x7ecf26cd9a36990b8ea477853663092333f59979",
+      "name": "Perpetual Protocol",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
+    },
+    {
+      "chainId": 100,
+      "address": "0xdfc20ae04ed70bd9c7d720f449eedae19f659d65",
+      "name": "Badger",
+      "symbol": "BADGER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1696513059"
+    },
+    {
+      "chainId": 100,
+      "address": "0x7ef541e2a22058048904fe5744f9c7e4c57af717",
+      "name": "Balancer",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1696511572"
+    },
+    {
+      "chainId": 100,
+      "address": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+      "name": "Gnosis",
+      "symbol": "GNO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/662/thumb/logo_square_simple_300px.png?1696501854"
+    },
+    {
+      "chainId": 100,
+      "address": "0xabef652195f98a91e490f047a5006b71c85f058d",
+      "name": "crvUSD",
+      "symbol": "CRVUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/thumb/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
+    },
+    {
+      "chainId": 100,
+      "address": "0x256eb8a51f382650b2a1e946b8811953640ee47d",
+      "name": "Streamr",
+      "symbol": "DATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17869/thumb/DATA_new_symbol_3x.png?1696517392"
+    },
+    {
+      "chainId": 100,
+      "address": "0xaf204776c7245bf4147c2612bf6e5972ee483701",
+      "name": "Savings xDAI",
+      "symbol": "SDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32066/thumb/sDAI_Logo_%281%29.png?1696530863"
+    },
+    {
+      "chainId": 100,
+      "address": "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
+      "name": "Bridged Wrapped stETH  Gnosis ",
+      "symbol": "WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33017/thumb/wStETH.png?1700190250"
+    },
+    {
+      "chainId": 100,
+      "address": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
+      "name": "Monerium EUR emoney",
+      "symbol": "EURE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23354/thumb/eur.png?1696522569"
+    },
+    {
+      "chainId": 100,
+      "address": "0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f",
+      "name": "Autonolas",
+      "symbol": "OLAS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31099/thumb/OLAS-token.png?1696529930"
+    },
+    {
+      "chainId": 100,
+      "address": "0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8",
+      "name": "Everclear",
+      "symbol": "NEXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31293/thumb/photo_2024-06-03_12-14-59.png?1717638614"
+    },
+    {
+      "chainId": 100,
+      "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
+      "name": "Gnosis xDai Bridged WETH  Gnosis Chain ",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39731/thumb/weth.png?1723759168"
+    },
+    {
+      "chainId": 100,
+      "address": "0xd589f00fa2eb83367f732ab3cda92ee0940389cf",
+      "name": "Fuse",
+      "symbol": "FUSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/thumb/fuse.png?1696510348"
+    },
+    {
+      "chainId": 100,
+      "address": "0xdbf3ea6f5bee45c02255b2c26a16f300502f68da",
+      "name": "Swarm",
+      "symbol": "BZZ",
+      "decimals": 16,
+      "logoURI": "https://assets.coingecko.com/coins/images/16509/thumb/Circle_Orange_onWhite.png?1696516071"
+    },
+    {
+      "chainId": 100,
+      "address": "0x6a8cb6714b1ee5b471a7d2ec4302cb4f5ff25ec2",
+      "name": "Energy Web",
+      "symbol": "EWT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10886/thumb/R9gQTJV__400x400.png?1696510839"
+    },
+    {
+      "chainId": 100,
+      "address": "0x21a42669643f45bc0e086b8fc2ed70c23d67509d",
+      "name": "ShapeShift FOX",
+      "symbol": "FOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/fox_token.png?1728373561"
+    },
+    {
+      "chainId": 100,
+      "address": "0xd057604a14982fe8d88c5fc25aac3267ea142a08",
+      "name": "HOPR",
+      "symbol": "HOPR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1696513786"
+    },
+    {
+      "chainId": 100,
+      "address": "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+      "name": "Gnosis xDAI Bridged USDC  Gnosis ",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35300/thumb/USDC_Icon.png?1708083625"
+    },
+    {
+      "chainId": 100,
+      "address": "0xfecb3f7c54e2caae9dc6ac9060a822d47e053760",
+      "name": "BRLA Digital BRLA",
+      "symbol": "BRLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40062/thumb/IconGreen400.png?1725459580"
+    },
+    {
+      "chainId": 100,
+      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
+      "name": "Gyroscope GYD",
+      "symbol": "GYD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33428/thumb/GYD-gradient_resized_transparent.png?1702316822"
+    },
+    {
+      "chainId": 100,
+      "address": "0x37b60f4e9a31a64ccc0024dce7d0fd07eaa0f7b3",
+      "name": "Kleros",
+      "symbol": "PNK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3833/thumb/kleros.png?1696504500"
+    },
+    {
+      "chainId": 100,
+      "address": "0x4ecaba5870353805a9f068101a40e0f32ed605c6",
+      "name": "Gnosis xDai Bridged USDT  Gnosis ",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35072/thumb/logo.png?1707292488"
+    },
+    {
+      "chainId": 100,
+      "address": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
+      "name": "XDAI",
+      "symbol": "XDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11062/thumb/Identity-Primary-DarkBG.png?1696511004"
+    },
+    {
+      "chainId": 100,
+      "address": "0x4b1e2c2762667331bc91648052f646d1b0d35984",
+      "name": "EURA",
+      "symbol": "EURA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/thumb/agEUR-4.png?1710726218"
+    },
+    {
+      "chainId": 100,
+      "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
+      "name": "Aura Finance",
+      "symbol": "AURA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25942/thumb/logo.png?1696525021"
+    },
+    {
+      "chainId": 100,
+      "address": "0x2a22f9c3b484c3629090feed35f17ff8f88f76f0",
+      "name": "Gnosis xDAI Bridged USDC  Gnosis ",
+      "symbol": "USDCE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/38775/thumb/USDC_Icon.webp?1718798033"
+    },
+    {
+      "chainId": 100,
+      "address": "0x8e5bbbb09ed1ebde8674cda39a0c169401db4252",
+      "name": "Gnosis xDai Bridged WBTC  Gnosis Chain ",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39595/thumb/wbtc.png?1723016785"
+    },
+    {
+      "chainId": 100,
+      "address": "0x8b8407c6184f1f0fd1082e83d6a3b8349caced12",
+      "name": "Circuits of Value",
+      "symbol": "COVAL",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/588/thumb/coval-logo.png?1696501792"
+    },
+    {
+      "chainId": 100,
+      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "name": "Hop Protocol",
+      "symbol": "HOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25445/thumb/hop.png?1696524577"
+    },
+    {
+      "chainId": 100,
+      "address": "0x84e2c67cbefae6b5148fca7d02b341b12ff4b5bb",
+      "name": "Swash",
+      "symbol": "SWASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18774/thumb/Swash_icon_GP.png?1712869197"
+    },
+    {
+      "chainId": 100,
+      "address": "0x3f56e0c36d275367b8c502090edf38289b3dea0d",
+      "name": "MAI",
+      "symbol": "MIMATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15264/thumb/mimatic-red.png?1696514916"
+    },
+    {
+      "chainId": 100,
+      "address": "0x0000206329b97db379d5e1bf586bbdb969c63274",
+      "name": "USDA",
+      "symbol": "USDA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34510/thumb/agUSD-coingecko.png?1705288392"
+    },
+    {
+      "chainId": 100,
+      "address": "0x48b1b0d077b4919b65b4e4114806dd803901e1d9",
+      "name": "Etherisc DIP",
+      "symbol": "DIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4586/thumb/dip.png?1696505164"
+    },
+    {
+      "chainId": 100,
+      "address": "0xeeeeeb57642040be42185f49c52f7e9b38f8eeee",
+      "name": "Elk Finance",
+      "symbol": "ELK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17813/thumb/elk.png?1696517333"
+    },
+    {
+      "chainId": 100,
+      "address": "0x5cb9073902f2035222b9749f8fb0c9bfe5527108",
+      "name": "Monerium GBP emoney",
+      "symbol": "GBPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39004/thumb/gbp.png?1719840784"
+    },
+    {
+      "chainId": 100,
+      "address": "0x9fb1d52596c44603198fb0aee434fac3a679f702",
+      "name": "Jarvis Synthetic Euro",
+      "symbol": "JEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15725/thumb/jEUR.png?1696515352"
+    },
+    {
+      "chainId": 100,
+      "address": "0x431d5dff03120afa4bdf332c61a6e1766ef37bdb",
+      "name": "JPY Coin",
+      "symbol": "JPYC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25971/thumb/2023jpyc.png?1696525049"
+    },
+    {
+      "chainId": 100,
+      "address": "0xd3d47d5578e55c880505dc40648f7f9307c3e7a8",
+      "name": "DeFi Pulse Index",
+      "symbol": "DPI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1696512284"
+    },
+    {
+      "chainId": 100,
+      "address": "0x1d1498166ddceee616a6d99868e1e0677300056f",
+      "name": "Space Token",
+      "symbol": "SPACE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20676/thumb/jYw3kgsY_400x400.png?1696520076"
+    },
+    {
+      "chainId": 100,
+      "address": "0x2086f52651837600180de173b09470f54ef74910",
+      "name": "Balancer Stable USD",
+      "symbol": "STABAL3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32112/thumb/bal3.png?1696561317"
+    },
+    {
+      "chainId": 100,
+      "address": "0x524b969793a64a602342d89bc2789d43a016b13a",
+      "name": "Donut",
+      "symbol": "DONUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7538/thumb/Donut.png?1696507804"
+    },
+    {
+      "chainId": 100,
+      "address": "0x2d5563da42b06fbbf9c67b7dc073cf6a7842239e",
+      "name": "Jarvis Synthetic Swiss Franc",
+      "symbol": "JCHF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15727/thumb/jCHF.png?1696515353"
+    },
+    {
+      "chainId": 100,
+      "address": "0xd0dd6cef72143e22cced4867eb0d5f2328715533",
+      "name": "Aave v3 DAI",
+      "symbol": "ADAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32886/thumb/dai.png?1699769446"
+    },
+    {
+      "chainId": 100,
+      "address": "0xf490c80aae5f2616d3e3bda2483e30c4cb21d1a0",
+      "name": "StakeWise Staked GNO",
+      "symbol": "OSGNO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39458/thumb/stakewiseosgno_32.webp?1722390395"
+    },
+    {
+      "chainId": 100,
+      "address": "0x4f4f9b8d5b4d0dc10506e5551b0513b61fd59e75",
+      "name": "Giveth",
+      "symbol": "GIV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21792/thumb/GIVToken_200x200.png?1722577147"
+    },
+    {
+      "chainId": 100,
+      "address": "0xec3f3e6d7907acda3a7431abd230196cda3fbb19",
+      "name": "Ethix",
+      "symbol": "ETHIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3031/thumb/ETHIX_icon_256x256-256.png?1696503766"
+    },
+    {
+      "chainId": 100,
+      "address": "0x3a97704a1b25f08aa230ae53b352e2e72ef52843",
+      "name": "Agave",
+      "symbol": "AGVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14146/thumb/agve.png?1696513865"
+    },
+    {
+      "chainId": 100,
+      "address": "0x44fa8e6f47987339850636f88629646662444217",
+      "name": "OmniBridge Bridged DAI  Gnosis Chain ",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39808/thumb/dai.png?1724126705"
+    },
+    {
+      "chainId": 100,
+      "address": "0x71850b7e9ee3f13ab46d67167341e4bdc905eef9",
+      "name": "Honey",
+      "symbol": "HNY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12895/thumb/hnys.png?1696512683"
+    },
+    {
+      "chainId": 100,
+      "address": "0x004626a008b1acdc4c74ab51644093b155e59a23",
+      "name": "Angle Staked EURA",
+      "symbol": "STEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32036/thumb/stEUR-x4.png?1696530832"
+    },
+    {
+      "chainId": 100,
+      "address": "0x0aa1e96d2a46ec6beb2923de1e61addf5f5f1dce",
+      "name": "RealToken Ecosystem Governance",
+      "symbol": "REG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37785/thumb/realt.jpeg?1715586329"
+    },
+    {
+      "chainId": 100,
+      "address": "0xfbdd194376de19a88118e84e279b977f165d01b8",
+      "name": "DeHive",
+      "symbol": "DHV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14926/thumb/logo_200x200.png?1696514587"
+    },
+    {
+      "chainId": 100,
+      "address": "0x83ff60e2f93f8edd0637ef669c69d5fb4f64ca8e",
+      "name": "BrightID",
+      "symbol": "BRIGHT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18415/thumb/bright.PNG?1696517905"
+    },
+    {
+      "chainId": 100,
+      "address": "0x417602f4fbdd471a431ae29fb5fe0a681964c11b",
+      "name": "JPY Coin v1",
+      "symbol": "JPYC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17277/thumb/WoZ8rruL_400x400.png?1696516831"
+    },
+    {
+      "chainId": 100,
+      "address": "0xfa57aa7beed63d03aaf85ffd1753f5f6242588fb",
+      "name": "Mt Pelerin Shares",
+      "symbol": "MPS",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/11471/thumb/MPS.png?1696511378"
+    },
+    {
+      "chainId": 100,
+      "address": "0x4291f029b9e7acb02d49428458cf6fceac545f81",
+      "name": "1Hive Water",
+      "symbol": "WATER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26089/thumb/water_logo.png?1696525180"
+    },
+    {
+      "chainId": 100,
+      "address": "0xdd96b45877d0e8361a4ddb732da741e97f3191ff",
+      "name": "Bridged BUSD",
+      "symbol": "BUSD",
+      "decimals": 18
+    },
+    {
+      "chainId": 100,
+      "address": "0xb0c5f3100a4d9d9532a4cfd68c55f1ae8da987eb",
+      "name": "DAOhaus",
+      "symbol": "HAUS",
+      "decimals": 35,
+      "logoURI": "https://assets.coingecko.com/coins/images/14551/thumb/jN3kkqke_400x400.png?1696514234"
+    },
+    {
+      "chainId": 100,
+      "address": "0x97edc0e345fbbbd8460847fcfa3bc2a13bf8641f",
+      "name": "DAOSquare",
+      "symbol": "RICE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19084/thumb/tw5gu1dW_400x400.jpeg?1696518537"
+    },
+    {
+      "chainId": 100,
+      "address": "0x3a3e9715018d80916740e8ac300713fdf6614d19",
+      "name": "hiveWater",
+      "symbol": "HIVEWATER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30424/thumb/hivewater_transparent.png?1696529312"
+    },
+    {
+      "chainId": 100,
+      "address": "0x532801ed6f82fffd2dab70a19fc2d7b2772c4f4b",
+      "name": "Swapr",
+      "symbol": "SWPR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18740/thumb/swapr.jpg?1696518206"
+    },
+    {
+      "chainId": 100,
+      "address": "0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9",
+      "name": "Backed Coinbase Global",
+      "symbol": "BCOIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31872/thumb/b-COIN-200x200.png?1696530684"
+    },
+    {
+      "chainId": 100,
+      "address": "0x8c88ea1fd60462ef7004b9e288afcb4680a3c50c",
+      "name": "0xMonero",
+      "symbol": "0XMR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11035/thumb/0xmnr.PNG?1696510979"
+    },
+    {
+      "chainId": 100,
+      "address": "0x07279343ce61c11cb091142c8a20a1f8194d0ca8",
+      "name": "Zenland",
+      "symbol": "ZENF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29477/thumb/tokenicon200px.png?1696528421"
+    },
+    {
+      "chainId": 100,
+      "address": "0xb90d6bec20993be5d72a5ab353343f7a0281f158",
+      "name": "DXdao",
+      "symbol": "DXD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11148/thumb/dxdao.png?1696511083"
+    },
+    {
+      "chainId": 100,
+      "address": "0x18e9262e68cc6c6004db93105cc7c001bb103e49",
+      "name": "Raid",
+      "symbol": "RAID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18133/thumb/raid_200_oswlvz.png?1696517636"
+    },
+    {
+      "chainId": 100,
+      "address": "0x364b5975385b4de226cf450df82d7ed69902ac5a",
+      "name": "TORG",
+      "symbol": "TORG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17596/thumb/TORG_Logo_200x200.png?1696517129"
+    },
+    {
+      "chainId": 100,
+      "address": "0xb7d311e2eb55f2f68a9440da38e7989210b9a05e",
+      "name": "STAKE",
+      "symbol": "STAKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11061/thumb/xdai.png?1696511003"
+    },
+    {
+      "chainId": 100,
+      "address": "0x63e62989d9eb2d37dfdb1f93a22f063635b07d51",
+      "name": "Minerva Wallet",
+      "symbol": "MIVA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14732/thumb/MIVA-Token_200x200.png?1696514401"
+    },
+    {
+      "chainId": 100,
+      "address": "0x1e2c4fb7ede391d116e6b41cd0608260e8801d59",
+      "name": "Backed CSPX Core S P 500",
+      "symbol": "BCSPX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31891/thumb/b-CSPX-200x200.png?1696530702"
+    },
+    {
+      "chainId": 100,
+      "address": "0xb5d592f85ab2d955c25720ebe6ff8d4d1e1be300",
+      "name": "Particle",
+      "symbol": "PRTCLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14395/thumb/unknown.png?1696514085"
+    },
+    {
+      "chainId": 100,
+      "address": "0x38fb649ad3d6ba1113be5f57b927053e97fc5bf7",
+      "name": "xDai Native Comb",
+      "symbol": "XCOMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16012/thumb/logo.png?1696515623"
+    },
+    {
+      "chainId": 100,
+      "address": "0xc6b7aca6de8a6044e0e32d0c841a89244a10d284",
+      "name": "Aave v3 USDC",
+      "symbol": "AUSDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/32847/thumb/usdc_%281%29.png?1699619355"
+    }
+  ],
+  "timestamp": "2024-12-06T16:10:22.098Z"
+}

--- a/src/public/CoinGecko.100.json
+++ b/src/public/CoinGecko.100.json
@@ -116,14 +116,6 @@
     },
     {
       "chainId": 100,
-      "address": "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
-      "name": "Bridged Wrapped stETH  Gnosis ",
-      "symbol": "WSTETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33017/thumb/wStETH.png?1700190250"
-    },
-    {
-      "chainId": 100,
       "address": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
       "name": "Monerium EUR emoney",
       "symbol": "EURE",
@@ -153,6 +145,14 @@
       "symbol": "WETH",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/39731/thumb/weth.png?1723759168"
+    },
+    {
+      "chainId": 100,
+      "address": "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
+      "name": "Bridged Wrapped stETH  Gnosis ",
+      "symbol": "WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33017/thumb/wStETH.png?1700190250"
     },
     {
       "chainId": 100,
@@ -642,5 +642,5 @@
       "logoURI": "https://assets.coingecko.com/coins/images/32847/thumb/usdc_%281%29.png?1699619355"
     }
   ],
-  "timestamp": "2024-12-06T16:10:22.098Z"
+  "timestamp": "2024-12-06T16:12:22.702Z"
 }

--- a/src/public/CoinGecko.42161.json
+++ b/src/public/CoinGecko.42161.json
@@ -1,5 +1,5 @@
 {
-  "name": "Coingecko top 500 on arbitrum-one",
+  "name": "Coingecko top 500 on Arbitrum one",
   "logoURI": "https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png",
   "keywords": [
     "defi"
@@ -36,27 +36,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
-      "name": "Curve DAO",
-      "symbol": "CRV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12124/large/Curve.png?1696511967"
-    },
-    {
-      "chainId": 42161,
       "address": "0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0",
       "name": "Uniswap",
       "symbol": "UNI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/12504/large/uniswap-logo.png?1720676669"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
-      "name": "Arbitrum Bridged WETH  Arbitrum One ",
-      "symbol": "WETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39713/large/WETH.PNG?1723731496"
     },
     {
       "chainId": 42161,
@@ -76,6 +60,22 @@
     },
     {
       "chainId": 42161,
+      "address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
+      "name": "Curve DAO",
+      "symbol": "CRV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12124/large/Curve.png?1696511967"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+      "name": "Arbitrum Bridged WETH  Arbitrum One ",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39713/large/WETH.PNG?1723731496"
+    },
+    {
+      "chainId": 42161,
       "address": "0x09199d9a5f4448d0848e4395d065e1ad9c4a1f74",
       "name": "Bonk",
       "symbol": "BONK",
@@ -84,11 +84,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
-      "name": "LayerZero",
-      "symbol": "ZRO",
+      "address": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
+      "name": "Sushi",
+      "symbol": "SUSHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/large/512x512_Logo_no_chop.png?1696512101"
     },
     {
       "chainId": 42161,
@@ -100,11 +100,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x289ba1701c2f088cf0faf8b3705246331cb8a839",
-      "name": "Livepeer",
-      "symbol": "LPT",
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "name": "LayerZero",
+      "symbol": "ZRO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7137/large/badge-logo-circuit-green.png?1719357686"
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60",
+      "name": "Lido DAO",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1696513326"
     },
     {
       "chainId": 42161,
@@ -124,11 +132,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60",
-      "name": "Lido DAO",
-      "symbol": "LDO",
+      "address": "0x1b896893dfc86bb67cf57767298b9073d2c1ba2c",
+      "name": "PancakeSwap",
+      "symbol": "CAKE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1696513326"
+      "logoURI": "https://assets.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0c880f6761f1af8d9aa9c466984b80dab9a8c9e8",
+      "name": "Pendle",
+      "symbol": "PENDLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb0ffa8000886e57f86dd5264b9582b2ad87b2b91",
+      "name": "Wormhole",
+      "symbol": "W",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35087/large/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
     },
     {
       "chainId": 42161,
@@ -148,75 +172,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xb0ffa8000886e57f86dd5264b9582b2ad87b2b91",
-      "name": "Wormhole",
-      "symbol": "W",
+      "address": "0x1a6b3a62391eccaaa992ade44cd4afe6bec8cff1",
+      "name": "UXLINK",
+      "symbol": "UXLINK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35087/large/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1b896893dfc86bb67cf57767298b9073d2c1ba2c",
-      "name": "PancakeSwap",
-      "symbol": "CAKE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x354a6da3fcde098f8389cad84b0182725c6c91de",
-      "name": "Compound",
-      "symbol": "COMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10775/large/COMP.png?1696510737"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
-      "name": "Arbitrum Bridged WBTC  Arbitrum One ",
-      "symbol": "WBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39532/large/wbtc.png?1722810336"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0c880f6761f1af8d9aa9c466984b80dab9a8c9e8",
-      "name": "Pendle",
-      "symbol": "PENDLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x53691596d1bce8cea565b84d4915e69e03d9c99d",
-      "name": "Across Protocol",
-      "symbol": "ACX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
-      "name": "Sushi",
-      "symbol": "SUSHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12271/large/512x512_Logo_no_chop.png?1696512101"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xaeaeed23478c3a4b798e4ed40d8b7f41366ae861",
-      "name": "Ankr Network",
-      "symbol": "ANKR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1696504928"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x82e3a8f066a6989666b031d916c43672085b1582",
-      "name": "yearn finance",
-      "symbol": "YFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11849/large/yearn.jpg?1696511720"
+      "logoURI": "https://assets.coingecko.com/coins/images/39229/large/uxlink.jpg?1721201390"
     },
     {
       "chainId": 42161,
@@ -228,107 +188,35 @@
     },
     {
       "chainId": 42161,
-      "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
-      "name": "Wrapped stETH",
-      "symbol": "WSTETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
+      "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+      "name": "Arbitrum Bridged WBTC  Arbitrum One ",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39532/large/wbtc.png?1722810336"
     },
     {
       "chainId": 42161,
-      "address": "0x4cb9a7ae498cedcbb5eae9f25736ae7d428c9d66",
-      "name": "Xai",
-      "symbol": "XAI",
+      "address": "0x354a6da3fcde098f8389cad84b0182725c6c91de",
+      "name": "Compound",
+      "symbol": "COMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34258/large/round_icon_2048_px.png?1719523838"
+      "logoURI": "https://assets.coingecko.com/coins/images/10775/large/COMP.png?1696510737"
     },
     {
       "chainId": 42161,
-      "address": "0x46d0ce7de6247b0a95f67b43b589b4041bae7fbe",
-      "name": "Loopring",
-      "symbol": "LRC",
+      "address": "0x82e3a8f066a6989666b031d916c43672085b1582",
+      "name": "yearn finance",
+      "symbol": "YFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/913/large/LRC.png?1696502034"
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/large/yearn.jpg?1696511720"
     },
     {
       "chainId": 42161,
-      "address": "0x1a6b3a62391eccaaa992ade44cd4afe6bec8cff1",
-      "name": "UXLINK",
-      "symbol": "UXLINK",
+      "address": "0x289ba1701c2f088cf0faf8b3705246331cb8a839",
+      "name": "Livepeer",
+      "symbol": "LPT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39229/large/uxlink.jpg?1721201390"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9f07f8a82cb1af1466252e505b7b7ddee103bc91",
-      "name": "Degen  Base ",
-      "symbol": "DEGEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
-      "name": "Arbitrum Bridged USDC  Arbitrum ",
-      "symbol": "USDCE",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/30691/large/usdc.png?1696529560"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc87b37a581ec3257b734886d9d3a581f5a9d056c",
-      "name": "Aethir",
-      "symbol": "ATH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xcafcd85d8ca7ad1e1c6f82f651fa15e33aefd07b",
-      "name": "WOO",
-      "symbol": "WOO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7",
-      "name": "Frax Share",
-      "symbol": "FXS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1696513183"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6694340fc020c5e6b96567843da2df01b2ce1eb6",
-      "name": "Stargate Finance",
-      "symbol": "STG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x539bde0d7dbd336b79148aa742883198bbf60342",
-      "name": "Treasure",
-      "symbol": "MAGIC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18623/large/magic.png?1696518095"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
-      "name": "CARV",
-      "symbol": "CARV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
-      "name": "GMX",
-      "symbol": "GMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18323/large/arbit.png?1696517814"
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/large/badge-logo-circuit-green.png?1719357686"
     },
     {
       "chainId": 42161,
@@ -340,35 +228,91 @@
     },
     {
       "chainId": 42161,
-      "address": "0x23ee2343b892b1bb63503a4fabc840e0e2c6810f",
-      "name": "Axelar",
-      "symbol": "AXL",
+      "address": "0x53691596d1bce8cea565b84d4915e69e03d9c99d",
+      "name": "Across Protocol",
+      "symbol": "ACX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc87b37a581ec3257b734886d9d3a581f5a9d056c",
+      "name": "Aethir",
+      "symbol": "ATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+      "name": "Wrapped stETH",
+      "symbol": "WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9f07f8a82cb1af1466252e505b7b7ddee103bc91",
+      "name": "Degen  Base ",
+      "symbol": "DEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4cb9a7ae498cedcbb5eae9f25736ae7d428c9d66",
+      "name": "Xai",
+      "symbol": "XAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34258/large/round_icon_2048_px.png?1719523838"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x539bde0d7dbd336b79148aa742883198bbf60342",
+      "name": "Treasure",
+      "symbol": "MAGIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18623/large/magic.png?1696518095"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+      "name": "Arbitrum Bridged USDC  Arbitrum ",
+      "symbol": "USDCE",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg?1696526329"
+      "logoURI": "https://assets.coingecko.com/coins/images/30691/large/usdc.png?1696529560"
     },
     {
       "chainId": 42161,
-      "address": "0x61a1ff55c5216b636a294a07d77c6f4df10d3b56",
-      "name": "ApeX",
-      "symbol": "APEX",
+      "address": "0x6694340fc020c5e6b96567843da2df01b2ce1eb6",
+      "name": "Stargate Finance",
+      "symbol": "STG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25266/large/CxpMECpk_400x400_%281%29.png?1696524406"
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
     },
     {
       "chainId": 42161,
-      "address": "0xda0a57b710768ae17941a9fa33f8b720c8bd9ddd",
-      "name": "Marlin",
-      "symbol": "POND",
+      "address": "0xcafcd85d8ca7ad1e1c6f82f651fa15e33aefd07b",
+      "name": "WOO",
+      "symbol": "WOO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8903/large/200x200.png?1706115827"
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
     },
     {
       "chainId": 42161,
-      "address": "0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04",
-      "name": "CoW Protocol",
-      "symbol": "COW",
+      "address": "0x46d0ce7de6247b0a95f67b43b589b4041bae7fbe",
+      "name": "Loopring",
+      "symbol": "LRC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+      "logoURI": "https://assets.coingecko.com/coins/images/913/large/LRC.png?1696502034"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaeaeed23478c3a4b798e4ed40d8b7f41366ae861",
+      "name": "Ankr Network",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1696504928"
     },
     {
       "chainId": 42161,
@@ -380,27 +324,35 @@
     },
     {
       "chainId": 42161,
-      "address": "0x35751007a407ca6feffe80b3cb397736d2cf4dbe",
-      "name": "Wrapped eETH",
-      "symbol": "WEETH",
+      "address": "0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7",
+      "name": "Frax Share",
+      "symbol": "FXS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1696513183"
     },
     {
       "chainId": 42161,
-      "address": "0x753d224bcf9aafacd81558c32341416df61d3dac",
-      "name": "Perpetual Protocol",
-      "symbol": "PERP",
+      "address": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
+      "name": "GMX",
+      "symbol": "GMX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
+      "logoURI": "https://assets.coingecko.com/coins/images/18323/large/arbit.png?1696517814"
     },
     {
       "chainId": 42161,
-      "address": "0x3e6648c5a70a150a88bce65f4ad4d506fe15d2af",
-      "name": "Spell",
-      "symbol": "SPELL",
+      "address": "0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04",
+      "name": "CoW Protocol",
+      "symbol": "COW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15861/large/abracadabra-3.png?1696515477"
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x23ee2343b892b1bb63503a4fabc840e0e2c6810f",
+      "name": "Axelar",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg?1696526329"
     },
     {
       "chainId": 42161,
@@ -420,51 +372,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x3a8b787f78d775aecfeea15706d4221b40f345ab",
-      "name": "Celer Network",
-      "symbol": "CELR",
+      "address": "0x61a1ff55c5216b636a294a07d77c6f4df10d3b56",
+      "name": "ApeX",
+      "symbol": "APEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4379/large/Celr.png?1696504978"
+      "logoURI": "https://assets.coingecko.com/coins/images/25266/large/CxpMECpk_400x400_%281%29.png?1696524406"
     },
     {
       "chainId": 42161,
-      "address": "0x69eb4fa4a2fbd498c257c57ea8b7655a2559a581",
-      "name": "DODO",
-      "symbol": "DODO",
+      "address": "0x35f1c5cb7fb977e669fd244c567da99d8a3a6850",
+      "name": "Usual USD",
+      "symbol": "USD0",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12651/large/dodo_logo.png?1696512458"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe4dddfe67e7164b0fe14e218d80dc4c08edc01cb",
-      "name": "Kyber Network Crystal",
-      "symbol": "KNC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14899/large/RwdVsGcw_400x400.jpg?1696514562"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x371c7ec6d8039ff7933a2aa28eb827ffe1f52f07",
-      "name": "JOE",
-      "symbol": "JOE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17569/large/LFJ_JOE_Logo.png?1727200941"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xda661fa59320b808c5a6d23579fcfedf1fd3cf36",
-      "name": "Mobox",
-      "symbol": "MBOX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14751/large/mobox.PNG?1696514420"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x319f865b287fcc10b30d8ce6144e8b6d1b476999",
-      "name": "Cartesi",
-      "symbol": "CTSI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
+      "logoURI": "https://assets.coingecko.com/coins/images/38272/large/USD0LOGO.png?1716962811"
     },
     {
       "chainId": 42161,
@@ -476,11 +396,35 @@
     },
     {
       "chainId": 42161,
-      "address": "0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40",
-      "name": "tBTC",
-      "symbol": "TBTC",
+      "address": "0x319f865b287fcc10b30d8ce6144e8b6d1b476999",
+      "name": "Cartesi",
+      "symbol": "CTSI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xda661fa59320b808c5a6d23579fcfedf1fd3cf36",
+      "name": "Mobox",
+      "symbol": "MBOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14751/large/mobox.PNG?1696514420"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+      "name": "CARV",
+      "symbol": "CARV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe4dddfe67e7164b0fe14e218d80dc4c08edc01cb",
+      "name": "Kyber Network Crystal",
+      "symbol": "KNC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14899/large/RwdVsGcw_400x400.jpg?1696514562"
     },
     {
       "chainId": 42161,
@@ -492,6 +436,54 @@
     },
     {
       "chainId": 42161,
+      "address": "0x3a8b787f78d775aecfeea15706d4221b40f345ab",
+      "name": "Celer Network",
+      "symbol": "CELR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/large/Celr.png?1696504978"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8f5c1a99b1df736ad685006cb6adca7b7ae4b514",
+      "name": "Enzyme",
+      "symbol": "MLN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/605/large/Enzyme_Icon_Secondary.png?1696501803"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x371c7ec6d8039ff7933a2aa28eb827ffe1f52f07",
+      "name": "JOE",
+      "symbol": "JOE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17569/large/LFJ_JOE_Logo.png?1727200941"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x753d224bcf9aafacd81558c32341416df61d3dac",
+      "name": "Perpetual Protocol",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x69eb4fa4a2fbd498c257c57ea8b7655a2559a581",
+      "name": "DODO",
+      "symbol": "DODO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12651/large/dodo_logo.png?1696512458"
+    },
+    {
+      "chainId": 42161,
       "address": "0x080f6aed32fc474dd5717105dba5ea57268f46eb",
       "name": "Synapse",
       "symbol": "SYN",
@@ -500,19 +492,27 @@
     },
     {
       "chainId": 42161,
+      "address": "0x3e6648c5a70a150a88bce65f4ad4d506fe15d2af",
+      "name": "Spell",
+      "symbol": "SPELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/large/abracadabra-3.png?1696515477"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc1eb7689147c81ac840d4ff0d298489fc7986d52",
+      "name": "Venus",
+      "symbol": "XVS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
+    },
+    {
+      "chainId": 42161,
       "address": "0xb766039cc6db368759c1e56b79affe831d0cc507",
       "name": "Rocket Pool",
       "symbol": "RPL",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x17fc002b466eec40dae837fc4be5c67993ddbd6f",
-      "name": "Frax",
-      "symbol": "FRAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1696513182"
     },
     {
       "chainId": 42161,
@@ -532,99 +532,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xc1eb7689147c81ac840d4ff0d298489fc7986d52",
-      "name": "Venus",
-      "symbol": "XVS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
-    },
-    {
-      "chainId": 42161,
       "address": "0xa0b862f60edef4452f25b4160f177db44deb6cf1",
       "name": "Gnosis",
       "symbol": "GNO",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/662/large/logo_square_simple_300px.png?1696501854"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x498bf2b1e120fed3ad3d42ea2165e9b73f99c1e5",
-      "name": "crvUSD",
-      "symbol": "CRVUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30118/large/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
-      "name": "Axelar Bridged USDC",
-      "symbol": "AXLUSDC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/26476/large/uausdc_D_3x.png?1696525548"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x35f1c5cb7fb977e669fd244c567da99d8a3a6850",
-      "name": "Usual USD",
-      "symbol": "USD0",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38272/large/USD0LOGO.png?1716962811"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1debd73e752beaf79865fd6446b0c970eae7732f",
-      "name": "Coinbase Wrapped Staked ETH",
-      "symbol": "CBETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1709186989"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8f5c1a99b1df736ad685006cb6adca7b7ae4b514",
-      "name": "Enzyme",
-      "symbol": "MLN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/605/large/Enzyme_Icon_Secondary.png?1696501803"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
-      "name": "Telos",
-      "symbol": "TLOS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7588/large/tlos_png.png?1722391289"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
-      "name": "Renzo Restaked ETH",
-      "symbol": "EZETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x18c11fd286c5ec11c3b683caa813b77f5163a122",
-      "name": "Gains Network",
-      "symbol": "GNS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19737/large/logo.png?1696519161"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
-      "name": "MakerDAO Arbitrum Bridged DAI  Arbitrum",
-      "symbol": "DAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39790/large/dai.png?1724111653"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3b60ff35d3f7f62d636b067dd0dc0dfdad670e4e",
-      "name": "Milady Meme Coin",
-      "symbol": "LADYS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30194/large/LADYS_Clean.png?1725897475"
     },
     {
       "chainId": 42161,
@@ -636,91 +548,43 @@
     },
     {
       "chainId": 42161,
-      "address": "0x35e050d3c0ec2d29d269a8ecea763a183bdf9a9d",
-      "name": "Ondo US Dollar Yield",
-      "symbol": "USDY",
+      "address": "0xda0a57b710768ae17941a9fa33f8b720c8bd9ddd",
+      "name": "Marlin",
+      "symbol": "POND",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31700/large/usdy_%281%29.png?1696530524"
+      "logoURI": "https://assets.coingecko.com/coins/images/8903/large/200x200.png?1706115827"
     },
     {
       "chainId": 42161,
-      "address": "0xcaa38bcc8fb3077975bbe217acfaa449e6596a84",
-      "name": "DAO Maker",
-      "symbol": "DAO",
+      "address": "0x498bf2b1e120fed3ad3d42ea2165e9b73f99c1e5",
+      "name": "crvUSD",
+      "symbol": "CRVUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13915/large/4.jpg?1727532864"
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/large/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
     },
     {
       "chainId": 42161,
-      "address": "0x0d81e50bc677fa67341c44d7eaa9228dee64a4e1",
-      "name": "BarnBridge",
-      "symbol": "BOND",
+      "address": "0x17fc002b466eec40dae837fc4be5c67993ddbd6f",
+      "name": "Frax",
+      "symbol": "FRAX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12811/large/barnbridge.jpg?1696512604"
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1696513182"
     },
     {
       "chainId": 42161,
-      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
-      "name": "Pocket Network",
-      "symbol": "POKT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7e7a7c916c19a45769f6bdaf91087f93c6c12f78",
-      "name": "Eigenpie",
-      "symbol": "EGP",
+      "address": "0x3b60ff35d3f7f62d636b067dd0dc0dfdad670e4e",
+      "name": "Milady Meme Coin",
+      "symbol": "LADYS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37810/large/eigenpie.jpeg?1715597613"
+      "logoURI": "https://assets.coingecko.com/coins/images/30194/large/LADYS_Clean.png?1725897475"
     },
     {
       "chainId": 42161,
-      "address": "0xf4d48ce3ee1ac3651998971541badbb9a14d7234",
-      "name": "Cream",
-      "symbol": "CREAM",
+      "address": "0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40",
+      "name": "tBTC",
+      "symbol": "TBTC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11976/large/Cream.png?1696511834"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
-      "name": "World Mobile Token",
-      "symbol": "WMTX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x772598e9e62155d7fdfe65fdf01eb5a53a8465be",
-      "name": "Empyreal",
-      "symbol": "EMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31374/large/logomainblacktransparent.png?1719953450"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x178412e79c25968a32e89b11f63b33f733770c2a",
-      "name": "Frax Ether",
-      "symbol": "FRXETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28284/large/frxETH_icon.png?1696527284"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
-      "name": "Port3 Network",
-      "symbol": "PORT3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33383/large/port3-bc-200x200.png?1710075114"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdadeca1167fe47499e53eb50f261103630974905",
-      "name": "Neuron",
-      "symbol": "NRN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38838/large/Nrn_with_gradient_-NEW_TO_BE_UPDATED.png?1728551601"
+      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
     },
     {
       "chainId": 42161,
@@ -732,83 +596,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
-      "name": "Bridged USDe",
-      "symbol": "USDE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39962/large/usde.png?1724952425"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
-      "name": "OX Coin",
-      "symbol": "OX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6a9896837021ea3ed83f623f655c119c54abe02c",
-      "name": "ChainBounty",
-      "symbol": "BOUNTY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3369/large/Chainbounty_logomark_256px.png?1731462528"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa23e44aea714fbbc08ef28340d78067b9a8cad73",
-      "name": "Lybra",
-      "symbol": "LBR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29958/large/New_LBR_V2.png?1696528884"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6a7661795c374c0bfc635934efaddff3a7ee23b6",
-      "name": "DOLA",
-      "symbol": "DOLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
-      "name": "Ignition FBTC",
-      "symbol": "FBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39182/large/FBTC_LOGO.png?1720850455"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x386601d1e55c48e759bbf57c56015aad0d7f1b56",
-      "name": "Worldwide USD",
-      "symbol": "WUSD",
+      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
+      "name": "Axelar Bridged USDC",
+      "symbol": "AXLUSDC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
+      "logoURI": "https://assets.coingecko.com/coins/images/26476/large/uausdc_D_3x.png?1696525548"
     },
     {
       "chainId": 42161,
-      "address": "0xae6aab43c4f3e0cea4ab83752c278f8debaba689",
-      "name": "dForce",
-      "symbol": "DF",
+      "address": "0x1debd73e752beaf79865fd6446b0c970eae7732f",
+      "name": "Coinbase Wrapped Staked ETH",
+      "symbol": "CBETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9709/large/xlGxxIjI_400x400.jpg?1696509776"
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1709186989"
     },
     {
       "chainId": 42161,
-      "address": "0x5575552988a3a80504bbaeb1311674fcfd40ad4b",
-      "name": "Sperax",
-      "symbol": "SPA",
+      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
+      "name": "Telos",
+      "symbol": "TLOS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12232/large/sperax_logo.jpg?1696512065"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbc011a12da28e8f0f528d9ee5e7039e22f91cf18",
-      "name": "Swell Ethereum",
-      "symbol": "SWETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30326/large/_lB7zEtS_400x400.jpg?1696529227"
+      "logoURI": "https://assets.coingecko.com/coins/images/7588/large/tlos_png.png?1722391289"
     },
     {
       "chainId": 42161,
@@ -820,6 +628,150 @@
     },
     {
       "chainId": 42161,
+      "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+      "name": "MakerDAO Arbitrum Bridged DAI  Arbitrum",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39790/large/dai.png?1724111653"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x18c11fd286c5ec11c3b683caa813b77f5163a122",
+      "name": "Gains Network",
+      "symbol": "GNS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19737/large/logo.png?1696519161"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
+      "name": "World Mobile Token",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35751007a407ca6feffe80b3cb397736d2cf4dbe",
+      "name": "Wrapped eETH",
+      "symbol": "WEETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7e7a7c916c19a45769f6bdaf91087f93c6c12f78",
+      "name": "Eigenpie",
+      "symbol": "EGP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37810/large/eigenpie.jpeg?1715597613"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x59062301fb510f4ea2417b67404cb16d31e604ba",
+      "name": "LogX Network",
+      "symbol": "LOGX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50226/large/Token_200px.png?1726556358"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x346c574c56e1a4aaa8dc88cda8f7eb12b39947ab",
+      "name": "Solv Protocol SolvBTC BBN",
+      "symbol": "SOLVBTCBBN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39384/large/unnamed.png?1721961640"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcaa38bcc8fb3077975bbe217acfaa449e6596a84",
+      "name": "DAO Maker",
+      "symbol": "DAO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13915/large/4.jpg?1727532864"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf4d48ce3ee1ac3651998971541badbb9a14d7234",
+      "name": "Cream",
+      "symbol": "CREAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11976/large/Cream.png?1696511834"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f850b0ab1988dd17b69ac564c1e2857949e4dee",
+      "name": "Lift Dollar",
+      "symbol": "USDL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38484/large/USDL-Token-200px.png?1725022887"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0d81e50bc677fa67341c44d7eaa9228dee64a4e1",
+      "name": "BarnBridge",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/large/barnbridge.jpg?1696512604"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6a9896837021ea3ed83f623f655c119c54abe02c",
+      "name": "ChainBounty",
+      "symbol": "BOUNTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3369/large/Chainbounty_logomark_256px.png?1731462528"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x680447595e8b7b3aa1b43beb9f6098c79ac2ab3f",
+      "name": "USDD",
+      "symbol": "USDD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25380/large/UUSD.jpg?1696524513"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xae6aab43c4f3e0cea4ab83752c278f8debaba689",
+      "name": "dForce",
+      "symbol": "DF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9709/large/xlGxxIjI_400x400.jpg?1696509776"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa23e44aea714fbbc08ef28340d78067b9a8cad73",
+      "name": "Lybra",
+      "symbol": "LBR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29958/large/New_LBR_V2.png?1696528884"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7dff72693f6a4149b17e7c6314655f6a9f7c8b33",
+      "name": "GHO",
+      "symbol": "GHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30663/large/gho-token-logo.png?1720517092"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6a7661795c374c0bfc635934efaddff3a7ee23b6",
+      "name": "DOLA",
+      "symbol": "DOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
+      "name": "Pocket Network",
+      "symbol": "POKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
+    },
+    {
+      "chainId": 42161,
       "address": "0x560363bda52bc6a44ca6c8c9b4a5fadbda32fa60",
       "name": "Seedify fund",
       "symbol": "SFUND",
@@ -828,19 +780,43 @@
     },
     {
       "chainId": 42161,
-      "address": "0x221c5799209132766a01c4cbed0d28600d282b41",
-      "name": "Bitrium",
-      "symbol": "BTRM",
+      "address": "0x772598e9e62155d7fdfe65fdf01eb5a53a8465be",
+      "name": "Empyreal",
+      "symbol": "EMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39118/large/20240709-160716.png?1720593799"
+      "logoURI": "https://assets.coingecko.com/coins/images/31374/large/logomainblacktransparent.png?1719953450"
     },
     {
       "chainId": 42161,
-      "address": "0x8b0e6f19ee57089f7649a455d89d7bc6314d04e8",
-      "name": "Dream Machine Token",
-      "symbol": "DMT",
+      "address": "0x386601d1e55c48e759bbf57c56015aad0d7f1b56",
+      "name": "Worldwide USD",
+      "symbol": "WUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30505/large/dmt.png?1696529391"
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+      "name": "Bridged USDe",
+      "symbol": "USDE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39962/large/usde.png?1724952425"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x93b346b6bc2548da6a1e7d98e9a421b42541425b",
+      "name": "Liquity USD",
+      "symbol": "LUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1696514341"
     },
     {
       "chainId": 42161,
@@ -860,19 +836,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x7dff72693f6a4149b17e7c6314655f6a9f7c8b33",
-      "name": "GHO",
-      "symbol": "GHO",
+      "address": "0x95146881b86b3ee99e63705ec87afe29fcc044d9",
+      "name": "Vertex",
+      "symbol": "VRTX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30663/large/gho-token-logo.png?1720517092"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x680447595e8b7b3aa1b43beb9f6098c79ac2ab3f",
-      "name": "USDD",
-      "symbol": "USDD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25380/large/UUSD.jpg?1696524513"
+      "logoURI": "https://assets.coingecko.com/coins/images/27927/large/vrtx.png?1696526947"
     },
     {
       "chainId": 42161,
@@ -892,22 +860,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0x95146881b86b3ee99e63705ec87afe29fcc044d9",
-      "name": "Vertex",
-      "symbol": "VRTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27927/large/vrtx.png?1696526947"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x99f40b01ba9c469193b360f72740e416b17ac332",
-      "name": "MATH",
-      "symbol": "MATH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11335/large/2020-05-19-token-200.png?1696511257"
-    },
-    {
-      "chainId": 42161,
       "address": "0xabd587f2607542723b17f14d00d99b987c29b074",
       "name": "SmarDex",
       "symbol": "SDEX",
@@ -916,51 +868,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8",
-      "name": "Everclear",
-      "symbol": "NEXT",
+      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
+      "name": "Port3 Network",
+      "symbol": "PORT3",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31293/large/photo_2024-06-03_12-14-59.png?1717638614"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x59062301fb510f4ea2417b67404cb16d31e604ba",
-      "name": "LogX Network",
-      "symbol": "LOGX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50226/large/Token_200px.png?1726556358"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4425742f1ec8d98779690b5a3a6276db85ddc01a",
-      "name": "Own The Doge",
-      "symbol": "DOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18111/large/Doge.png?1696517615"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2172fad929e857ddfd7ddc31e24904438434cb0b",
-      "name": "Babypie Wrapped BTC",
-      "symbol": "MBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/50314/large/mbtc_%281%29.png?1727079604"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x93b346b6bc2548da6a1e7d98e9a421b42541425b",
-      "name": "Liquity USD",
-      "symbol": "LUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1696514341"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x12275dcb9048680c4be40942ea4d92c74c63b844",
-      "name": "Electronic USD",
-      "symbol": "EUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28445/large/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
+      "logoURI": "https://assets.coingecko.com/coins/images/33383/large/port3-bc-200x200.png?1710075114"
     },
     {
       "chainId": 42161,
@@ -972,19 +884,83 @@
     },
     {
       "chainId": 42161,
-      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
-      "name": "Mountain Protocol USD",
-      "symbol": "USDM",
+      "address": "0x99f40b01ba9c469193b360f72740e416b17ac332",
+      "name": "MATH",
+      "symbol": "MATH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31719/large/usdm.png?1696530540"
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/large/2020-05-19-token-200.png?1696511257"
     },
     {
       "chainId": 42161,
-      "address": "0x9dce8e754913d928eb39bc4fc3cf047e364f7f2c",
-      "name": "Bloktopia",
-      "symbol": "BLOK",
+      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
+      "name": "Ignition FBTC",
+      "symbol": "FBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39182/large/FBTC_LOGO.png?1720850455"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8",
+      "name": "Everclear",
+      "symbol": "NEXT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18819/large/logo-bholdus-6.png?1696518281"
+      "logoURI": "https://assets.coingecko.com/coins/images/31293/large/photo_2024-06-03_12-14-59.png?1717638614"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdadeca1167fe47499e53eb50f261103630974905",
+      "name": "Neuron",
+      "symbol": "NRN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38838/large/Nrn_with_gradient_-NEW_TO_BE_UPDATED.png?1728551601"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf929de51d91c77e42f5090069e0ad7a09e513c73",
+      "name": "ShapeShift FOX",
+      "symbol": "FOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9988/large/fox_token.png?1728373561"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3d9907f9a368ad0a51be60f7da3b97cf940982d8",
+      "name": "Camelot Token",
+      "symbol": "GRAIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28416/large/vj5DIMhP_400x400.jpeg?1696527414"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3124678d62d2aa1f615b54525310fbfda6dcf7ae",
+      "name": "Sensay",
+      "symbol": "SNSY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36121/large/sensay.jpeg?1710495398"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x88a269df8fe7f53e590c561954c52fccc8ec0cfb",
+      "name": "Ninja Squad Token",
+      "symbol": "NST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22248/large/nst-logo-200x200.png?1711559985"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8b0e6f19ee57089f7649a455d89d7bc6314d04e8",
+      "name": "Dream Machine Token",
+      "symbol": "DMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30505/large/dmt.png?1696529391"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35e050d3c0ec2d29d269a8ecea763a183bdf9a9d",
+      "name": "Ondo US Dollar Yield",
+      "symbol": "USDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31700/large/usdy_%281%29.png?1696530524"
     },
     {
       "chainId": 42161,
@@ -1004,134 +980,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0x3d9907f9a368ad0a51be60f7da3b97cf940982d8",
-      "name": "Camelot Token",
-      "symbol": "GRAIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28416/large/vj5DIMhP_400x400.jpeg?1696527414"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd56734d7f9979dd94fae3d67c7e928234e71cd4c",
-      "name": "Bridged TIA  Hyperlane ",
-      "symbol": "TIAN",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/33199/large/tia.n.png?1701047832"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x06e90a57d1ece8752d6ce92d1ad348ead5eae4f4",
-      "name": "Real Smurf Cat",
-      "symbol": "SMURFCAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31751/large/SMURFCAT.png?1708079642"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x346c574c56e1a4aaa8dc88cda8f7eb12b39947ab",
-      "name": "Solv Protocol SolvBTC BBN",
-      "symbol": "SOLVBTCBBN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39384/large/unnamed.png?1721961640"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe22c452bd2ade15dfc8ad98286bc6bdf0c9219b7",
-      "name": "Polytrade",
-      "symbol": "TRADE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16416/large/Logo_colored_200.png?1696516012"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
-      "name": "PAW",
-      "symbol": "PAW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28946/large/PawLogo.png?1699394612"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x580e933d90091b9ce380740e3a4a39c67eb85b4c",
-      "name": "GameSwift",
-      "symbol": "GSWIFT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30949/large/GameSwift_Token.png?1696529788"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3124678d62d2aa1f615b54525310fbfda6dcf7ae",
-      "name": "Sensay",
-      "symbol": "SNSY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36121/large/sensay.jpeg?1710495398"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6b021b3f68491974be6d4009fee61a4e3c708fd6",
-      "name": "Fuse",
-      "symbol": "FUSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x94fcd9c18f99538c0f7c61c5500ca79f0d5c4dab",
-      "name": "Kima Network",
-      "symbol": "KIMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50764/large/K-logo-01.png?1729053099"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x11bf4f05eb28b802ed3ab672594decb20ffe2313",
-      "name": "Aurory",
-      "symbol": "AURY",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/19324/large/Ico_Blanc_%281%29.png?1713464485"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe80772eaf6e2e18b651f160bc9158b2a5cafca65",
-      "name": "Overnight fi USD   Arbitrum One ",
-      "symbol": "USD+",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39630/large/usd_plus.png?1723181710"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4186bfc76e2e237523cbc30fd220fe055156b41f",
-      "name": "KelpDAO Bridged rsETH  Arbitrum ",
-      "symbol": "RSETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39543/large/rseth.png?1722849891"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x88a269df8fe7f53e590c561954c52fccc8ec0cfb",
-      "name": "Ninja Squad Token",
-      "symbol": "NST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22248/large/nst-logo-200x200.png?1711559985"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9e758b8a98a42d612b3d38b66a22074dc03d7370",
-      "name": "Symbiosis",
-      "symbol": "SIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20805/large/SymbiosisFinance_logo-150x150.jpeg?1696520198"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x95ab45875cffdba1e5f451b950bc2e42c0053f39",
-      "name": "Staked Frax Ether",
-      "symbol": "SFRXETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28285/large/sfrxETH_icon.png?1696527285"
-    },
-    {
-      "chainId": 42161,
       "address": "0x93fa0b88c0c78e45980fa74cdd87469311b7b3e4",
       "name": "XBorg",
       "symbol": "XBG",
@@ -1140,451 +988,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0xd77b108d4f6cefaa0cae9506a934e825becca46e",
-      "name": "WINR Protocol",
-      "symbol": "WINR",
+      "address": "0x9dce8e754913d928eb39bc4fc3cf047e364f7f2c",
+      "name": "Bloktopia",
+      "symbol": "BLOK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29340/large/WINR.png?1696528290"
+      "logoURI": "https://assets.coingecko.com/coins/images/18819/large/logo-bholdus-6.png?1696518281"
     },
     {
       "chainId": 42161,
-      "address": "0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca",
-      "name": "Kujira",
-      "symbol": "KUJI",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/20685/large/kuji-200x200.png?1696520085"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf0cb2dc0db5e6c66b9a70ac27b06b878da017028",
-      "name": "Olympus",
-      "symbol": "OHM",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/14483/large/token_OHM_%281%29.png?1696514169"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf929de51d91c77e42f5090069e0ad7a09e513c73",
-      "name": "ShapeShift FOX",
-      "symbol": "FOX",
+      "address": "0x5575552988a3a80504bbaeb1311674fcfd40ad4b",
+      "name": "Sperax",
+      "symbol": "SPA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9988/large/fox_token.png?1728373561"
+      "logoURI": "https://assets.coingecko.com/coins/images/12232/large/sperax_logo.jpg?1696512065"
     },
     {
       "chainId": 42161,
-      "address": "0x7be5dd337cc6ce3e474f64e2a92a566445290864",
-      "name": "OpenLeverage",
-      "symbol": "OLE",
+      "address": "0x178412e79c25968a32e89b11f63b33f733770c2a",
+      "name": "Frax Ether",
+      "symbol": "FRXETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26098/large/256x256_OLE_Token_Logo.png?1696525189"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa5312c3e42a82d459162b2a3bd7ffc4f9099b911",
-      "name": "GALAXIS Token",
-      "symbol": "GALAXIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36221/large/500x500.png?1714755244"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb08d8becab1bf76a9ce3d2d5fa946f65ec1d3e83",
-      "name": "GammaSwap",
-      "symbol": "GS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29222/large/newLogo2.png?1731702645"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x00cbcf7b3d37844e44b888bc747bdd75fcf4e555",
-      "name": "xPet tech",
-      "symbol": "XPET",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33553/large/xpet_token.jpeg?1702428894"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x619c82392cb6e41778b7d088860fea8447941f4c",
-      "name": "Army of Fortune Gem",
-      "symbol": "AFG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35084/large/Token_GEM_AOFVERSE.png?1707317138"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x046029f68b0e00ebec2e394d17f70ec848fcf1d2",
-      "name": "Stable com USD3",
-      "symbol": "USD3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39865/large/2024-04-stable_com-usd3_coin.png?1724379520"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3b58a4c865b568a2f6a957c264f6b50cba35d8ce",
-      "name": "SuperWalk GRND",
-      "symbol": "GRND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27186/large/GRND_3x.png?1696526235"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc760f9782f8cea5b06d862574464729537159966",
-      "name": "Contango",
-      "symbol": "TANGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50721/large/400x400_-_Tango_%281%29.png?1729251498"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc24a365a870821eb83fd216c9596edd89479d8d7",
-      "name": "GAM3S GG",
-      "symbol": "G3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35662/large/G3_logo.jpg?1709454143"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd6cf874e24a9f5f43075142101a6b13735cdd424",
-      "name": "CoinbarPay",
-      "symbol": "CBPAY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38794/large/cbpay-icon_resized2.png?1729148991"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe10d4a4255d2d35c9e23e2c4790e073046fbaf5c",
-      "name": "LandX Governance Token",
-      "symbol": "LNDX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/33565/large/LNDX-200.png?1702445947"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x51c601dc278eb2cfea8e52c4caa35b3d6a9a2c26",
-      "name": "Chainge",
-      "symbol": "XCHNG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16526/large/chainge.jpeg?1708099639"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xca4e51f6ad4afd9d1068e5899de9dd7d73f3463d",
-      "name": "Aark Digital",
-      "symbol": "AARK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37813/large/aark.png?1715599394"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x24ef78c7092d255ed14a0281ac1800c359af3afe",
-      "name": "Rabbit Wallet",
-      "symbol": "RAB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29433/large/200x200.png?1696528381"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xacc51ffdef63fb0c014c882267c3a17261a5ed50",
-      "name": "Stryke",
-      "symbol": "SYK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36531/large/stryke.jpeg?1711704094"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7b5eb3940021ec0e8e463d5dbb4b7b09a89ddf96",
-      "name": "Wombat Exchange",
-      "symbol": "WOM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26946/large/Wombat_Token.png?1696526001"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x55678cd083fcdc2947a0df635c93c838c89454a3",
-      "name": "Tokenlon",
-      "symbol": "LON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13454/large/lon_logo.png?1696513217"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x050c24dbf1eec17babe5fc585f06116a259cc77a",
-      "name": "dlcBTC",
-      "symbol": "DLCBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/37289/large/dlcBTC_ico_200px.png?1713946623"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2680e82fb8beb5a153a67fe687ffa67abb6b9013",
-      "name": "Swarm Markets",
-      "symbol": "SMT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17488/large/swarm-SMT-token-symbol_200x200.png?1696517029"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
-      "name": "Osaka Protocol",
-      "symbol": "OSAK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30911/large/OSAK_LOGO_200x200.png?1723662197"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa4f63404b58c3efd9db6d53352bd386ffa174e5a",
-      "name": "Miracle Play",
-      "symbol": "MPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32653/large/MPT.png?1698895300"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfa296fca3c7dba4a92a42ec0b5e2138da3b29050",
-      "name": "AiShiba",
-      "symbol": "SHIBAI",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29898/large/Fotor_AI%EF%BC%882%EF%BC%89.png?1696528822"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe0ee18eacafddaeb38f8907c74347c44385578ab",
-      "name": "AxonDAO Governance Token",
-      "symbol": "AXGT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35290/large/AXGT-logo-7.png?1708076161"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
-      "name": "Gyroscope GYD",
-      "symbol": "GYD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x16f1967565aad72dd77588a332ce445e7cef752b",
-      "name": "crow with knife",
-      "symbol": "CAW",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/36067/large/200px.png?1710405601"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55",
-      "name": "Dopex",
-      "symbol": "DPX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16652/large/DPX_%281%29.png?1696516213"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x18c14c2d707b2212e17d1579789fc06010cfca23",
-      "name": "ETHPlus",
-      "symbol": "ETH+",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38061/large/ETH__Logo.png?1716440789"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xadd5620057336f868eae78a451c503ae7b576bad",
-      "name": "enqAI",
-      "symbol": "ENQAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29908/large/icon.png?1702507913"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x088cd8f5ef3652623c22d48b1605dcfe860cd704",
-      "name": "Vela Token",
-      "symbol": "VELA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28739/large/VELA_logo_-_no_background.png?1696527719"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x330bd769382cfc6d50175903434ccc8d206dcae5",
-      "name": "Kleros",
-      "symbol": "PNK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3833/large/kleros.png?1696504500"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
-      "name": "Wagmi",
-      "symbol": "WAGMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31887/large/wagmi_token_logo.png?1696530698"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdcbf4cb83d27c408b30dd7f39bfcabd7176b1ba3",
-      "name": "OpenOcean",
-      "symbol": "OOE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17014/large/ooe_log.png?1696516578"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8697841b82c71fcbd9e58c15f6de68cd1c63fd02",
-      "name": "NutCoin",
-      "symbol": "NUT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37569/large/icon-2_200x200.png?1714886224"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa61f74247455a40b01b0559ff6274441fafa22a3",
-      "name": "Magpie",
-      "symbol": "MGP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27972/large/MagpieLogo.png?1696526991"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
-      "name": "Truflation",
-      "symbol": "TRUF",
-      "decimals": 15,
-      "logoURI": "https://assets.coingecko.com/coins/images/36642/large/truflation.jpg?1733315818"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9f6abbf0ba6b5bfa27f4deb6597cc6ec20573fda",
-      "name": "Ferrum Network",
-      "symbol": "FRM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8251/large/FRM.png?1696508455"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x27bc2757fab0b8ab406016d1f71d8123452095d3",
-      "name": "Landshare",
-      "symbol": "LAND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17507/large/Landshare.png?1696517046"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
-      "name": "Any Inu",
-      "symbol": "AI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34126/large/anyinulogo200.png?1704174269"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0534d7272a8e4f24d269b56605f2bf6cf3271891",
-      "name": "U Coin",
-      "symbol": "U",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51359/large/coingecko.png?1730877953"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x13278cd824d33a7adb9f0a9a84aca7c0d2deebf7",
-      "name": "Tarot",
-      "symbol": "TAROT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31800/large/TAROT.jpg?1696530615"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x60d01ec2d5e98ac51c8b4cf84dfcce98d527c747",
-      "name": "iZUMi Finance",
-      "symbol": "IZI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21791/large/izumi-logo-symbol.png?1696521144"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdfb8be6f8c87f74295a87de951974362cedcfa30",
-      "name": "Edge Matrix Computing",
-      "symbol": "EMC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34461/large/cgc.jpg?1725022711"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbad58ed9b5f26a002ea250d7a60dc6729a4a2403",
-      "name": "Paribus",
-      "symbol": "PBX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18410/large/paribus.PNG?1696517900"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4a24b101728e07a52053c13fb4db2bcf490cabc3",
-      "name": "Arbius",
-      "symbol": "AIUS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35246/large/arbius-200x-logo.png?1707987961"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x74ccbe53f77b08632ce0cb91d3a545bf6b8e0979",
-      "name": "Fantom Bomb",
-      "symbol": "BOMB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24109/large/logo-blue.png?1696523301"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x02cea97794d2cfb5f560e1ff4e9c59d1bec75969",
-      "name": "VNX Swiss Franc",
-      "symbol": "VCHF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29547/large/VNXCHF_%282%29.png?1696528488"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x24404dc041d74cd03cfe28855f555559390c931b",
-      "name": "r CryptoCurrency Moons",
-      "symbol": "MOON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11222/large/Moons.png?1696511153"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
-      "name": "Dexalot",
-      "symbol": "ALOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24188/large/logo_200x200.png?1696523376"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3d15fd46ce9e551498328b1c83071d9509e2c3a0",
-      "name": "Universal ETH",
-      "symbol": "UNIETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28477/large/uniETH_200.png?1696527471"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6fd58f5a2f3468e35feb098b5f59f04157002407",
-      "name": "POGAI",
-      "symbol": "POGAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30116/large/pogai.jpeg?1696529039"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7ce746b45eabd0c4321538dec1b849c79a9a8476",
-      "name": "DSLA Protocol",
-      "symbol": "DSLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/6694/large/dsla_logo-squared_200x200.png?1696507035"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfa5ed56a203466cbbc2430a43c66b9d8723528e7",
-      "name": "EURA",
-      "symbol": "EURA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19479/large/agEUR-4.png?1710726218"
+      "logoURI": "https://assets.coingecko.com/coins/images/28284/large/frxETH_icon.png?1696527284"
     },
     {
       "chainId": 42161,
@@ -1596,283 +1020,243 @@
     },
     {
       "chainId": 42161,
-      "address": "0x5117f4ad0bc70dbb3b05bf39a1ec1ee40dd67654",
-      "name": "Avive",
-      "symbol": "AVIVE",
+      "address": "0x3b58a4c865b568a2f6a957c264f6b50cba35d8ce",
+      "name": "SuperWalk GRND",
+      "symbol": "GRND",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33697/large/avive_token.png?1702814979"
+      "logoURI": "https://assets.coingecko.com/coins/images/27186/large/GRND_3x.png?1696526235"
     },
     {
       "chainId": 42161,
-      "address": "0x13a7dedb7169a17be92b0e3c7c2315b46f4772b3",
-      "name": "Boop",
-      "symbol": "BOOP",
+      "address": "0x221c5799209132766a01c4cbed0d28600d282b41",
+      "name": "Bitrium",
+      "symbol": "BTRM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33874/large/Boop_resized.png?1703144302"
+      "logoURI": "https://assets.coingecko.com/coins/images/39118/large/20240709-160716.png?1720593799"
     },
     {
       "chainId": 42161,
-      "address": "0x9578a9937dff45b4e29e49120ab83cb806f1aa4f",
-      "name": "AITom",
-      "symbol": "AITOM",
+      "address": "0x12275dcb9048680c4be40942ea4d92c74c63b844",
+      "name": "Electronic USD",
+      "symbol": "EUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32013/large/aitom.png?1696530811"
+      "logoURI": "https://assets.coingecko.com/coins/images/28445/large/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
     },
     {
       "chainId": 42161,
-      "address": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a",
-      "name": "Alchemix USD",
-      "symbol": "ALUSD",
+      "address": "0x9e758b8a98a42d612b3d38b66a22074dc03d7370",
+      "name": "Symbiosis",
+      "symbol": "SIS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14114/large/Alchemix_USD.png?1696513835"
+      "logoURI": "https://assets.coingecko.com/coins/images/20805/large/SymbiosisFinance_logo-150x150.jpeg?1696520198"
     },
     {
       "chainId": 42161,
-      "address": "0x6c511dc18572d31c2c3f7b1505cb2bbc08282fcc",
-      "name": "Aipocalypto",
-      "symbol": "AIPO",
+      "address": "0xe22c452bd2ade15dfc8ad98286bc6bdf0c9219b7",
+      "name": "Polytrade",
+      "symbol": "TRADE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51400/large/aipo.png?1731084580"
+      "logoURI": "https://assets.coingecko.com/coins/images/16416/large/Logo_colored_200.png?1696516012"
     },
     {
       "chainId": 42161,
-      "address": "0xa58663faef461761e44066ea26c1fcddf2927b80",
-      "name": "Kommunitas",
-      "symbol": "KOM",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/17483/large/Kommunitas_HD.png?1726922129"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x87aaffdf26c6885f6010219208d5b161ec7609c0",
-      "name": "Equation",
-      "symbol": "EQU",
+      "address": "0x18c14c2d707b2212e17d1579789fc06010cfca23",
+      "name": "ETHPlus",
+      "symbol": "ETH+",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32592/large/equation_logo.png?1699220377"
+      "logoURI": "https://assets.coingecko.com/coins/images/38061/large/ETH__Logo.png?1716440789"
     },
     {
       "chainId": 42161,
-      "address": "0x75ec618a817eb0a4a7e44ac3dfc64c963daf921a",
-      "name": "Token7007",
-      "symbol": "7007",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50293/large/token7007.png?1726931640"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xee0a242f28034fce0bdfac33c0ad2a58ec35fd38",
-      "name": "Rosa Inu",
-      "symbol": "ROSA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37963/large/ROSA_TOKEN_3.png?1716183016"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1b7ad346b6ff2d196daa8e78aed86baa6d7e3b02",
-      "name": "VitAI",
-      "symbol": "VITAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52350/large/aadadsadasdas.png?1733162989"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xedd6ca8a4202d4a36611e2fff109648c4863ae19",
-      "name": "Maha",
-      "symbol": "MAHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13404/large/black.png?1724679606"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x60bf4e7cf16ff34513514b968483b54beff42a81",
-      "name": "ViciCoin",
-      "symbol": "VCNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31305/large/ViciCoin_-_small.png?1696530124"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3212dc0f8c834e4de893532d27cc9b6001684db0",
-      "name": "Pear Protocol",
-      "symbol": "PEAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50484/large/pearlogo.jpg?1727897446"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3269a3c00ab86c753856fd135d97b87facb0d848",
-      "name": "Florence Finance Medici",
-      "symbol": "FFM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34382/large/M_PNG_200x200_copy.png?1704779326"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
-      "name": "Seedworld",
-      "symbol": "SWORLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51000/large/IMG_2798.PNG?1729685531"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf1264873436a0771e440e2b28072fafcc5eebd01",
-      "name": "Kenshi",
-      "symbol": "KNS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30759/large/kenshi.jpg?1696529628"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdb40357fbc1eb1038c5df94c1cd7b7fd3f434480",
-      "name": "SpunkySDX",
-      "symbol": "SSDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52469/large/spunkysdx.png?1733412208"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1bc8bf18256d8b45d8367aac50fe2e24fc6aa8ca",
-      "name": "Vestate",
-      "symbol": "VES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35475/large/IMG_0759.png?1708772732"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x11920f139a3121c2836e01551d43f95b3c31159c",
-      "name": "YieldBricks",
-      "symbol": "YBR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51471/large/fjord-token-logo-darkbg.png?1731384618"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xcf934e2402a5e072928a39a956964eb8f2b5b79c",
-      "name": "PoolTogether",
-      "symbol": "POOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14003/large/PoolTogether.png?1696513732"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb6093b61544572ab42a0e43af08abafd41bf25a6",
-      "name": "WeatherXM",
-      "symbol": "WXM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38154/large/weatherxm-network-logo.png?1716668976"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4d840b741bc05fde325d4ec0b4cfcd0cea237e4e",
-      "name": "Quantlytica",
-      "symbol": "QTLX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50217/large/eebgcbNa_400x400.jpg?1726443400"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb9600c807f069d27f92a2a65b48f12eeef7e2007",
-      "name": "Altranium",
-      "symbol": "ALTR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38301/large/altr.jpg?1717034749"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x894134a25a5fac1c2c26f1d8fbf05111a3cb9487",
-      "name": "Grai",
-      "symbol": "GRAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30427/large/GRAI_Token.png?1696529315"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x092baadb7def4c3981454dd9c0a0d7ff07bcfc86",
-      "name": "MorpheusAI",
-      "symbol": "MOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37969/large/MOR200X200.png?1716327119"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc9c4fd7579133701fa2769b6955e7e56bb386db1",
-      "name": "Bridge Oracle",
-      "symbol": "BRG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12512/large/brg.png?1696512327"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-      "name": "Hop Protocol",
-      "symbol": "HOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25445/large/hop.png?1696524577"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2b41806cbf1ffb3d9e31a9ece6b738bf9d6f645f",
-      "name": "ENO",
-      "symbol": "ENO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26501/large/Logo_%281%29.png?1709565574"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7ba4a00d54a07461d9db2aef539e91409943adc9",
-      "name": "Stake DAO",
-      "symbol": "SDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13724/large/stakedao_logo.jpg?1696513468"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3096e7bfd0878cc65be71f8899bc4cfb57187ba3",
-      "name": "Xend Finance",
-      "symbol": "RWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14496/large/WeChat_Image_20210325163206.png?1696514181"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418",
-      "name": "Ramses Exchange",
-      "symbol": "RAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29420/large/newram.png?1708427055"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb688ba096b7bb75d7841e47163cd12d18b36a5bf",
-      "name": "mPendle",
-      "symbol": "MPENDLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31918/large/mPendle.png?1696530726"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd6b3d81868770083307840f513a3491960b95cb6",
-      "name": "Credbull",
-      "symbol": "CBL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39396/large/2024-11-15_06.09.28.jpg?1731735429"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbe5acfd64358805616b5cbd5277b9a85011d7cf1",
-      "name": "Pichi Finance",
-      "symbol": "PCH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39683/large/Group_1000003884.png?1723654999"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1c986661170c1834db49c3830130d4038eeeb866",
-      "name": "Aperture Finance",
-      "symbol": "APTR",
+      "address": "0xd56734d7f9979dd94fae3d67c7e928234e71cd4c",
+      "name": "Bridged TIA  Hyperlane ",
+      "symbol": "TIAN",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37940/large/icon_white.png?1715967425"
+      "logoURI": "https://assets.coingecko.com/coins/images/33199/large/tia.n.png?1701047832"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
+      "name": "Gyroscope GYD",
+      "symbol": "GYD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6b021b3f68491974be6d4009fee61a4e3c708fd6",
+      "name": "Fuse",
+      "symbol": "FUSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x050c24dbf1eec17babe5fc585f06116a259cc77a",
+      "name": "iBTC",
+      "symbol": "IBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/37289/large/dlcBTC_ico_200px.png?1713946623"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x580e933d90091b9ce380740e3a4a39c67eb85b4c",
+      "name": "GameSwift",
+      "symbol": "GSWIFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30949/large/GameSwift_Token.png?1696529788"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x94fcd9c18f99538c0f7c61c5500ca79f0d5c4dab",
+      "name": "Kima Network",
+      "symbol": "KIMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50764/large/K-logo-01.png?1729053099"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca",
+      "name": "Kujira",
+      "symbol": "KUJI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20685/large/kuji-200x200.png?1696520085"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x00cbcf7b3d37844e44b888bc747bdd75fcf4e555",
+      "name": "xPet tech",
+      "symbol": "XPET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33553/large/xpet_token.jpeg?1702428894"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4425742f1ec8d98779690b5a3a6276db85ddc01a",
+      "name": "Own The Doge",
+      "symbol": "DOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18111/large/Doge.png?1696517615"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd77b108d4f6cefaa0cae9506a934e825becca46e",
+      "name": "WINR Protocol",
+      "symbol": "WINR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29340/large/WINR.png?1696528290"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51c601dc278eb2cfea8e52c4caa35b3d6a9a2c26",
+      "name": "Chainge",
+      "symbol": "XCHNG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16526/large/chainge.jpeg?1708099639"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb08d8becab1bf76a9ce3d2d5fa946f65ec1d3e83",
+      "name": "GammaSwap",
+      "symbol": "GS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29222/large/newLogo2.png?1731702645"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa5312c3e42a82d459162b2a3bd7ffc4f9099b911",
+      "name": "GALAXIS Token",
+      "symbol": "GALAXIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36221/large/500x500.png?1714755244"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe80772eaf6e2e18b651f160bc9158b2a5cafca65",
+      "name": "Overnight fi USD   Arbitrum One ",
+      "symbol": "USD+",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39630/large/usd_plus.png?1723181710"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf0cb2dc0db5e6c66b9a70ac27b06b878da017028",
+      "name": "Olympus",
+      "symbol": "OHM",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/14483/large/token_OHM_%281%29.png?1696514169"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfa5ed56a203466cbbc2430a43c66b9d8723528e7",
+      "name": "EURA",
+      "symbol": "EURA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/large/agEUR-4.png?1710726218"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x046029f68b0e00ebec2e394d17f70ec848fcf1d2",
+      "name": "Stable com USD3",
+      "symbol": "USD3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39865/large/2024-04-stable_com-usd3_coin.png?1724379520"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
+      "name": "Dexalot",
+      "symbol": "ALOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24188/large/logo_200x200.png?1696523376"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe10d4a4255d2d35c9e23e2c4790e073046fbaf5c",
+      "name": "LandX Governance Token",
+      "symbol": "LNDX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/33565/large/LNDX-200.png?1702445947"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x24ef78c7092d255ed14a0281ac1800c359af3afe",
+      "name": "Rabbit Wallet",
+      "symbol": "RAB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29433/large/200x200.png?1696528381"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa4f63404b58c3efd9db6d53352bd386ffa174e5a",
+      "name": "Miracle Play",
+      "symbol": "MPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32653/large/MPT.png?1698895300"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13278cd824d33a7adb9f0a9a84aca7c0d2deebf7",
+      "name": "Tarot",
+      "symbol": "TAROT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31800/large/TAROT.jpg?1696530615"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd6cf874e24a9f5f43075142101a6b13735cdd424",
+      "name": "CoinbarPay",
+      "symbol": "CBPAY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38794/large/cbpay-icon_resized2.png?1729148991"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7b5eb3940021ec0e8e463d5dbb4b7b09a89ddf96",
+      "name": "Wombat Exchange",
+      "symbol": "WOM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26946/large/Wombat_Token.png?1696526001"
     },
     {
       "chainId": 42161,
@@ -1884,43 +1268,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0xc4cbd54ffa7a6a142fd73554cc6c23dd95cd8e01",
-      "name": " GAME Token",
-      "symbol": "GAME",
+      "address": "0xe0ee18eacafddaeb38f8907c74347c44385578ab",
+      "name": "AxonDAO Governance Token",
+      "symbol": "AXGT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38429/large/_GAME_Token.png?1717497071"
+      "logoURI": "https://assets.coingecko.com/coins/images/35290/large/AXGT-logo-7.png?1708076161"
     },
     {
       "chainId": 42161,
-      "address": "0x2297aebd383787a160dd0d9f71508148769342e3",
-      "name": "Avalanche Bridged BTC  Arbitrum One ",
-      "symbol": "BTCB",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/51135/large/avalanche-core.png?1730195092"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x847503fbf003ce8b005546aa3c03b80b7c2f9771",
-      "name": "Byte",
-      "symbol": "BYTE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/33527/large/Byte200.jpeg?1702138460"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
-      "name": "Nya",
-      "symbol": "NYA",
+      "address": "0xbc011a12da28e8f0f528d9ee5e7039e22f91cf18",
+      "name": "Swell Ethereum",
+      "symbol": "SWETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40082/large/nya.jpg?1725523655"
+      "logoURI": "https://assets.coingecko.com/coins/images/30326/large/_lB7zEtS_400x400.jpg?1696529227"
     },
     {
       "chainId": 42161,
-      "address": "0x3bd2dfd03bc7c3011ed7fb8c4d0949b382726cee",
-      "name": "Roobee",
-      "symbol": "ROOBEE",
+      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
+      "name": "Any Inu",
+      "symbol": "AI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8791/large/Group_11.png?1696508946"
+      "logoURI": "https://assets.coingecko.com/coins/images/34126/large/anyinulogo200.png?1704174269"
     },
     {
       "chainId": 42161,
@@ -1932,115 +1300,171 @@
     },
     {
       "chainId": 42161,
-      "address": "0x83d6c8c06ac276465e4c92e7ac8c23740f435140",
-      "name": "HMX",
-      "symbol": "HMX",
+      "address": "0xc24a365a870821eb83fd216c9596edd89479d8d7",
+      "name": "GAM3S GG",
+      "symbol": "G3",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31206/large/HMXlogo_CG.png?1696530033"
+      "logoURI": "https://assets.coingecko.com/coins/images/35662/large/G3_logo.jpg?1709454143"
     },
     {
       "chainId": 42161,
-      "address": "0x9e20461bc2c4c980f62f1b279d71734207a6a356",
-      "name": "OmniCat",
-      "symbol": "OMNI",
+      "address": "0x74ccbe53f77b08632ce0cb91d3a545bf6b8e0979",
+      "name": "Fantom Bomb",
+      "symbol": "BOMB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33917/large/omnicatlogo.png?1717544778"
+      "logoURI": "https://assets.coingecko.com/coins/images/24109/large/logo-blue.png?1696523301"
     },
     {
       "chainId": 42161,
-      "address": "0xadf5dd3e51bf28ab4f07e684ecf5d00691818790",
-      "name": "ICHI",
-      "symbol": "ICHI",
+      "address": "0x188fb5f5ae5bbe4154d5778f2bbb2fb985c94d25",
+      "name": "OpenBlox",
+      "symbol": "OBX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13119/large/ICHI_%28Round%29.jpg?1696512907"
+      "logoURI": "https://assets.coingecko.com/coins/images/26150/large/OBX_token-black_background_preview.png?1696525239"
     },
     {
       "chainId": 42161,
-      "address": "0xe82335d58abb1cd44cd5f47cf7f5b378e4c32f05",
-      "name": "SuperCells",
-      "symbol": "SCT",
+      "address": "0x02cea97794d2cfb5f560e1ff4e9c59d1bec75969",
+      "name": "VNX Swiss Franc",
+      "symbol": "VCHF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38800/large/photo_2024-09-24_18-31-07.jpg?1728417418"
+      "logoURI": "https://assets.coingecko.com/coins/images/29547/large/VNXCHF_%282%29.png?1696528488"
     },
     {
       "chainId": 42161,
-      "address": "0x000000000026839b3f4181f2cf69336af6153b99",
-      "name": "Reboot",
-      "symbol": "GG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31228/large/gg_cyan_black_square.png?1703749951"
+      "address": "0x16f1967565aad72dd77588a332ce445e7cef752b",
+      "name": "crow with knife",
+      "symbol": "CAW",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/36067/large/200px.png?1710405601"
     },
     {
       "chainId": 42161,
-      "address": "0xa0995d43901551601060447f9abf93ebc277cec2",
-      "name": "HIPPOP",
-      "symbol": "HIP",
+      "address": "0x55678cd083fcdc2947a0df635c93c838c89454a3",
+      "name": "Tokenlon",
+      "symbol": "LON",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37854/large/KakaoTalk_Image_2024-05-14-16-50-31.png?1715781999"
+      "logoURI": "https://assets.coingecko.com/coins/images/13454/large/lon_logo.png?1696513217"
     },
     {
       "chainId": 42161,
-      "address": "0x2ac2b254bc18cd4999f64773a966e4f4869c34ee",
-      "name": "Penpie",
-      "symbol": "PNP",
+      "address": "0x6fd58f5a2f3468e35feb098b5f59f04157002407",
+      "name": "POGAI",
+      "symbol": "POGAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30760/large/PNP_Token.png?1696529629"
+      "logoURI": "https://assets.coingecko.com/coins/images/30116/large/pogai.jpeg?1696529039"
     },
     {
       "chainId": 42161,
-      "address": "0xb299751b088336e165da313c33e3195b8c6663a6",
-      "name": "StarHeroes",
-      "symbol": "STAR",
+      "address": "0x2680e82fb8beb5a153a67fe687ffa67abb6b9013",
+      "name": "Swarm Markets",
+      "symbol": "SMT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34147/large/Screenshot_2024-03-08_180444.png?1709892309"
+      "logoURI": "https://assets.coingecko.com/coins/images/17488/large/swarm-SMT-token-symbol_200x200.png?1696517029"
     },
     {
       "chainId": 42161,
-      "address": "0x4883c8f0529f37e40ebea870f3c13cdfad5d01f8",
-      "name": "VNX EURO",
-      "symbol": "VEUR",
+      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
+      "name": "PAW",
+      "symbol": "PAW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29351/large/VNXEUR_%281%29.png?1696528300"
+      "logoURI": "https://assets.coingecko.com/coins/images/28946/large/PawLogo.png?1699394612"
     },
     {
       "chainId": 42161,
-      "address": "0xf6dae0d2be4993b00a2673360820af6bafd53887",
-      "name": "Launchpool",
-      "symbol": "LPOOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14041/large/dGUvV0HQ_400x400.jpg?1696513767"
+      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
+      "name": "Truflation",
+      "symbol": "TRUF",
+      "decimals": 15,
+      "logoURI": "https://assets.coingecko.com/coins/images/36642/large/truflation.jpg?1733315818"
     },
     {
       "chainId": 42161,
-      "address": "0x0cbd6fadcf8096cc9a43d90b45f65826102e3ece",
-      "name": "CheckDot",
-      "symbol": "CDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20370/large/token-200x200_%281%29.png?1696519781"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb2f30a7c980f052f02563fb518dcc39e6bf38175",
-      "name": "Synthetix USDx",
+      "address": "0xf3527ef8de265eaa3716fb312c12847bfba66cef",
+      "name": "usdx money USDX",
       "symbol": "USDX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51047/large/USDX.jpg?1729845921"
+      "logoURI": "https://assets.coingecko.com/coins/images/50360/large/USDX200px.png?1731906044"
     },
     {
       "chainId": 42161,
-      "address": "0x5d4974f8543bc78d43fd1044ecfdb9d85482aa21",
-      "name": "Bitbama",
-      "symbol": "BAMA",
+      "address": "0x60d01ec2d5e98ac51c8b4cf84dfcce98d527c747",
+      "name": "iZUMi Finance",
+      "symbol": "IZI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36686/large/photo_2024-03-31_14-20-41.jpg?1712073912"
+      "logoURI": "https://assets.coingecko.com/coins/images/21791/large/izumi-logo-symbol.png?1696521144"
     },
     {
       "chainId": 42161,
-      "address": "0x982239d38af50b0168da33346d85fb12929c4c07",
-      "name": "Arbitrove Governance Token",
-      "symbol": "TROVE",
+      "address": "0x088cd8f5ef3652623c22d48b1605dcfe860cd704",
+      "name": "Vela Token",
+      "symbol": "VELA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29017/large/trove.png?1696527988"
+      "logoURI": "https://assets.coingecko.com/coins/images/28739/large/VELA_logo_-_no_background.png?1696527719"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfa296fca3c7dba4a92a42ec0b5e2138da3b29050",
+      "name": "AiShiba",
+      "symbol": "SHIBAI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29898/large/Fotor_AI%EF%BC%882%EF%BC%89.png?1696528822"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x06e90a57d1ece8752d6ce92d1ad348ead5eae4f4",
+      "name": "Real Smurf Cat",
+      "symbol": "SMURFCAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31751/large/SMURFCAT.png?1708079642"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9f6abbf0ba6b5bfa27f4deb6597cc6ec20573fda",
+      "name": "Ferrum Network",
+      "symbol": "FRM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8251/large/FRM.png?1696508455"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
+      "name": "Seedworld",
+      "symbol": "SWORLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51000/large/IMG_2798.PNG?1729685531"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4a24b101728e07a52053c13fb4db2bcf490cabc3",
+      "name": "Arbius",
+      "symbol": "AIUS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35246/large/arbius-200x-logo.png?1707987961"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdfb8be6f8c87f74295a87de951974362cedcfa30",
+      "name": "Edge Matrix Computing",
+      "symbol": "EMC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34461/large/cgc.jpg?1725022711"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a",
+      "name": "Alchemix USD",
+      "symbol": "ALUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14114/large/Alchemix_USD.png?1696513835"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xadd5620057336f868eae78a451c503ae7b576bad",
+      "name": "enqAI",
+      "symbol": "ENQAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29908/large/icon.png?1702507913"
     },
     {
       "chainId": 42161,
@@ -2052,35 +1476,99 @@
     },
     {
       "chainId": 42161,
-      "address": "0xffa188493c15dfaf2c206c97d8633377847b6a52",
-      "name": "Wefi",
-      "symbol": "WEFI",
+      "address": "0xca4e51f6ad4afd9d1068e5899de9dd7d73f3463d",
+      "name": "Aark Digital",
+      "symbol": "AARK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30540/large/wefi.png?1696529412"
+      "logoURI": "https://assets.coingecko.com/coins/images/37813/large/aark.png?1715599394"
     },
     {
       "chainId": 42161,
-      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
-      "name": "Glo Dollar",
-      "symbol": "USDGLO",
+      "address": "0xacc51ffdef63fb0c014c882267c3a17261a5ed50",
+      "name": "Stryke",
+      "symbol": "SYK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29319/large/GLO_logo_pine_on_cyan_1_3.png?1716971065"
+      "logoURI": "https://assets.coingecko.com/coins/images/36531/large/stryke.jpeg?1711704094"
     },
     {
       "chainId": 42161,
-      "address": "0xafafd68afe3fe65d376eec9eab1802616cfaccb8",
-      "name": "Solv Protocol SolvBTC ENA",
-      "symbol": "SOLVBTCENA",
+      "address": "0x5d4974f8543bc78d43fd1044ecfdb9d85482aa21",
+      "name": "Bitbama",
+      "symbol": "BAMA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38931/large/BTC_ena.png?1719562313"
+      "logoURI": "https://assets.coingecko.com/coins/images/36686/large/photo_2024-03-31_14-20-41.jpg?1712073912"
     },
     {
       "chainId": 42161,
-      "address": "0x4a7779abed707a9c7deadbbef5c15f3e52370a99",
-      "name": "Flame",
-      "symbol": "FLAME",
+      "address": "0x4d840b741bc05fde325d4ec0b4cfcd0cea237e4e",
+      "name": "Quantlytica",
+      "symbol": "QTLX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34280/large/20240104-164053.jpg?1704452348"
+      "logoURI": "https://assets.coingecko.com/coins/images/50217/large/eebgcbNa_400x400.jpg?1726443400"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7be5dd337cc6ce3e474f64e2a92a566445290864",
+      "name": "OpenLeverage",
+      "symbol": "OLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26098/large/256x256_OLE_Token_Logo.png?1696525189"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdcbf4cb83d27c408b30dd7f39bfcabd7176b1ba3",
+      "name": "OpenOcean",
+      "symbol": "OOE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17014/large/ooe_log.png?1696516578"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0534d7272a8e4f24d269b56605f2bf6cf3271891",
+      "name": "U Coin",
+      "symbol": "U",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51359/large/coingecko.png?1730877953"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x27bc2757fab0b8ab406016d1f71d8123452095d3",
+      "name": "Landshare",
+      "symbol": "LAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17507/large/Landshare.png?1696517046"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc760f9782f8cea5b06d862574464729537159966",
+      "name": "Contango",
+      "symbol": "TANGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50721/large/400x400_-_Tango_%281%29.png?1729251498"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x24404dc041d74cd03cfe28855f555559390c931b",
+      "name": "r CryptoCurrency Moons",
+      "symbol": "MOON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11222/large/Moons.png?1696511153"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa61f74247455a40b01b0559ff6274441fafa22a3",
+      "name": "Magpie",
+      "symbol": "MGP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27972/large/MagpieLogo.png?1696526991"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd6b3d81868770083307840f513a3491960b95cb6",
+      "name": "Credbull",
+      "symbol": "CBL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39396/large/2024-11-15_06.09.28.jpg?1731735429"
     },
     {
       "chainId": 42161,
@@ -2092,203 +1580,59 @@
     },
     {
       "chainId": 42161,
-      "address": "0x431402e8b9de9aa016c743880e04e517074d8cec",
-      "name": "Hegic",
-      "symbol": "HEGIC",
+      "address": "0x3096e7bfd0878cc65be71f8899bc4cfb57187ba3",
+      "name": "Xend Finance",
+      "symbol": "RWA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12454/large/new.png?1696512274"
+      "logoURI": "https://assets.coingecko.com/coins/images/14496/large/WeChat_Image_20210325163206.png?1696514181"
     },
     {
       "chainId": 42161,
-      "address": "0xdc8184ba488e949815d4aafb35b3c56ad03b4179",
-      "name": "Roseon",
-      "symbol": "ROSX",
+      "address": "0x9578a9937dff45b4e29e49120ab83cb806f1aa4f",
+      "name": "AITom",
+      "symbol": "AITOM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29698/large/roseon.png?1696528631"
+      "logoURI": "https://assets.coingecko.com/coins/images/32013/large/aitom.png?1696530811"
     },
     {
       "chainId": 42161,
-      "address": "0x45d9831d8751b2325f3dbf48db748723726e1c8c",
-      "name": "EverValue Coin",
-      "symbol": "EVA",
+      "address": "0x1bc8bf18256d8b45d8367aac50fe2e24fc6aa8ca",
+      "name": "Vestate",
+      "symbol": "VES",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50997/large/EVA_Logo_-_with_dark_background_-_200x200.png?1729720258"
+      "logoURI": "https://assets.coingecko.com/coins/images/35475/large/IMG_0759.png?1708772732"
     },
     {
       "chainId": 42161,
-      "address": "0x21e60ee73f17ac0a411ae5d690f908c3ed66fe12",
-      "name": "Deri Protocol",
-      "symbol": "DERI",
+      "address": "0xb6093b61544572ab42a0e43af08abafd41bf25a6",
+      "name": "WeatherXM",
+      "symbol": "WXM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13931/large/200vs200.jpg?1696513670"
+      "logoURI": "https://assets.coingecko.com/coins/images/38154/large/weatherxm-network-logo.png?1716668976"
     },
     {
       "chainId": 42161,
-      "address": "0xe85b662fe97e8562f4099d8a1d5a92d4b453bf30",
-      "name": "Thales",
-      "symbol": "THALES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18388/large/CLVZJN_C_400x400.png?1696517879"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8d9ba570d6cb60c7e3e0f31343efe75ab8e65fb1",
-      "name": "Governance OHM",
-      "symbol": "GOHM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21129/large/token_wsOHM_logo.png?1696520508"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb64e280e9d1b5dbec4accedb2257a87b400db149",
-      "name": "Level",
-      "symbol": "LVL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28628/large/Token.png?1696527613"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2c7941a0fe9c52223b229747322af16160161c98",
-      "name": "Jarvis",
-      "symbol": "JARVIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35812/large/jarvis.png?1709873633"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1dd6b5f9281c6b4f043c02a83a46c2772024636c",
-      "name": "Lumi Finance LUAUSD",
-      "symbol": "LUAUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33503/large/LUAUSD.png?1702038709"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x10393c20975cf177a3513071bc110f7962cd67da",
-      "name": "Jones DAO",
-      "symbol": "JONES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23290/large/3c8c2ed8-afb3-4b67-9937-5493acd88b50.jpg?1696522508"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa586b3b80d7e3e8d439e25fbc16bc5bcee3e2c85",
-      "name": "Codyfight",
-      "symbol": "CTOK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23592/large/ctok.jpg?1715904249"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x569deb225441fd18bde18aed53e2ec7eb4e10d93",
-      "name": "Your Futures Exchange",
-      "symbol": "YFX",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/15654/large/yfx.PNG?1696515285"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3404149e9ee6f17fb41db1ce593ee48fbdcd9506",
-      "name": "Hydranet",
-      "symbol": "HDN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25177/large/HDXdarkblueInv.png?1696524322"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xee9801669c6138e84bd50deb500827b776777d28",
-      "name": "O3 Swap",
-      "symbol": "O3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15460/large/o3.png?1696515107"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
-      "name": "Magic Internet Money  Arbitrum ",
-      "symbol": "MIM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37324/large/mim.png?1714016666"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
-      "name": "Ankr Staked ETH",
-      "symbol": "ANKRETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13403/large/aETHc.png?1696513165"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x55ff62567f09906a85183b866df84bf599a4bf70",
-      "name": "Kromatika",
-      "symbol": "KROM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20541/large/KROM_Transparent.png?1696519948"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x711b771c7c443ebb695e4b3495c337fdaf37be11",
-      "name": "Dackie USD",
-      "symbol": "DCKUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39966/large/Dackie_USD_Stablecoin.png?1724957262"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
-      "name": "Lava Network",
-      "symbol": "LAVA",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37354/large/lava_logo.png?1714098423"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf763fa322dc58dee588252fafee5f448e863b633",
-      "name": "Carbon Protocol",
-      "symbol": "SWTH",
+      "address": "0xa58663faef461761e44066ea26c1fcddf2927b80",
+      "name": "Kommunitas",
+      "symbol": "KOM",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/3645/large/SWTH_Symbol_Origin.png?1696504327"
+      "logoURI": "https://assets.coingecko.com/coins/images/17483/large/Kommunitas_HD.png?1726922129"
     },
     {
       "chainId": 42161,
-      "address": "0x1d987200df3b744cfa9c14f713f5334cb4bc4d5d",
-      "name": "REKT",
-      "symbol": "REKT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29954/large/New_Project_%288%29.png?1696528881"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9e523234d36973f9e38642886197d023c88e307e",
-      "name": "Darwinia Network",
-      "symbol": "RING",
+      "address": "0x330bd769382cfc6d50175903434ccc8d206dcae5",
+      "name": "Kleros",
+      "symbol": "PNK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9443/large/RING.png?1696509535"
+      "logoURI": "https://assets.coingecko.com/coins/images/3833/large/kleros.png?1696504500"
     },
     {
       "chainId": 42161,
-      "address": "0xb6212b633c941e9be168c4b9c2d9e785f1cd42fb",
-      "name": "Bitoro",
-      "symbol": "BTORO",
+      "address": "0x092baadb7def4c3981454dd9c0a0d7ff07bcfc86",
+      "name": "MorpheusAI",
+      "symbol": "MOR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50334/large/bitoro-logo-highres.jpg?1727306095"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x816e21c33fa5f8440ebcdf6e01d39314541bea72",
-      "name": "LiquidDriver",
-      "symbol": "LQDR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15782/large/LQDR_Glowing_Icon.png?1696515405"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7c8a1a80fdd00c9cccd6ebd573e9ecb49bfa2a59",
-      "name": "AI CODE",
-      "symbol": "AICODE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30057/large/AICODE.png?1696528979"
+      "logoURI": "https://assets.coingecko.com/coins/images/37969/large/MOR200X200.png?1716327119"
     },
     {
       "chainId": 42161,
@@ -2300,99 +1644,107 @@
     },
     {
       "chainId": 42161,
-      "address": "0x7a2c1b8e26c48a5b73816b7ec826fd4053f5f34b",
-      "name": "GoSleep ZZZ",
-      "symbol": "ZZZ",
+      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
+      "name": "Glo Dollar",
+      "symbol": "USDGLO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29901/large/ZZZ200_200.png?1696528830"
+      "logoURI": "https://assets.coingecko.com/coins/images/29319/large/GLO_logo_pine_on_cyan_1_3.png?1716971065"
     },
     {
       "chainId": 42161,
-      "address": "0xa970af1a584579b618be4d69ad6f73459d112f95",
-      "name": "sUSD",
-      "symbol": "SUSD",
+      "address": "0xa0995d43901551601060447f9abf93ebc277cec2",
+      "name": "HIPPOP",
+      "symbol": "HIP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5013/large/sUSD.png?1696505546"
+      "logoURI": "https://assets.coingecko.com/coins/images/37854/large/KakaoTalk_Image_2024-05-14-16-50-31.png?1715781999"
     },
     {
       "chainId": 42161,
-      "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
-      "name": "MUX Protocol",
-      "symbol": "MCB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11796/large/mux.jpg?1696511672"
+      "address": "0x1c986661170c1834db49c3830130d4038eeeb866",
+      "name": "Aperture Finance",
+      "symbol": "APTR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37940/large/icon_white.png?1715967425"
     },
     {
       "chainId": 42161,
-      "address": "0xb52bd62ee0cf462fa9ccbda4bf27fe84d9ab6cf7",
-      "name": "Clipper SAIL",
-      "symbol": "SAIL",
+      "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+      "name": "usdx money Staked USDX",
+      "symbol": "SUSDX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31380/large/SAIL-Logo.png?1696530197"
+      "logoURI": "https://assets.coingecko.com/coins/images/50836/large/sUSDX200px.png?1731906119"
     },
     {
       "chainId": 42161,
-      "address": "0xf061956612b3dc79fd285d3d51bc128f2ea87740",
-      "name": "YfDAI finance",
-      "symbol": "YF-DAI",
+      "address": "0xb688ba096b7bb75d7841e47163cd12d18b36a5bf",
+      "name": "mPendle",
+      "symbol": "MPENDLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12385/large/1619048513068.png?1696512208"
+      "logoURI": "https://assets.coingecko.com/coins/images/31918/large/mPendle.png?1696530726"
     },
     {
       "chainId": 42161,
-      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
-      "name": "Overnight Finance",
-      "symbol": "OVN",
+      "address": "0xbad58ed9b5f26a002ea250d7a60dc6729a4a2403",
+      "name": "Paribus",
+      "symbol": "PBX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31970/large/OVN.png?1696959174"
+      "logoURI": "https://assets.coingecko.com/coins/images/18410/large/paribus.PNG?1696517900"
     },
     {
       "chainId": 42161,
-      "address": "0xb1bc21f748ae2be95674876710bc6d78235480e0",
-      "name": "Hord",
-      "symbol": "HORD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14972/large/HORD_TOKEN_%281%29_1.png?1705414356"
+      "address": "0x2172fad929e857ddfd7ddc31e24904438434cb0b",
+      "name": "Babypie Wrapped BTC",
+      "symbol": "MBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/50314/large/mbtc_%281%29.png?1727079604"
     },
     {
       "chainId": 42161,
-      "address": "0x429fed88f10285e61b12bdf00848315fbdfcc341",
-      "name": "THORWallet DEX",
-      "symbol": "TGT",
+      "address": "0xedd6ca8a4202d4a36611e2fff109648c4863ae19",
+      "name": "Maha",
+      "symbol": "MAHA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21843/large/tgt_logo.png?1696521198"
+      "logoURI": "https://assets.coingecko.com/coins/images/13404/large/black.png?1724679606"
     },
     {
       "chainId": 42161,
-      "address": "0xbcf339df10d78f2b44aa760ead0f715a7a7d7269",
-      "name": "Guardian GUARD",
-      "symbol": "GUARD",
+      "address": "0x11920f139a3121c2836e01551d43f95b3c31159c",
+      "name": "YieldBricks",
+      "symbol": "YBR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17995/large/LS_wolfDen_logo.0025_Light_200x200.png?1696517512"
+      "logoURI": "https://assets.coingecko.com/coins/images/51471/large/fjord-token-logo-darkbg.png?1731384618"
     },
     {
       "chainId": 42161,
-      "address": "0xb00eaedb98f1e30ad545703d8ff14b24d109514f",
-      "name": "Yaku",
-      "symbol": "YAKU",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/26785/large/yaku_logo.png?1706636424"
+      "address": "0x2b41806cbf1ffb3d9e31a9ece6b738bf9d6f645f",
+      "name": "ENO",
+      "symbol": "ENO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26501/large/Logo_%281%29.png?1709565574"
     },
     {
       "chainId": 42161,
-      "address": "0x306fd3e7b169aa4ee19412323e1a5995b8c1a1f4",
-      "name": "Black Agnus",
-      "symbol": "FTW",
+      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
+      "name": "Wagmi",
+      "symbol": "WAGMI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50170/large/32x32.png?1727177729"
+      "logoURI": "https://assets.coingecko.com/coins/images/31887/large/wagmi_token_logo.png?1696530698"
     },
     {
       "chainId": 42161,
-      "address": "0x47c337bd5b9344a6f3d6f58c474d9d8cd419d8ca",
-      "name": "DackieSwap",
-      "symbol": "DACKIE",
+      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
+      "name": "Nya",
+      "symbol": "NYA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30752/large/dackieswap_large.png?1707290196"
+      "logoURI": "https://assets.coingecko.com/coins/images/40082/large/nya.jpg?1725523655"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+      "name": "Mountain Protocol USD",
+      "symbol": "USDM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31719/large/usdm.png?1696530540"
     },
     {
       "chainId": 42161,
@@ -2404,11 +1756,691 @@
     },
     {
       "chainId": 42161,
-      "address": "0xee0b14e8fc86691cf6ee42b9954985b4cf968534",
-      "name": "ZenPandaCoin",
-      "symbol": "ZPC",
+      "address": "0x4883c8f0529f37e40ebea870f3c13cdfad5d01f8",
+      "name": "VNX EURO",
+      "symbol": "VEUR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30269/large/panda.png?1696529176"
+      "logoURI": "https://assets.coingecko.com/coins/images/29351/large/VNXEUR_%281%29.png?1696528300"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4186bfc76e2e237523cbc30fd220fe055156b41f",
+      "name": "KelpDAO Bridged rsETH  Arbitrum ",
+      "symbol": "RSETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39543/large/rseth.png?1722849891"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x894134a25a5fac1c2c26f1d8fbf05111a3cb9487",
+      "name": "Grai",
+      "symbol": "GRAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30427/large/GRAI_Token.png?1696529315"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13a7dedb7169a17be92b0e3c7c2315b46f4772b3",
+      "name": "Boop",
+      "symbol": "BOOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33874/large/Boop_resized.png?1703144302"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6c511dc18572d31c2c3f7b1505cb2bbc08282fcc",
+      "name": "Aipocalypto",
+      "symbol": "AIPO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51400/large/aipo.png?1731084580"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc4cbd54ffa7a6a142fd73554cc6c23dd95cd8e01",
+      "name": " GAME Token",
+      "symbol": "GAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38429/large/_GAME_Token.png?1717497071"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbcf339df10d78f2b44aa760ead0f715a7a7d7269",
+      "name": "Guardian GUARD",
+      "symbol": "GUARD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17995/large/LS_wolfDen_logo.0025_Light_200x200.png?1696517512"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x83d6c8c06ac276465e4c92e7ac8c23740f435140",
+      "name": "HMX",
+      "symbol": "HMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31206/large/HMXlogo_CG.png?1696530033"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8697841b82c71fcbd9e58c15f6de68cd1c63fd02",
+      "name": "NutCoin",
+      "symbol": "NUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37569/large/icon-2_200x200.png?1714886224"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
+      "name": "Osaka Protocol",
+      "symbol": "OSAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30911/large/OSAK_LOGO_200x200.png?1723662197"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb2f30a7c980f052f02563fb518dcc39e6bf38175",
+      "name": "Synthetix USDx",
+      "symbol": "USDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51047/large/USDX.jpg?1729845921"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbc4c97fb9befaa8b41448e1dfcc5236da543217f",
+      "name": "SpaceCatch",
+      "symbol": "CATCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36632/large/Logomark_colours.png?1712022405"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa970af1a584579b618be4d69ad6f73459d112f95",
+      "name": "sUSD",
+      "symbol": "SUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/large/sUSD.png?1696505546"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x847503fbf003ce8b005546aa3c03b80b7c2f9771",
+      "name": "Byte",
+      "symbol": "BYTE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/33527/large/Byte200.jpeg?1702138460"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xadf5dd3e51bf28ab4f07e684ecf5d00691818790",
+      "name": "ICHI",
+      "symbol": "ICHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13119/large/ICHI_%28Round%29.jpg?1696512907"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418",
+      "name": "Ramses Exchange",
+      "symbol": "RAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29420/large/newram.png?1708427055"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9e20461bc2c4c980f62f1b279d71734207a6a356",
+      "name": "OmniCat",
+      "symbol": "OMNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33917/large/omnicatlogo.png?1717544778"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11bf4f05eb28b802ed3ab672594decb20ffe2313",
+      "name": "Aurory",
+      "symbol": "AURY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19324/large/Ico_Blanc_%281%29.png?1713464485"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbe5acfd64358805616b5cbd5277b9a85011d7cf1",
+      "name": "Pichi Finance",
+      "symbol": "PCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39683/large/Group_1000003884.png?1723654999"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe85b662fe97e8562f4099d8a1d5a92d4b453bf30",
+      "name": "Thales",
+      "symbol": "THALES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18388/large/CLVZJN_C_400x400.png?1696517879"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x619c82392cb6e41778b7d088860fea8447941f4c",
+      "name": "Army of Fortune Gem",
+      "symbol": "AFG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35084/large/Token_GEM_AOFVERSE.png?1707317138"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x000000000026839b3f4181f2cf69336af6153b99",
+      "name": "Reboot",
+      "symbol": "GG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31228/large/gg_cyan_black_square.png?1703749951"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x95ab45875cffdba1e5f451b950bc2e42c0053f39",
+      "name": "Staked Frax Ether",
+      "symbol": "SFRXETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28285/large/sfrxETH_icon.png?1696527285"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x34229b3f16fbcdfa8d8d9d17c0852f9496f4c7bb",
+      "name": "IPOR",
+      "symbol": "IPOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png?1696527376"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7ce746b45eabd0c4321538dec1b849c79a9a8476",
+      "name": "DSLA Protocol",
+      "symbol": "DSLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6694/large/dsla_logo-squared_200x200.png?1696507035"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3bd2dfd03bc7c3011ed7fb8c4d0949b382726cee",
+      "name": "Roobee",
+      "symbol": "ROOBEE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8791/large/Group_11.png?1696508946"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x711b771c7c443ebb695e4b3495c337fdaf37be11",
+      "name": "Dackie USD",
+      "symbol": "DCKUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39966/large/Dackie_USD_Stablecoin.png?1724957262"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x20547341e58fb558637fa15379c92e11f7b7f710",
+      "name": "Mozaic",
+      "symbol": "MOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30100/large/Main_Logo_1-200x200jpg.jpg?1696529024"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x45d9831d8751b2325f3dbf48db748723726e1c8c",
+      "name": "EverValue Coin",
+      "symbol": "EVA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50997/large/EVA_Logo_-_with_dark_background_-_200x200.png?1729720258"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8d9ba570d6cb60c7e3e0f31343efe75ab8e65fb1",
+      "name": "Governance OHM",
+      "symbol": "GOHM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21129/large/token_wsOHM_logo.png?1696520508"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3404149e9ee6f17fb41db1ce593ee48fbdcd9506",
+      "name": "Hydranet",
+      "symbol": "HDN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25177/large/HDXdarkblueInv.png?1696524322"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3269a3c00ab86c753856fd135d97b87facb0d848",
+      "name": "Florence Finance Medici",
+      "symbol": "FFM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34382/large/M_PNG_200x200_copy.png?1704779326"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x589d35656641d6ab57a545f08cf473ecd9b6d5f7",
+      "name": "GYEN",
+      "symbol": "GYEN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14191/large/icon_gyen_200_200.png?1696513909"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc9c4fd7579133701fa2769b6955e7e56bb386db1",
+      "name": "Bridge Oracle",
+      "symbol": "BRG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12512/large/brg.png?1696512327"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x982239d38af50b0168da33346d85fb12929c4c07",
+      "name": "Arbitrove Governance Token",
+      "symbol": "TROVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29017/large/trove.png?1696527988"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf6dae0d2be4993b00a2673360820af6bafd53887",
+      "name": "Launchpool",
+      "symbol": "LPOOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14041/large/dGUvV0HQ_400x400.jpg?1696513767"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0341c0c0ec423328621788d4854119b97f44e391",
+      "name": "Silo Finance",
+      "symbol": "SILO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21454/large/y0iYKZOv_400x400.png?1696520816"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x47c337bd5b9344a6f3d6f58c474d9d8cd419d8ca",
+      "name": "DackieSwap",
+      "symbol": "DACKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30752/large/dackieswap_large.png?1707290196"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xffa188493c15dfaf2c206c97d8633377847b6a52",
+      "name": "Wefi",
+      "symbol": "WEFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30540/large/wefi.png?1696529412"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "name": "Hop Protocol",
+      "symbol": "HOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25445/large/hop.png?1696524577"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5117f4ad0bc70dbb3b05bf39a1ec1ee40dd67654",
+      "name": "Avive",
+      "symbol": "AVIVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33697/large/avive_token.png?1702814979"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb829b68f57cc546da7e5806a929e53be32a4625d",
+      "name": "Axelar Wrapped Ether",
+      "symbol": "AXLETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28171/large/weth-wei_D_3x.png?1696527174"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x429fed88f10285e61b12bdf00848315fbdfcc341",
+      "name": "THORWallet DEX",
+      "symbol": "TGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21843/large/tgt_logo.png?1696521198"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x221a0f68770658c15b525d0f89f5da2baab5f321",
+      "name": "Open Dollar",
+      "symbol": "OD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38630/large/OD_Token_200_x_200.png?1718170821"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0cbd6fadcf8096cc9a43d90b45f65826102e3ece",
+      "name": "CheckDot",
+      "symbol": "CDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20370/large/token-200x200_%281%29.png?1696519781"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb299751b088336e165da313c33e3195b8c6663a6",
+      "name": "StarHeroes",
+      "symbol": "STAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34147/large/Screenshot_2024-03-08_180444.png?1709892309"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7ba4a00d54a07461d9db2aef539e91409943adc9",
+      "name": "Stake DAO",
+      "symbol": "SDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13724/large/stakedao_logo.jpg?1696513468"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4debfb9ed639144cf1e401674af361ffffcefb58",
+      "name": "CADAI",
+      "symbol": "CADAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38713/large/CADAI_Token_Logo.png?1718404394"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3212dc0f8c834e4de893532d27cc9b6001684db0",
+      "name": "Pear Protocol",
+      "symbol": "PEAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50484/large/pearlogo.jpg?1727897446"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdb40357fbc1eb1038c5df94c1cd7b7fd3f434480",
+      "name": "SpunkySDX",
+      "symbol": "SSDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52469/large/spunkysdx.png?1733412208"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf1264873436a0771e440e2b28072fafcc5eebd01",
+      "name": "Kenshi",
+      "symbol": "KNS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30759/large/kenshi.jpg?1696529628"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1b7ad346b6ff2d196daa8e78aed86baa6d7e3b02",
+      "name": "VitAI",
+      "symbol": "VITAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52350/large/aadadsadasdas.png?1733162989"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xee9801669c6138e84bd50deb500827b776777d28",
+      "name": "O3 Swap",
+      "symbol": "O3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15460/large/o3.png?1696515107"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x60bf4e7cf16ff34513514b968483b54beff42a81",
+      "name": "ViciCoin",
+      "symbol": "VCNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31305/large/ViciCoin_-_small.png?1696530124"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1dd6b5f9281c6b4f043c02a83a46c2772024636c",
+      "name": "Lumi Finance LUAUSD",
+      "symbol": "LUAUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33503/large/LUAUSD.png?1702038709"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb64e280e9d1b5dbec4accedb2257a87b400db149",
+      "name": "Level",
+      "symbol": "LVL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28628/large/Token.png?1696527613"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x816e21c33fa5f8440ebcdf6e01d39314541bea72",
+      "name": "LiquidDriver",
+      "symbol": "LQDR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15782/large/LQDR_Glowing_Icon.png?1696515405"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe82335d58abb1cd44cd5f47cf7f5b378e4c32f05",
+      "name": "SuperCells",
+      "symbol": "SCT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38800/large/photo_2024-09-24_18-31-07.jpg?1728417418"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7c8a1a80fdd00c9cccd6ebd573e9ecb49bfa2a59",
+      "name": "AI CODE",
+      "symbol": "AICODE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30057/large/AICODE.png?1696528979"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcf985aba4647a432e60efceeb8054bbd64244305",
+      "name": "EUROe Stablecoin",
+      "symbol": "EUROE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28913/large/euroe-200x200-round.png?1696527889"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
+      "name": "Magic Internet Money  Arbitrum ",
+      "symbol": "MIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37324/large/mim.png?1714016666"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xee0a242f28034fce0bdfac33c0ad2a58ec35fd38",
+      "name": "Rosa Inu",
+      "symbol": "ROSA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37963/large/ROSA_TOKEN_3.png?1716183016"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9fb9a33956351cf4fa040f65a13b835a3c8764e3",
+      "name": "Multichain",
+      "symbol": "MULTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22087/large/1_Wyot-SDGZuxbjdkaOeT2-A.png?1696521430"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9e523234d36973f9e38642886197d023c88e307e",
+      "name": "Darwinia Network",
+      "symbol": "RING",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9443/large/RING.png?1696509535"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x75ec618a817eb0a4a7e44ac3dfc64c963daf921a",
+      "name": "Token7007",
+      "symbol": "7007",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50293/large/token7007.png?1726931640"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb9600c807f069d27f92a2a65b48f12eeef7e2007",
+      "name": "Altranium",
+      "symbol": "ALTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38301/large/altr.jpg?1717034749"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
+      "name": "Overnight Finance",
+      "symbol": "OVN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31970/large/OVN.png?1696959174"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdc8184ba488e949815d4aafb35b3c56ad03b4179",
+      "name": "Roseon",
+      "symbol": "ROSX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29698/large/roseon.png?1696528631"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7a2c1b8e26c48a5b73816b7ec826fd4053f5f34b",
+      "name": "GoSleep ZZZ",
+      "symbol": "ZZZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29901/large/ZZZ200_200.png?1696528830"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xad4b9c1fbf4923061814dd9d5732eb703faa53d4",
+      "name": "Wicrypt",
+      "symbol": "WNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21223/large/wicrypt.PNG?1696520597"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x21e60ee73f17ac0a411ae5d690f908c3ed66fe12",
+      "name": "Deri Protocol",
+      "symbol": "DERI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13931/large/200vs200.jpg?1696513670"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x431402e8b9de9aa016c743880e04e517074d8cec",
+      "name": "Hegic",
+      "symbol": "HEGIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12454/large/new.png?1696512274"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2ea0be86990e8dac0d09e4316bb92086f304622d",
+      "name": "TheStandard USD",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50381/large/USDs-200x200.png?1727411027"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4a7779abed707a9c7deadbbef5c15f3e52370a99",
+      "name": "Flame",
+      "symbol": "FLAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34280/large/20240104-164053.jpg?1704452348"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x10393c20975cf177a3513071bc110f7962cd67da",
+      "name": "Jones DAO",
+      "symbol": "JONES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23290/large/3c8c2ed8-afb3-4b67-9937-5493acd88b50.jpg?1696522508"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2297aebd383787a160dd0d9f71508148769342e3",
+      "name": "Avalanche Bridged BTC  Arbitrum One ",
+      "symbol": "BTCB",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/51135/large/avalanche-core.png?1730195092"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb1bc21f748ae2be95674876710bc6d78235480e0",
+      "name": "Hord",
+      "symbol": "HORD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14972/large/HORD_TOKEN_%281%29_1.png?1705414356"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4dd40ec670722067241b4396dbd253c38dd820b5",
+      "name": "MTMS Network",
+      "symbol": "MTMS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39043/large/Logo-MTMS.png?1720067131"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+      "name": "MUX Protocol",
+      "symbol": "MCB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11796/large/mux.jpg?1696511672"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3405e88af759992937b84e58f2fe691ef0eea320",
+      "name": "Frax Price Index Share",
+      "symbol": "FPIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24944/large/FPIS_icon.png?1696524099"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc3abc47863524ced8daf3ef98d74dd881e131c38",
+      "name": "Lumi Finance",
+      "symbol": "LUA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33502/large/LUA.png?1702038548"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1d987200df3b744cfa9c14f713f5334cb4bc4d5d",
+      "name": "REKT",
+      "symbol": "REKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29954/large/New_Project_%288%29.png?1696528881"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x53bcf6698c911b2a7409a740eacddb901fc2a2c6",
+      "name": "Kabosu  Arbitrum ",
+      "symbol": "KABOSU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30320/large/IMG_20230510_204814_554_copy_200x200.jpg?1696529222"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x87aaffdf26c6885f6010219208d5b161ec7609c0",
+      "name": "Equation",
+      "symbol": "EQU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32592/large/equation_logo.png?1699220377"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x55ff62567f09906a85183b866df84bf599a4bf70",
+      "name": "Kromatika",
+      "symbol": "KROM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20541/large/KROM_Transparent.png?1696519948"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf50874f8246776ca4b89eef471e718f70f38458f",
+      "name": "Arbswap",
+      "symbol": "ARBS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30565/large/Arb-Logo_Circle_DARK_LOGO_ONLY.png?1696529436"
     },
     {
       "chainId": 42161,
@@ -2428,627 +2460,35 @@
     },
     {
       "chainId": 42161,
-      "address": "0x53bcf6698c911b2a7409a740eacddb901fc2a2c6",
-      "name": "Kabosu  Arbitrum ",
-      "symbol": "KABOSU",
+      "address": "0xf061956612b3dc79fd285d3d51bc128f2ea87740",
+      "name": "YfDAI finance",
+      "symbol": "YF-DAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30320/large/IMG_20230510_204814_554_copy_200x200.jpg?1696529222"
+      "logoURI": "https://assets.coingecko.com/coins/images/12385/large/1619048513068.png?1696512208"
     },
     {
       "chainId": 42161,
-      "address": "0xf50874f8246776ca4b89eef471e718f70f38458f",
-      "name": "Arbswap",
-      "symbol": "ARBS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30565/large/Arb-Logo_Circle_DARK_LOGO_ONLY.png?1696529436"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc3abc47863524ced8daf3ef98d74dd881e131c38",
-      "name": "Lumi Finance",
-      "symbol": "LUA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33502/large/LUA.png?1702038548"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4dd40ec670722067241b4396dbd253c38dd820b5",
-      "name": "MTMS Network",
-      "symbol": "MTMS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39043/large/Logo-MTMS.png?1720067131"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7ae9ab13fc8945323b778b3f8678145e80ec2efb",
-      "name": "WorldBrain Coin",
-      "symbol": "WBC",
+      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
+      "name": "Lava Network",
+      "symbol": "LAVA",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39650/large/Frame_48096646.png?1723455673"
+      "logoURI": "https://assets.coingecko.com/coins/images/37354/large/lava_logo.png?1714098423"
     },
     {
       "chainId": 42161,
-      "address": "0xeb4d25db65dcef52380c99ba7e1344c820ecb1fc",
-      "name": "X World Games",
-      "symbol": "XWG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17847/large/200_200_%281%29_%281%29.png?1696790226"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5",
-      "name": "Smolcoin",
-      "symbol": "SMOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33951/large/Smol_Coin_Icon.png?1703558329"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbc4c97fb9befaa8b41448e1dfcc5236da543217f",
-      "name": "SpaceCatch",
-      "symbol": "CATCH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36632/large/Logomark_colours.png?1712022405"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x71eeba415a523f5c952cc2f06361d5443545ad28",
-      "name": "XDAO",
-      "symbol": "XDAO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27363/large/token_2.png?1696526408"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0341c0c0ec423328621788d4854119b97f44e391",
-      "name": "Silo Finance",
-      "symbol": "SILO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21454/large/y0iYKZOv_400x400.png?1696520816"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
-      "name": "Gains Network USDC",
-      "symbol": "GUSDC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39042/large/logo_gUSDC.png?1720066451"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x06d65ec13465ac5a4376dc101e1141252c4addf8",
-      "name": "Zunami ETH",
-      "symbol": "ZUNETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37835/large/zunETH_200x200.png?1715741123"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x188fb5f5ae5bbe4154d5778f2bbb2fb985c94d25",
-      "name": "OpenBlox",
-      "symbol": "OBX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26150/large/OBX_token-black_background_preview.png?1696525239"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc19669a405067927865b40ea045a2baabbbe57f5",
-      "name": "Star",
-      "symbol": "STAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31277/large/coin-icon_Star-200x200.png?1732742256"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3405e88af759992937b84e58f2fe691ef0eea320",
-      "name": "Frax Price Index Share",
-      "symbol": "FPIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24944/large/FPIS_icon.png?1696524099"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xad4b9c1fbf4923061814dd9d5732eb703faa53d4",
-      "name": "Wicrypt",
-      "symbol": "WNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21223/large/wicrypt.PNG?1696520597"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2b089381f53525451fe5115f23e9d2cc92d7ff1d",
-      "name": "Digital Reserve Currency",
-      "symbol": "DRC",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/12802/large/DRC_Logo.jpg?1696512595"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4debfb9ed639144cf1e401674af361ffffcefb58",
-      "name": "CADAI",
-      "symbol": "CADAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38713/large/CADAI_Token_Logo.png?1718404394"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2ea0be86990e8dac0d09e4316bb92086f304622d",
-      "name": "TheStandard USD",
-      "symbol": "USDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50381/large/USDs-200x200.png?1727411027"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe3b3fe7bca19ca77ad877a5bebab186becfad906",
-      "name": "Staked FRAX",
-      "symbol": "SFRAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35383/large/sfrax.png?1708445569"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x34229b3f16fbcdfa8d8d9d17c0852f9496f4c7bb",
-      "name": "IPOR",
-      "symbol": "IPOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png?1696527376"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x20547341e58fb558637fa15379c92e11f7b7f710",
-      "name": "Mozaic",
-      "symbol": "MOZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30100/large/Main_Logo_1-200x200jpg.jpg?1696529024"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x130096af9163b185cae4a833f856760199fc6ceb",
-      "name": "FU Money",
-      "symbol": "FU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38629/large/FU_logo_black.png?1718170125"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbfbcfe8873fe28dfa25f1099282b088d52bbad9c",
-      "name": "Equilibria Finance",
-      "symbol": "EQB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30645/large/QLLK8pmR_400x400.jpg?1696529516"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x86f65121804d2cdbef79f9f072d4e0c2eebabc08",
-      "name": "Garden",
-      "symbol": "SEED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34671/large/icon.png?1705656915"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x439c0cf1038f8002a4cad489b427e217ba4b42ad",
-      "name": "GNB",
-      "symbol": "GNB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38687/large/GINAICNLOGO.png?1718344439"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb829b68f57cc546da7e5806a929e53be32a4625d",
-      "name": "Axelar Wrapped Ether",
-      "symbol": "AXLETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28171/large/weth-wei_D_3x.png?1696527174"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xcf985aba4647a432e60efceeb8054bbd64244305",
-      "name": "EUROe Stablecoin",
-      "symbol": "EUROE",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/28913/large/euroe-200x200-round.png?1696527889"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x999faf0af2ff109938eefe6a7bf91ca56f0d07e1",
-      "name": "Ledgity Token",
-      "symbol": "LDY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35046/large/ldy-token.png?1707204910"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x589d35656641d6ab57a545f08cf473ecd9b6d5f7",
-      "name": "GYEN",
-      "symbol": "GYEN",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/14191/large/icon_gyen_200_200.png?1696513909"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x346e74dc9935a9b02eb34fb84658a66010fa056d",
-      "name": "Zunami Governance Token",
-      "symbol": "ZUN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38298/large/ZUN_200x200.png?1717194404"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x299142a6370e1912156e53fbd4f25d7ba49ddcc5",
-      "name": "AI Meta Club",
-      "symbol": "AMC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31919/large/aimeta.jpg?1696530728"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9cf7eebb75b751dc8fdd2268ae8c9b570b4c97b9",
-      "name": "NULL MATRIX",
-      "symbol": "NULL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51086/large/dark.png?1732460149"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb1084db8d3c05cebd5fa9335df95ee4b8a0edc30",
-      "name": "Overnight fi USDT ",
-      "symbol": "USDT+",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/30168/large/USDT_.png?1696529088"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x32eb7902d4134bf98a28b963d26de779af92a212",
-      "name": "Dopex Rebate",
-      "symbol": "RDPX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16659/large/rDPX_200x200_Coingecko.png?1696516221"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x11bbf12363dc8375b78d2719395d505f52a02f68",
-      "name": "Router Protocol  OLD ",
-      "symbol": "ROUTE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13709/large/router.jpg?1722424977"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbea0005b8599265d41256905a9b3073d397812e4",
-      "name": "Bean",
-      "symbol": "BEAN",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/18447/large/bean-logo-coingecko.png?1696517934"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6bcc14b02cd624ebe1a8a665cb6d4067aa097230",
-      "name": "Foxify",
-      "symbol": "FOX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32354/large/Foxify_200x200.png?1697475371"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbcd4d5ac29e06e4973a1ddcd782cd035d04bc0b7",
-      "name": "Quick Intel",
-      "symbol": "QKNTL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29605/large/IMG_6589D0616DF1-1.jpeg?1696528542"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7fb7ede54259cb3d4e1eaf230c7e2b1ffc951e9a",
-      "name": "Numa",
-      "symbol": "NUMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35807/large/numa200.png?1709845645"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8cf7e3aa6faf6ae180e5ec3f0fb95081c2086ebe",
-      "name": "SX Network",
-      "symbol": "SX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34934/large/sx-ntework.jpeg?1706699134"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6dd963c510c2d2f09d5eddb48ede45fed063eb36",
-      "name": "FactorDAO",
-      "symbol": "FCTR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29018/large/FactorLogo.png?1696527989"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x93ca0d85837ff83158cd14d65b169cdb223b1921",
-      "name": "Eclipse Fi",
-      "symbol": "ECLIP",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/31815/large/ECLIP_token_logo.png?1696530629"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf3527ef8de265eaa3716fb312c12847bfba66cef",
-      "name": "usdx money USDX",
-      "symbol": "USDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50360/large/USDX200px.png?1731906044"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x13461c85887e85fdc942ac94c4d2699995ad1960",
-      "name": "Cradles",
-      "symbol": "CRDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33084/large/cradles_icon.png?1700601703"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9fb9a33956351cf4fa040f65a13b835a3c8764e3",
-      "name": "Multichain",
-      "symbol": "MULTI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22087/large/1_Wyot-SDGZuxbjdkaOeT2-A.png?1696521430"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd3188e0df68559c0b63361f6160c57ad88b239d8",
-      "name": "Astra DAO",
-      "symbol": "ASTRADAO",
+      "address": "0x569deb225441fd18bde18aed53e2ec7eb4e10d93",
+      "name": "Your Futures Exchange",
+      "symbol": "YFX",
       "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/32870/large/ASTRADAO.jpg?1699673097"
+      "logoURI": "https://assets.coingecko.com/coins/images/15654/large/yfx.PNG?1696515285"
     },
     {
       "chainId": 42161,
-      "address": "0x655a6beebf2361a19549a99486ff65f709bd2646",
-      "name": "LilAI",
-      "symbol": "LILAI",
+      "address": "0xee0b14e8fc86691cf6ee42b9954985b4cf968534",
+      "name": "ZenPandaCoin",
+      "symbol": "ZPC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30621/large/LogoLilai_CoinGecko.png?1696529495"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x79ead7a012d97ed8deece279f9bc39e264d7eef9",
-      "name": "Bonsai",
-      "symbol": "BONSAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37883/large/bonsai.jpeg?1715840730"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3f56e0c36d275367b8c502090edf38289b3dea0d",
-      "name": "MAI  Arbitrum ",
-      "symbol": "MIMATIC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35517/large/mimatic-red.png?1709005586"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa71e2738704e367798baa2755af5a10499634953",
-      "name": "Avarik Saga",
-      "symbol": "AVRK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51914/large/Logo500x500.png?1732258561"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7f4db37d7beb31f445307782bc3da0f18df13696",
-      "name": "Yield Yak",
-      "symbol": "YAK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17654/large/yieldyak.png?1696517185"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf5a27e55c748bcddbfea5477cb9ae924f0f7fd2e",
-      "name": "TheStandard Token",
-      "symbol": "TST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20598/large/TheStandard-logo_variation-01.png?1696520005"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1bd013bd089c2b6b2d30a0e0b545810a5844e761",
-      "name": "OtterHome",
-      "symbol": "HOME",
-      "decimals": 16,
-      "logoURI": "https://assets.coingecko.com/coins/images/30740/large/LOGO.png?1696529610"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x27f485b62c4a7e635f561a87560adf5090239e93",
-      "name": "DFX Finance",
-      "symbol": "DFX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14091/large/DFX.png?1696513813"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x872bad41cfc8ba731f811fea8b2d0b9fd6369585",
-      "name": "BattleFly",
-      "symbol": "GFLY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28828/large/GFLY_LOGO.png?1696527804"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8bf591eae535f93a242d5a954d3cde648b48a5a8",
-      "name": "Sumer Money suUSD",
-      "symbol": "SUUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33266/large/Sumer_Money_Logo.jpg?1701321416"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x577fd586c9e6ba7f2e85e025d5824dbe19896656",
-      "name": "Synonym Finance",
-      "symbol": "SYNO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35065/large/SYNO-token.png?1707241258"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1a5b0aaf478bf1fda7b934c76e7692d722982a6d",
-      "name": "Buffer Token",
-      "symbol": "BFR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18540/large/Qk6pjeZ3_400x400.jpg?1696518020"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xde70aed3d14d39b4955147efcf272334bdb75ab5",
-      "name": "YachtingVerse",
-      "symbol": "YACHT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32858/large/aMmNwBTH_400x400.jpg?1699666370"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xddd6ebd74684318fa912084a41a01f11b6c277f7",
-      "name": "WorkoutApp",
-      "symbol": "WRT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37270/large/wrt.jpg?1713888102"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4b019aaa21e98e212d31e54c843e73ff34d25717",
-      "name": "TUX Project",
-      "symbol": "TUXC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37537/large/tuxc.jpg?1714687219"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
-      "name": "BetSwirl",
-      "symbol": "BETS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26618/large/icon_200.png?1696525691"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x56659245931cb6920e39c189d2a0e7dd0da2d57b",
-      "name": "Impermax",
-      "symbol": "IBEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27606/large/IqwOmX-c_400x400.jpeg?1696526637"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xef04804e1e474d3f9b73184d7ef5d786f3fce930",
-      "name": "Wall Street Games",
-      "symbol": "WSG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36483/large/wsg.jpeg?1711539007"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xafe8107123eefd62469474dec9680860b890e5b6",
-      "name": "Oil Token",
-      "symbol": "OIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39504/large/logo_oil_200%D1%85200.png?1722581566"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0002bcdaf53f4889bf2f43a3252d7c03fe1b80bc",
-      "name": "GorplesCoin",
-      "symbol": "GORPLES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38681/large/Round_Avatar.png?1720520435"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x949185d3be66775ea648f4a306740ea9eff9c567",
-      "name": "Yel Finance",
-      "symbol": "YEL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17429/large/Logo200.png?1696516976"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
-      "name": "Pickle Finance",
-      "symbol": "PICKLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12435/large/0M4W6Yr6_400x400.jpg?1696512255"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x965d00aa7abc62ca10132e641d08593435ac811d",
-      "name": "KAP Games",
-      "symbol": "KAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27682/large/KAP_Logo.png?1696526710"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x54bdbf3ce36f451ec61493236b8e6213ac87c0f6",
-      "name": "Radpie",
-      "symbol": "RDP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34052/large/Radpie_token_3_2.png?1704672743"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x80dd74145b8bb10cef01bf914f796bd8b54d7809",
-      "name": "Hepton",
-      "symbol": "HTE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30274/large/HTECoingecko.png?1696529180"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6dbf2155b0636cb3fd5359fccefb8a2c02b6cb51",
-      "name": "Plutus RDNT",
-      "symbol": "PLSRDNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30635/large/plsRDNT.png?1696529508"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x51fc0f6660482ea73330e414efd7808811a57fa2",
-      "name": "Premia",
-      "symbol": "PREMIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13962/large/apple-touch-icon.png?1696513698"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x249c48e22e95514ca975de31f473f30c2f3c0916",
-      "name": "USDFI",
-      "symbol": "USDFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31149/large/USDFI_200.png?1696529977"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x155f0dd04424939368972f4e1838687d6a831151",
-      "name": "ArbiDoge",
-      "symbol": "ADOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18333/large/Screen-Shot-2021-09-04-at-11-59-16-AM.png?1696517824"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa334884bf6b0a066d553d19e507315e839409e62",
-      "name": "Ethos Reserve Note",
-      "symbol": "ERN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29744/large/ERN200x200.png?1696528676"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x64343594ab9b56e99087bfa6f2335db24c2d1f17",
-      "name": "Vesta Stable",
-      "symbol": "VST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23621/large/vesta.png?1696522826"
+      "logoURI": "https://assets.coingecko.com/coins/images/30269/large/panda.png?1696529176"
     },
     {
       "chainId": 42161,
@@ -3060,323 +2500,91 @@
     },
     {
       "chainId": 42161,
-      "address": "0xa9011ee5796be43123651181dc75c0e72bb1191c",
-      "name": "NeuroPulse AI",
-      "symbol": "NPAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31848/large/NPAI.png?1700257725"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9cfb13e6c11054ac9fcb92ba89644f30775436e4",
-      "name": "Bridged Wrapped stETH  Axelar ",
-      "symbol": "AXL-WSTETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32223/large/steth-wei_D_3x.png?1696926841"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xecc68d0451e20292406967fe7c04280e5238ac7d",
-      "name": "Axelar Bridged Frax Ether",
-      "symbol": "AXLFRXETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38976/large/Screen_Shot_2024-06-18_at_12.55.54_PM_2.png?1719714886"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x221a0f68770658c15b525d0f89f5da2baab5f321",
-      "name": "Open Dollar",
-      "symbol": "OD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38630/large/OD_Token_200_x_200.png?1718170821"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd4848211b699503c772aa1bc7d33b433c4242ac3",
-      "name": "Equilibria Finance ePENDLE",
-      "symbol": "EPENDLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33379/large/photo_2023-12-02_19-45-14.jpg?1701665986"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x07e49d5de43dda6162fa28d24d5935c151875283",
-      "name": "CVI",
-      "symbol": "GOVI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13875/large/GOVI.png?1696513619"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe4421566a501045ae4285996577a36f6cf074190",
-      "name": "Ice",
-      "symbol": "ICE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35093/large/ICE_LOGO.jpg?1707363813"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x31c91d8fb96bff40955dd2dbc909b36e8b104dde",
-      "name": "Poison Finance",
-      "symbol": "POION",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28630/large/poisonlogo160x160.png?1696527614"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd978f8489e1245568704407a479a71fcce2afe8f",
-      "name": "ApeSwap",
-      "symbol": "BANANA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14870/large/banana.png?1696514534"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8347dff20de05b11c0781aaea90d5bee46c30252",
-      "name": "Playahh App",
-      "symbol": "PLAH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40098/large/logoPlayahh10.png?1725632328"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x079504b86d38119f859c4194765029f692b7b7aa",
-      "name": "Lyra Finance",
-      "symbol": "LYRA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21490/large/Add-a-heading-26.png?1696520850"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0caadd427a6feb5b5fc1137eb05aa7ddd9c08ce9",
-      "name": "VEE",
-      "symbol": "VEE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52199/large/1000002075.png?1732732974"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x83e60b9f7f4db5cdb0877659b1740e73c662c55b",
-      "name": "Pingu Exchange",
-      "symbol": "PINGU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34790/large/icon_primary.png?1706030846"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xafccb724e3aec1657fc9514e3e53a0e71e80622d",
-      "name": "Vaultka",
-      "symbol": "VKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32408/large/VKA_logo_PNG.png?1698057073"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfd2fb8de10ec41ddd898a8c7fa70d8fc100834c4",
-      "name": "Bitci DOGE",
-      "symbol": "BOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38048/large/DOGE_TOKEN_200.png?1716401036"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdb298285fe4c5410b05390ca80e8fbe9de1f259b",
-      "name": "handle fi",
-      "symbol": "FOREX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18533/large/handle.fiFOREXLogoDark200x200.png?1696518013"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7f90122bf0700f9e7e1f688fe926940e8839f353",
-      "name": "Curve fi USDC USDT",
-      "symbol": "2CRV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28365/large/curve2.png?1696527368"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x498c620c7c91c6eba2e3cd5485383f41613b7eb6",
-      "name": "Alongside Crypto Market Index",
-      "symbol": "AMKT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28496/large/22999.png?1696527488"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xed5740209fcf6974d6f3a5f11e295b5e468ac27c",
-      "name": "KEWL EXCHANGE",
-      "symbol": "KWL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36883/large/yamuk.png?1712649510"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xccd05a0fcfc1380e9da27862adb2198e58e0d66f",
-      "name": "ANIMA",
-      "symbol": "ANIMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30377/large/anima_logo_yellow.png?1696529271"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd45e486a90ebb84e9336d371a35dcb021424b96c",
-      "name": "Superpower Squad",
-      "symbol": "SQUAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28466/large/SQUAD200X200.png?1696527460"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x45940000009600102a1c002f0097c4a500fa00ab",
-      "name": "Hermes Protocol",
-      "symbol": "HERMES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24251/large/Transparent-13_%281%29_%281%29.png?1725188033"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x00000000ea00f3f4000e7ed5ed91965b19f1009b",
-      "name": "Maia",
-      "symbol": "MAIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22502/large/Transparent-04_%281%29_%281%29.png?1725187885"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6f5401c53e2769c858665621d22ddbf53d8d27c5",
-      "name": "Connect Financial",
-      "symbol": "CNFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13592/large/cf-logo-iconic-black.png?1696513344"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x323665443cef804a3b5206103304bd4872ea4253",
-      "name": "Verified USD",
-      "symbol": "USDV",
+      "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+      "name": "Gains Network USDC",
+      "symbol": "GUSDC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/32948/large/usdv_%281%29.png?1699933314"
+      "logoURI": "https://assets.coingecko.com/coins/images/39042/large/logo_gUSDC.png?1720066451"
     },
     {
       "chainId": 42161,
-      "address": "0x16a500aec6c37f84447ef04e66c57cfc6254cf92",
-      "name": "Umoja",
-      "symbol": "UMJA",
+      "address": "0x71eeba415a523f5c952cc2f06361d5443545ad28",
+      "name": "XDAO",
+      "symbol": "XDAO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38328/large/Umoja_Logo.png?1717639928"
+      "logoURI": "https://assets.coingecko.com/coins/images/27363/large/token_2.png?1696526408"
     },
     {
       "chainId": 42161,
-      "address": "0x65c936f008bc34fe819bce9fa5afd9dc2d49977f",
-      "name": "Y2K",
-      "symbol": "Y2K",
+      "address": "0x2ac2b254bc18cd4999f64773a966e4f4869c34ee",
+      "name": "Penpie",
+      "symbol": "PNP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28542/large/l7jRo-5-_400x400.jpg?1696527534"
+      "logoURI": "https://assets.coingecko.com/coins/images/30760/large/PNP_Token.png?1696529629"
     },
     {
       "chainId": 42161,
-      "address": "0x6612ce012ba5574a2ecea3a825c1ddf641f78623",
-      "name": "Dorado Finance",
-      "symbol": "DORAB",
+      "address": "0xcf934e2402a5e072928a39a956964eb8f2b5b79c",
+      "name": "PoolTogether",
+      "symbol": "POOL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38347/large/Dorado_Logo.png?1717143752"
+      "logoURI": "https://assets.coingecko.com/coins/images/14003/large/PoolTogether.png?1696513732"
     },
     {
       "chainId": 42161,
-      "address": "0x3b475f6f2f41853706afc9fa6a6b8c5df1a2724c",
-      "name": "Zyberswap",
-      "symbol": "ZYB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28943/large/logo_with_bg.png?1696527917"
+      "address": "0x93ca0d85837ff83158cd14d65b169cdb223b1921",
+      "name": "Eclipse Fi",
+      "symbol": "ECLIP",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31815/large/ECLIP_token_logo.png?1696530629"
     },
     {
       "chainId": 42161,
-      "address": "0xb9af4762c039d63e30039f1712dfab77026408c7",
-      "name": "BullBear AI",
-      "symbol": "AIBB",
+      "address": "0xe3b3fe7bca19ca77ad877a5bebab186becfad906",
+      "name": "Staked FRAX",
+      "symbol": "SFRAX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30096/large/ICON_200.png?1696529020"
+      "logoURI": "https://assets.coingecko.com/coins/images/35383/large/sfrax.png?1708445569"
     },
     {
       "chainId": 42161,
-      "address": "0x2fac624899a844e0628bfdcc70efcd25f6e90b95",
-      "name": "Youwho",
-      "symbol": "YOU",
+      "address": "0x6dd963c510c2d2f09d5eddb48ede45fed063eb36",
+      "name": "Factor",
+      "symbol": "FCTR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25353/large/youwho_200.png?1696524487"
+      "logoURI": "https://assets.coingecko.com/coins/images/29018/large/FactorLogo.png?1696527989"
     },
     {
       "chainId": 42161,
-      "address": "0x643b34980e635719c15a2d4ce69571a258f940e9",
-      "name": "The Standard EURO",
-      "symbol": "EUROS",
+      "address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
+      "name": "Ankr Staked ETH",
+      "symbol": "ANKRETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32231/large/EUROs-coingecko.png?1696936278"
+      "logoURI": "https://assets.coingecko.com/coins/images/13403/large/aETHc.png?1696513165"
     },
     {
       "chainId": 42161,
-      "address": "0x8038f3c971414fd1fc220ba727f2d4a0fc98cb65",
-      "name": "dHEDGE DAO",
-      "symbol": "DHT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12508/large/dht.png?1696512323"
+      "address": "0x2b089381f53525451fe5115f23e9d2cc92d7ff1d",
+      "name": "Digital Reserve Currency",
+      "symbol": "DRC",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/12802/large/DRC_Logo.jpg?1696512595"
     },
     {
       "chainId": 42161,
-      "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
-      "name": "usdx money Staked USDX",
-      "symbol": "SUSDX",
+      "address": "0x655a6beebf2361a19549a99486ff65f709bd2646",
+      "name": "LilAI",
+      "symbol": "LILAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50836/large/sUSDX200px.png?1731906119"
+      "logoURI": "https://assets.coingecko.com/coins/images/30621/large/LogoLilai_CoinGecko.png?1696529495"
     },
     {
       "chainId": 42161,
-      "address": "0x6b5b5eac259e883b484ed879d43dd4d616a90e65",
-      "name": "The Knowers",
-      "symbol": "KNOW",
+      "address": "0xeb4d25db65dcef52380c99ba7e1344c820ecb1fc",
+      "name": "X World Games",
+      "symbol": "XWG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36964/large/63_%281%29.png?1712907583"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1d1498166ddceee616a6d99868e1e0677300056f",
-      "name": "Space Token",
-      "symbol": "SPACE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20676/large/jYw3kgsY_400x400.png?1696520076"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x59debed8d46a0cb823d8be8b957add987ead39aa",
-      "name": "Quack Token",
-      "symbol": "QUACK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31436/large/0x639C0D019C257966C4907bD4E68E3F349bB58109.png?1696530251"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdc8b6b6beab4d5034ae91b7a1cf7d05a41f0d239",
-      "name": "Gemach",
-      "symbol": "GMAC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32334/large/gmac-200x200.png?1697452788"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0bbf664d46becc28593368c97236faa0fb397595",
-      "name": "KNOX Dollar",
-      "symbol": "KNOX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38074/large/knox%28200_x_200_px%29.png?1716449113"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3419875b4d3bca7f3fdda2db7a476a79fd31b4fe",
-      "name": "DizzyHavoc",
-      "symbol": "DZHV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35575/large/dizzyhavoc_circle_3_200_200_transparentBg.png?1709194317"
+      "logoURI": "https://assets.coingecko.com/coins/images/17847/large/200_200_%281%29_%281%29.png?1696790226"
     },
     {
       "chainId": 42161,
@@ -3388,195 +2596,275 @@
     },
     {
       "chainId": 42161,
-      "address": "0x36295e7de7024362ad95bb8be93d6d6d21d7f6c1",
-      "name": "XGPU AI",
-      "symbol": "XGPU",
+      "address": "0x439c0cf1038f8002a4cad489b427e217ba4b42ad",
+      "name": "GNB",
+      "symbol": "GNB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37453/large/xgpu.png?1714448873"
+      "logoURI": "https://assets.coingecko.com/coins/images/38687/large/GINAICNLOGO.png?1718344439"
     },
     {
       "chainId": 42161,
-      "address": "0x7f5373ae26c3e8ffc4c77b7255df7ec1a9af52a6",
-      "name": "Bridged Tether  Axelar ",
-      "symbol": "AXLUSDT",
+      "address": "0xb00eaedb98f1e30ad545703d8ff14b24d109514f",
+      "name": "Yaku",
+      "symbol": "YAKU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26785/large/yaku_logo.png?1706636424"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xafafd68afe3fe65d376eec9eab1802616cfaccb8",
+      "name": "Solv Protocol SolvBTC ENA",
+      "symbol": "SOLVBTCENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38931/large/BTC_ena.png?1719562313"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7ae9ab13fc8945323b778b3f8678145e80ec2efb",
+      "name": "WorldBrain Coin",
+      "symbol": "WBC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/31002/large/uusdt_D_3x.png?1696529840"
+      "logoURI": "https://assets.coingecko.com/coins/images/39650/large/Frame_48096646.png?1723455673"
     },
     {
       "chainId": 42161,
-      "address": "0x9b06f3c5de42d4623d7a2bd940ec735103c68a76",
-      "name": "Volta Club",
-      "symbol": "VOLTA",
+      "address": "0xbfbcfe8873fe28dfa25f1099282b088d52bbad9c",
+      "name": "Equilibria Finance",
+      "symbol": "EQB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31602/large/volta-200x200.png?1696530418"
+      "logoURI": "https://assets.coingecko.com/coins/images/30645/large/QLLK8pmR_400x400.jpg?1696529516"
     },
     {
       "chainId": 42161,
-      "address": "0x7a5d193fe4ed9098f7eadc99797087c96b002907",
-      "name": "Plutus ARB",
-      "symbol": "PLSARB",
+      "address": "0xb52bd62ee0cf462fa9ccbda4bf27fe84d9ab6cf7",
+      "name": "Clipper SAIL",
+      "symbol": "SAIL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30636/large/plsARB.png?1696529509"
+      "logoURI": "https://assets.coingecko.com/coins/images/31380/large/SAIL-Logo.png?1696530197"
     },
     {
       "chainId": 42161,
-      "address": "0xbbea044f9e7c0520195e49ad1e561572e7e1b948",
-      "name": "Mizar",
-      "symbol": "MZR",
+      "address": "0xf763fa322dc58dee588252fafee5f448e863b633",
+      "name": "Carbon Protocol",
+      "symbol": "SWTH",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/3645/large/SWTH_Symbol_Origin.png?1696504327"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x07e49d5de43dda6162fa28d24d5935c151875283",
+      "name": "CVI",
+      "symbol": "GOVI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23272/large/V1DTptkT_400x400.jpg?1696522492"
+      "logoURI": "https://assets.coingecko.com/coins/images/13875/large/GOVI.png?1696513619"
     },
     {
       "chainId": 42161,
-      "address": "0xf42e2b8bc2af8b110b65be98db1321b1ab8d44f5",
-      "name": "Donut",
-      "symbol": "DONUT",
+      "address": "0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55",
+      "name": "Dopex",
+      "symbol": "DPX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7538/large/Donut.png?1696507804"
+      "logoURI": "https://assets.coingecko.com/coins/images/16652/large/DPX_%281%29.png?1696516213"
     },
     {
       "chainId": 42161,
-      "address": "0xe20b9e246db5a0d21bf9209e4858bc9a3ff7a034",
-      "name": "Wrapped Banano",
-      "symbol": "WBAN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32617/large/WBAN.jpg?1698749253"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd1e094cabc5acb9d3b0599c3f76f2d01ff8d3563",
-      "name": "VirtuSwap",
-      "symbol": "VRSW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30629/large/VirtuSwap_Logo_Red_200x200.png?1696529502"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9d0c0675a995d5f12b03e880763f639d0628b5c6",
-      "name": "SuperWalk WALK",
-      "symbol": "WALK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37379/large/superwalk.jpeg?1714213441"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4e0da40b9063dc48364c1c0ffb4ae9d091fc2270",
-      "name": "Edgeware",
-      "symbol": "EDG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8452/large/logo-edgeware.png?1696508638"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa3210cd727fe6daf8386af5623ba51a367e46263",
-      "name": "Basket",
-      "symbol": "BSKT",
-      "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/34661/large/BSKT_Logo.png?1705636891"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9500ba777560daf9d3ab148ea1cf1ed39df9ebdb",
-      "name": "STYLE Token",
-      "symbol": "STYLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37507/large/Token_Logo__STYLE.png?1729579902"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3ed03e95dd894235090b3d4a49e0c3239edce59e",
-      "name": "Blox MYRC",
-      "symbol": "MYRC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38632/large/myrc-token-trans-200x200.png?1718172187"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x666966ef3925b1c92fa355fda9722899f3e73451",
-      "name": "Stable",
-      "symbol": "STABLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31148/large/stable_200.png?1696529976"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb01cf1be9568f09449382a47cd5bf58e2a9d5922",
-      "name": "Lightspeed",
-      "symbol": "SPEED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51401/large/lightspeed-round-200.png?1731085512"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x180f7cf38805d1be95c7632f653e26b0838e2969",
-      "name": "XDEFI",
-      "symbol": "XDEFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19524/large/xdefi.jpg?1723436519"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd26b0c6ef8581e921ae41c66e508c62a581b709d",
-      "name": "Sexone",
-      "symbol": "SEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32135/large/IMG_20231004_163306_491.jpg?1696589011"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4727a7d2022e99ee5c298513b730307f458f9b40",
-      "name": "Guberto",
-      "symbol": "GUBERTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50787/large/guberto_%281%29.jpg?1729210166"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x284592a004d945f98de5b040808578c61a4bb39a",
-      "name": "AIR",
-      "symbol": "AIR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36113/large/Air_%28AIR%29_1.png?1710487829"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7f850b0ab1988dd17b69ac564c1e2857949e4dee",
-      "name": "Lift Dollar",
-      "symbol": "USDL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38484/large/USDL-Token-200px.png?1725022887"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4d15a3a2286d883af0aa1b3f21367843fac63e07",
-      "name": "Bridged TrueUSD",
-      "symbol": "TUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30837/large/tusd.jpeg?1696529695"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4cfa50b7ce747e2d61724fcac57f24b748ff2b2a",
-      "name": "Fluid USDC",
-      "symbol": "FUSDC",
+      "address": "0xb1084db8d3c05cebd5fa9335df95ee4b8a0edc30",
+      "name": "Overnight fi USDT ",
+      "symbol": "USDT+",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/28471/large/fUSDC-200x200.png?1696527465"
+      "logoURI": "https://assets.coingecko.com/coins/images/30168/large/USDT_.png?1696529088"
     },
     {
       "chainId": 42161,
-      "address": "0xd44257dde89ca53f1471582f718632e690e46dc2",
-      "name": "S",
-      "symbol": "S",
+      "address": "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5",
+      "name": "Smolcoin",
+      "symbol": "SMOL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50350/large/s.jpg?1727249471"
+      "logoURI": "https://assets.coingecko.com/coins/images/33951/large/Smol_Coin_Icon.png?1703558329"
     },
     {
       "chainId": 42161,
-      "address": "0x0a3bb08b3a15a19b4de82f8acfc862606fb69a2d",
-      "name": "iZUMi Bond USD",
-      "symbol": "IUSD",
+      "address": "0xafccb724e3aec1657fc9514e3e53a0e71e80622d",
+      "name": "Vaultka",
+      "symbol": "VKA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25388/large/iusd-logo-symbol-10k%E5%A4%A7%E5%B0%8F.png?1696524521"
+      "logoURI": "https://assets.coingecko.com/coins/images/32408/large/VKA_logo_PNG.png?1698057073"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x323665443cef804a3b5206103304bd4872ea4253",
+      "name": "Verified USD",
+      "symbol": "USDV",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/32948/large/usdv_%281%29.png?1699933314"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1a5b0aaf478bf1fda7b934c76e7692d722982a6d",
+      "name": "Buffer Token",
+      "symbol": "BFR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18540/large/Qk6pjeZ3_400x400.jpg?1696518020"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xef04804e1e474d3f9b73184d7ef5d786f3fce930",
+      "name": "Wall Street Games",
+      "symbol": "WSG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36483/large/wsg.jpeg?1711539007"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9cf7eebb75b751dc8fdd2268ae8c9b570b4c97b9",
+      "name": "NULL MATRIX",
+      "symbol": "NULL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51086/large/dark.png?1732460149"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11bbf12363dc8375b78d2719395d505f52a02f68",
+      "name": "Router Protocol  OLD ",
+      "symbol": "ROUTE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13709/large/router.jpg?1722424977"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x79ead7a012d97ed8deece279f9bc39e264d7eef9",
+      "name": "Bonsai",
+      "symbol": "BONSAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37883/large/bonsai.jpeg?1715840730"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x64343594ab9b56e99087bfa6f2335db24c2d1f17",
+      "name": "Vesta Stable",
+      "symbol": "VST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23621/large/vesta.png?1696522826"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3d15fd46ce9e551498328b1c83071d9509e2c3a0",
+      "name": "Universal ETH",
+      "symbol": "UNIETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28477/large/uniETH_200.png?1696527471"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13461c85887e85fdc942ac94c4d2699995ad1960",
+      "name": "Cradles",
+      "symbol": "CRDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33084/large/cradles_icon.png?1700601703"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8347dff20de05b11c0781aaea90d5bee46c30252",
+      "name": "Playahh App",
+      "symbol": "PLAH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40098/large/logoPlayahh10.png?1725632328"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa334884bf6b0a066d553d19e507315e839409e62",
+      "name": "Ethos Reserve Note",
+      "symbol": "ERN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29744/large/ERN200x200.png?1696528676"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa586b3b80d7e3e8d439e25fbc16bc5bcee3e2c85",
+      "name": "Codyfight",
+      "symbol": "CTOK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23592/large/ctok.jpg?1715904249"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xde70aed3d14d39b4955147efcf272334bdb75ab5",
+      "name": "YachtingVerse",
+      "symbol": "YACHT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32858/large/aMmNwBTH_400x400.jpg?1699666370"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x577fd586c9e6ba7f2e85e025d5824dbe19896656",
+      "name": "Synonym Finance",
+      "symbol": "SYNO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35065/large/SYNO-token.png?1707241258"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd45e486a90ebb84e9336d371a35dcb021424b96c",
+      "name": "Superpower Squad",
+      "symbol": "SQUAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28466/large/SQUAD200X200.png?1696527460"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7fb7ede54259cb3d4e1eaf230c7e2b1ffc951e9a",
+      "name": "Numa",
+      "symbol": "NUMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35807/large/numa200.png?1709845645"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x27f485b62c4a7e635f561a87560adf5090239e93",
+      "name": "DFX Finance",
+      "symbol": "DFX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14091/large/DFX.png?1696513813"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x130096af9163b185cae4a833f856760199fc6ceb",
+      "name": "FU Money",
+      "symbol": "FU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38629/large/FU_logo_black.png?1718170125"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xddd6ebd74684318fa912084a41a01f11b6c277f7",
+      "name": "WorkoutApp",
+      "symbol": "WRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37270/large/wrt.jpg?1713888102"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x299142a6370e1912156e53fbd4f25d7ba49ddcc5",
+      "name": "AI Meta Club",
+      "symbol": "AMC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31919/large/aimeta.jpg?1696530728"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x306fd3e7b169aa4ee19412323e1a5995b8c1a1f4",
+      "name": "Black Agnus",
+      "symbol": "FTW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50170/large/32x32.png?1727177729"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf5a27e55c748bcddbfea5477cb9ae924f0f7fd2e",
+      "name": "TheStandard Token",
+      "symbol": "TST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20598/large/TheStandard-logo_variation-01.png?1696520005"
     },
     {
       "chainId": 42161,
@@ -3588,363 +2876,163 @@
     },
     {
       "chainId": 42161,
-      "address": "0x123389c2f0e9194d9ba98c21e63c375b67614108",
-      "name": "EthereumMax",
-      "symbol": "EMAX",
+      "address": "0x0caadd427a6feb5b5fc1137eb05aa7ddd9c08ce9",
+      "name": "VEE",
+      "symbol": "VEE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15540/large/EMAX-Coin-Final2000x.png?1696515181"
+      "logoURI": "https://assets.coingecko.com/coins/images/52199/large/1000002075.png?1732732974"
     },
     {
       "chainId": 42161,
-      "address": "0x30dcba0405004cf124045793e1933c798af9e66a",
-      "name": "Yieldification",
-      "symbol": "YDF",
+      "address": "0xafe8107123eefd62469474dec9680860b890e5b6",
+      "name": "Oil Token",
+      "symbol": "OIL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26699/large/logo.png?1696525772"
+      "logoURI": "https://assets.coingecko.com/coins/images/39504/large/logo_oil_200%D1%85200.png?1722581566"
     },
     {
       "chainId": 42161,
-      "address": "0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee",
-      "name": "Aave v3 DAI",
-      "symbol": "ADAI",
+      "address": "0x346e74dc9935a9b02eb34fb84658a66010fa056d",
+      "name": "Zunami Governance Token",
+      "symbol": "ZUN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32886/large/dai.png?1699769446"
+      "logoURI": "https://assets.coingecko.com/coins/images/38298/large/ZUN_200x200.png?1717194404"
     },
     {
       "chainId": 42161,
-      "address": "0x17a8541b82bf67e10b0874284b4ae66858cb1fd5",
-      "name": "Possum",
-      "symbol": "PSM",
+      "address": "0x8cf7e3aa6faf6ae180e5ec3f0fb95081c2086ebe",
+      "name": "SX Network",
+      "symbol": "SX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33596/large/PSM.png?1702521046"
+      "logoURI": "https://assets.coingecko.com/coins/images/34934/large/sx-ntework.jpeg?1706699134"
     },
     {
       "chainId": 42161,
-      "address": "0xf80d589b3dbe130c270a69f1a69d050f268786df",
-      "name": "Datamine FLUX",
-      "symbol": "FLUX",
+      "address": "0x965d00aa7abc62ca10132e641d08593435ac811d",
+      "name": "KAP Games",
+      "symbol": "KAP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11756/large/fluxres.png?1696511637"
+      "logoURI": "https://assets.coingecko.com/coins/images/27682/large/KAP_Logo.png?1696526710"
     },
     {
       "chainId": 42161,
-      "address": "0xf7693c6fd9a7172d537fa75d133d309501cbd657",
-      "name": "Web3 No Value",
-      "symbol": "W3N",
+      "address": "0x249c48e22e95514ca975de31f473f30c2f3c0916",
+      "name": "USDFI",
+      "symbol": "USDFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32083/large/WechatIMG718.jpg?1710596218"
+      "logoURI": "https://assets.coingecko.com/coins/images/31149/large/USDFI_200.png?1696529977"
     },
     {
       "chainId": 42161,
-      "address": "0x07dd5beaffb65b8ff2e575d500bdf324a05295dc",
-      "name": "ArbiPad",
-      "symbol": "ARBI",
+      "address": "0x0002bcdaf53f4889bf2f43a3252d7c03fe1b80bc",
+      "name": "GorplesCoin",
+      "symbol": "GORPLES",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30275/large/ARBI_Logo.png?1696529181"
+      "logoURI": "https://assets.coingecko.com/coins/images/38681/large/Round_Avatar.png?1720520435"
     },
     {
       "chainId": 42161,
-      "address": "0x602eb0d99a5e3e76d1510372c4d2020e12eaea8a",
-      "name": "TridentDAO",
-      "symbol": "PSI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/28955/large/trident.jpg?1696527928"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6cc5b1fb8c2fd7af1d2858f916f274b8faac82e1",
-      "name": "Ojamu",
-      "symbol": "OJA",
+      "address": "0xecc68d0451e20292406967fe7c04280e5238ac7d",
+      "name": "Axelar Bridged Frax Ether",
+      "symbol": "AXLFRXETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18947/large/ojamu-icon-PNK.png?1696518402"
+      "logoURI": "https://assets.coingecko.com/coins/images/38976/large/Screen_Shot_2024-06-18_at_12.55.54_PM_2.png?1719714886"
     },
     {
       "chainId": 42161,
-      "address": "0x352f4bf396a7353a0877f99e99757e5d294df374",
-      "name": "Sundae the Dog",
-      "symbol": "SUNDAE",
+      "address": "0x7f4db37d7beb31f445307782bc3da0f18df13696",
+      "name": "Yield Yak",
+      "symbol": "YAK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32010/large/sundae.jpg?1696530808"
+      "logoURI": "https://assets.coingecko.com/coins/images/17654/large/yieldyak.png?1696517185"
     },
     {
       "chainId": 42161,
-      "address": "0x5a7a183b6b44dc4ec2e3d2ef43f98c5152b1d76d",
-      "name": "Inception Restaked ETH",
-      "symbol": "INETH",
+      "address": "0x498c620c7c91c6eba2e3cd5485383f41613b7eb6",
+      "name": "Alongside Crypto Market Index",
+      "symbol": "AMKT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34127/large/inETH.png?1715036464"
+      "logoURI": "https://assets.coingecko.com/coins/images/28496/large/22999.png?1696527488"
     },
     {
       "chainId": 42161,
-      "address": "0xd5954c3084a1ccd70b4da011e67760b8e78aee84",
-      "name": "Arbidex",
-      "symbol": "ARX",
+      "address": "0xa71e2738704e367798baa2755af5a10499634953",
+      "name": "Avarik Saga",
+      "symbol": "AVRK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29506/large/tokenlogo.png?1696528451"
+      "logoURI": "https://assets.coingecko.com/coins/images/51914/large/Logo500x500.png?1732258561"
     },
     {
       "chainId": 42161,
-      "address": "0x96a993f06951b01430523d0d5590192d650ebf3e",
-      "name": "Revenue Generating USD",
-      "symbol": "RGUSD",
+      "address": "0x1b01514a2b3cdef16fd3c680a818a0ab97da8a09",
+      "name": "Frax Price Index",
+      "symbol": "FPI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38146/large/rgusd%28200_x_200_px%29.png?1716654569"
+      "logoURI": "https://assets.coingecko.com/coins/images/24945/large/FPI_icon.png?1696524100"
     },
     {
       "chainId": 42161,
-      "address": "0x848e0ba28b637e8490d88bae51fa99c87116409b",
-      "name": "Agave",
-      "symbol": "AGVE",
+      "address": "0x4b019aaa21e98e212d31e54c843e73ff34d25717",
+      "name": "TUX Project",
+      "symbol": "TUXC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14146/large/agve.png?1696513865"
+      "logoURI": "https://assets.coingecko.com/coins/images/37537/large/tuxc.jpg?1714687219"
     },
     {
       "chainId": 42161,
-      "address": "0xf65247b6ed3e7fdbac313959b3f62475fbb5f8e4",
-      "name": "Brightpool Finance BRIX",
-      "symbol": "BRIX",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37446/large/IMAGE_2024-04-29_13_55_38.jpg?1714446963"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9ed7e4b1bff939ad473da5e7a218c771d1569456",
-      "name": "Reunit Wallet",
-      "symbol": "REUNI",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29492/large/reunit_200.png?1696528436"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9f41b34f42058a7b74672055a5fae22c4b113fd1",
-      "name": "Yum",
-      "symbol": "YUM",
+      "address": "0x3f56e0c36d275367b8c502090edf38289b3dea0d",
+      "name": "MAI  Arbitrum ",
+      "symbol": "MIMATIC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39116/large/yum.png?1720590184"
+      "logoURI": "https://assets.coingecko.com/coins/images/35517/large/mimatic-red.png?1709005586"
     },
     {
       "chainId": 42161,
-      "address": "0xb4bbfe92702730ef7f1d28e4b9e42381182f48a5",
-      "name": "Hold VIP",
-      "symbol": "HOLD",
+      "address": "0x6dbf2155b0636cb3fd5359fccefb8a2c02b6cb51",
+      "name": "Plutus RDNT",
+      "symbol": "PLSRDNT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30129/large/RteOSWQ__400x400.jpg?1696529050"
+      "logoURI": "https://assets.coingecko.com/coins/images/30635/large/plsRDNT.png?1696529508"
     },
     {
       "chainId": 42161,
-      "address": "0xc72633f995e98ac3bb8a89e6a9c4af335c3d6e44",
-      "name": "Omnisea",
-      "symbol": "OSEA",
+      "address": "0x80dd74145b8bb10cef01bf914f796bd8b54d7809",
+      "name": "Hepton",
+      "symbol": "HTE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26475/large/logo-06_%281%29.png?1728502928"
+      "logoURI": "https://assets.coingecko.com/coins/images/30274/large/HTECoingecko.png?1696529180"
     },
     {
       "chainId": 42161,
-      "address": "0x57f5e098cad7a3d1eed53991d4d66c45c9af7812",
-      "name": "Wrapped USDM",
-      "symbol": "WUSDM",
+      "address": "0x93c15cd7de26f07265f0272e0b831c5d7fab174f",
+      "name": "Liquid Finance",
+      "symbol": "LIQD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33785/large/wUSDM_PNG_240px.png?1702981552"
+      "logoURI": "https://assets.coingecko.com/coins/images/27056/large/liqd.png?1696526107"
     },
     {
       "chainId": 42161,
-      "address": "0x76bc2e765414e6c8b596c0f52c4240f80268f41d",
-      "name": "Unibit",
-      "symbol": "UIBT",
+      "address": "0x7f90122bf0700f9e7e1f688fe926940e8839f353",
+      "name": "Curve fi USDC USDT",
+      "symbol": "2CRV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36911/large/Unibit.png?1712764033"
+      "logoURI": "https://assets.coingecko.com/coins/images/28365/large/curve2.png?1696527368"
     },
     {
       "chainId": 42161,
-      "address": "0x3106e2e148525b3db36795b04691d444c24972fb",
-      "name": "Wrapped Staked LINK",
-      "symbol": "WSTLINK",
+      "address": "0xdc8b6b6beab4d5034ae91b7a1cf7d05a41f0d239",
+      "name": "Gemach",
+      "symbol": "GMAC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35678/large/wstlink_logo.png?1709525182"
+      "logoURI": "https://assets.coingecko.com/coins/images/32334/large/gmac-200x200.png?1697452788"
     },
     {
       "chainId": 42161,
-      "address": "0x004626a008b1acdc4c74ab51644093b155e59a23",
-      "name": "Angle Staked EURA",
-      "symbol": "STEUR",
+      "address": "0xdce765f021410b3266aa0053c93cb4535f1e12e0",
+      "name": "peg eUSD",
+      "symbol": "PEUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32036/large/stEUR-x4.png?1696530832"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xed7f000ee335b8199b004cca1c6f36d188cf6cb8",
-      "name": "D2 Finance",
-      "symbol": "D2",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34914/large/D2_Token_Logo.png?1706610408"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x51318b7d00db7acc4026c88c3952b66278b6a67f",
-      "name": "PlutusDAO",
-      "symbol": "PLS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25326/large/M6nUndNU_400x400.jpg?1696524461"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x5429706887fcb58a595677b73e9b0441c25d993d",
-      "name": "UniDex",
-      "symbol": "UNIDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13178/large/unidx.png?1696512961"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2c650dab03a59332e2e0c0c4a7f726913e5028c1",
-      "name": "Tapioca DAO Token",
-      "symbol": "TAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38756/large/TAPP.png?1718729124"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xddf7d080c82b8048baae54e376a3406572429b4e",
-      "name": "GODDOG",
-      "symbol": "OOOOOO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38157/large/Goddog_logo_for_Coingecko_200x200.png?1716669510"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8b5e4c9a188b1a187f2d1e80b1c2fb17fa2922e1",
-      "name": "GoldenBoys",
-      "symbol": "GOLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31353/large/goldenboys.png?1696530170"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4d22e37eb4d71d1acc5f4889a65936d2a44a2f15",
-      "name": "Hat",
-      "symbol": "HAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39394/large/Black_circle_%281%29.png?1721976884"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6688b00f0c23a4a546beaae51a7c90c439895d48",
-      "name": "Tarot V1",
-      "symbol": "TAROT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17881/large/tarot-200px.png?1696517403"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x47de40ec7aa115fbc1f7b99ca4effc46a113de9b",
-      "name": "ZAI Stablecoin",
-      "symbol": "USDZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39733/large/Group_4.png?1723771588"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4d01397994aa636bdcc65c9e8024bc497498c3bb",
-      "name": "Mchain Network",
-      "symbol": "MARK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37447/large/mchain.png?1714447037"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4568ca00299819998501914690d6010ae48a59ba",
-      "name": "Army of Fortune Metaverse",
-      "symbol": "AFC",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/32577/large/UI_Icon_Coin_Token_AFC_200x200.png?1698558434"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd7a892f28dedc74e6b7b33f93be08abfc394a360",
-      "name": "Crypto Index Pool",
-      "symbol": "CIP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32504/large/photo_6176746894382970935_y_%281%29.jpg?1698313185"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7cb16cb78ea464ad35c8a50abf95dff3c9e09d5d",
-      "name": "0xBitcoin",
-      "symbol": "0XBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/4454/large/0xbtc.png?1696505045"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1b8d516e2146d7a32aca0fcbf9482db85fd42c3a",
-      "name": "AlphaScan AI",
-      "symbol": "ASCN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31180/large/AlphaScan_logo.jpg?1696530008"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf8388c2b6edf00e2e27eef5200b1befb24ce141d",
-      "name": "Nola",
-      "symbol": "NOLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33708/large/nola.jpg?1702854587"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xef888bca6ab6b1d26dbec977c455388ecd794794",
-      "name": "Rari Governance",
-      "symbol": "RGT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12900/large/Rari_Logo_Transparent.png?1696512688"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf29fdf6b7bdffb025d7e6dfdf344992d2d16e249",
-      "name": "Genius X",
-      "symbol": "GENSX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/30904/large/GX_short_logo.png?1696529749"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe934ab7e98d81e39477b1e47b961876c2d902598",
-      "name": "Nola",
-      "symbol": "NOLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37420/large/NOLA.png?1714377065"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x66e535e8d2ebf13f49f3d49e5c50395a97c137b1",
-      "name": "Molten",
-      "symbol": "MOLTEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36726/large/moltenmesh.png?1712147407"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x59a729658e9245b0cf1f8cb9fb37945d2b06ea27",
-      "name": "GenomesDAO GENE",
-      "symbol": "GENE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20807/large/1637683704200x200.png?1696520200"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x21ccbc5e7f353ec43b2f5b1fb12c3e9d89d30dca",
-      "name": "BlackDragon",
-      "symbol": "BDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13426/large/Black-Dragon-Black.png?1696513186"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1824a51c106efc27d35a74efb56d9bf54ddb22d4",
-      "name": "Perpy Finance",
-      "symbol": "PRY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29525/large/perpy-icon-dark.png?1696528468"
+      "logoURI": "https://assets.coingecko.com/coins/images/31521/large/peUSD_200x200.png?1696530331"
     },
     {
       "chainId": 42161,
@@ -3956,6 +3044,150 @@
     },
     {
       "chainId": 42161,
+      "address": "0x8038f3c971414fd1fc220ba727f2d4a0fc98cb65",
+      "name": "dHEDGE DAO",
+      "symbol": "DHT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12508/large/dht.png?1696512323"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
+      "name": "BetSwirl",
+      "symbol": "BETS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26618/large/icon_200.png?1696525691"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa3210cd727fe6daf8386af5623ba51a367e46263",
+      "name": "Basket",
+      "symbol": "BSKT",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/34661/large/BSKT_Logo.png?1705636891"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9dca587dc65ac0a043828b0acd946d71eb8d46c1",
+      "name": "iFARM",
+      "symbol": "IFARM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14472/large/ifarm.png?1696514159"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x56659245931cb6920e39c189d2a0e7dd0da2d57b",
+      "name": "Impermax",
+      "symbol": "IBEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27606/large/IqwOmX-c_400x400.jpeg?1696526637"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x155f0dd04424939368972f4e1838687d6a831151",
+      "name": "ArbiDoge",
+      "symbol": "ADOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18333/large/Screen-Shot-2021-09-04-at-11-59-16-AM.png?1696517824"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee",
+      "name": "Aave v3 DAI",
+      "symbol": "ADAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32886/large/dai.png?1699769446"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbbea044f9e7c0520195e49ad1e561572e7e1b948",
+      "name": "Mizar",
+      "symbol": "MZR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23272/large/V1DTptkT_400x400.jpg?1696522492"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x999faf0af2ff109938eefe6a7bf91ca56f0d07e1",
+      "name": "Ledgity Token",
+      "symbol": "LDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35046/large/ldy-token.png?1707204910"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x54bdbf3ce36f451ec61493236b8e6213ac87c0f6",
+      "name": "Radpie",
+      "symbol": "RDP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34052/large/Radpie_token_3_2.png?1704672743"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xed5740209fcf6974d6f3a5f11e295b5e468ac27c",
+      "name": "KEWL EXCHANGE",
+      "symbol": "KWL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36883/large/yamuk.png?1712649510"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb9af4762c039d63e30039f1712dfab77026408c7",
+      "name": "BullBear AI",
+      "symbol": "AIBB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30096/large/ICON_200.png?1696529020"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x45940000009600102a1c002f0097c4a500fa00ab",
+      "name": "Hermes Protocol",
+      "symbol": "HERMES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24251/large/Transparent-13_%281%29_%281%29.png?1725188033"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb6212b633c941e9be168c4b9c2d9e785f1cd42fb",
+      "name": "Bitoro",
+      "symbol": "BTORO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50334/large/bitoro-logo-highres.jpg?1727306095"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe4421566a501045ae4285996577a36f6cf074190",
+      "name": "Ice",
+      "symbol": "ICE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35093/large/ICE_LOGO.jpg?1707363813"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1bd013bd089c2b6b2d30a0e0b545810a5844e761",
+      "name": "OtterHome",
+      "symbol": "HOME",
+      "decimals": 16,
+      "logoURI": "https://assets.coingecko.com/coins/images/30740/large/LOGO.png?1696529610"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2fac624899a844e0628bfdcc70efcd25f6e90b95",
+      "name": "Youwho",
+      "symbol": "YOU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25353/large/youwho_200.png?1696524487"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd44257dde89ca53f1471582f718632e690e46dc2",
+      "name": "S",
+      "symbol": "S",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50350/large/s.jpg?1727249471"
+    },
+    {
+      "chainId": 42161,
       "address": "0xd08c3f25862077056cb1b710937576af899a4959",
       "name": "Inception stETH",
       "symbol": "INSTETH",
@@ -3964,35 +3196,107 @@
     },
     {
       "chainId": 42161,
-      "address": "0xd3ac016b1b8c80eeadde4d186a9138c9324e4189",
-      "name": "Okcash",
-      "symbol": "OK",
+      "address": "0xccd05a0fcfc1380e9da27862adb2198e58e0d66f",
+      "name": "ANIMA",
+      "symbol": "ANIMA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/274/large/ok-logo-200px.png?1696501624"
+      "logoURI": "https://assets.coingecko.com/coins/images/30377/large/anima_logo_yellow.png?1696529271"
     },
     {
       "chainId": 42161,
-      "address": "0x8ec1877698acf262fe8ad8a295ad94d6ea258988",
-      "name": "Davos xyz USD",
-      "symbol": "DUSD",
+      "address": "0xa9011ee5796be43123651181dc75c0e72bb1191c",
+      "name": "NeuroPulse AI",
+      "symbol": "NPAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28775/large/dusd_logo_200x200.png?1696527754"
+      "logoURI": "https://assets.coingecko.com/coins/images/31848/large/NPAI.png?1700257725"
     },
     {
       "chainId": 42161,
-      "address": "0x6aa395f06986ea4efe0a4630c7865c1eb08d5e7e",
-      "name": "Jarvis Reward",
-      "symbol": "JRT",
+      "address": "0xd978f8489e1245568704407a479a71fcce2afe8f",
+      "name": "ApeSwap",
+      "symbol": "BANANA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10390/large/cfeii0y.png?1696510389"
+      "logoURI": "https://assets.coingecko.com/coins/images/14870/large/banana.png?1696514534"
     },
     {
       "chainId": 42161,
-      "address": "0x28514bd097d5f9ecea778cc7a4ca4bac5fedb0b6",
-      "name": "BOO",
-      "symbol": "BOO",
+      "address": "0xd3188e0df68559c0b63361f6160c57ad88b239d8",
+      "name": "Astra DAO",
+      "symbol": "ASTRADAO",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/32870/large/ASTRADAO.jpg?1699673097"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x07dd5beaffb65b8ff2e575d500bdf324a05295dc",
+      "name": "ArbiPad",
+      "symbol": "ARBI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34234/large/boo_coin_%28200%29.png?1704306085"
+      "logoURI": "https://assets.coingecko.com/coins/images/30275/large/ARBI_Logo.png?1696529181"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f5373ae26c3e8ffc4c77b7255df7ec1a9af52a6",
+      "name": "Bridged Tether  Axelar ",
+      "symbol": "AXLUSDT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31002/large/uusdt_D_3x.png?1696529840"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa2f9ecf83a48b86265ff5fd36cdbaaa1f349916c",
+      "name": "Goons of Balatroon",
+      "symbol": "GOB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27104/large/TokenLogo200x200.png?1702250134"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2c7941a0fe9c52223b229747322af16160161c98",
+      "name": "Jarvis",
+      "symbol": "JARVIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35812/large/jarvis.png?1709873633"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbcd4d5ac29e06e4973a1ddcd782cd035d04bc0b7",
+      "name": "Quick Intel",
+      "symbol": "QKNTL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29605/large/IMG_6589D0616DF1-1.jpeg?1696528542"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6612ce012ba5574a2ecea3a825c1ddf641f78623",
+      "name": "Dorado Finance",
+      "symbol": "DORAB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38347/large/Dorado_Logo.png?1717143752"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfd2fb8de10ec41ddd898a8c7fa70d8fc100834c4",
+      "name": "Bitci DOGE",
+      "symbol": "BOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38048/large/DOGE_TOKEN_200.png?1716401036"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x36295e7de7024362ad95bb8be93d6d6d21d7f6c1",
+      "name": "XGPU AI",
+      "symbol": "XGPU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37453/large/xgpu.png?1714448873"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe20b9e246db5a0d21bf9209e4858bc9a3ff7a034",
+      "name": "Wrapped Banano",
+      "symbol": "WBAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32617/large/WBAN.jpg?1698749253"
     },
     {
       "chainId": 42161,
@@ -4004,12 +3308,707 @@
     },
     {
       "chainId": 42161,
-      "address": "0xa2f9ecf83a48b86265ff5fd36cdbaaa1f349916c",
-      "name": "Goons of Balatroon",
-      "symbol": "GOB",
+      "address": "0x004626a008b1acdc4c74ab51644093b155e59a23",
+      "name": "Angle Staked EURA",
+      "symbol": "STEUR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27104/large/TokenLogo200x200.png?1702250134"
+      "logoURI": "https://assets.coingecko.com/coins/images/32036/large/stEUR-x4.png?1696530832"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x31c91d8fb96bff40955dd2dbc909b36e8b104dde",
+      "name": "Poison Finance",
+      "symbol": "POION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28630/large/poisonlogo160x160.png?1696527614"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd26b0c6ef8581e921ae41c66e508c62a581b709d",
+      "name": "Sexone",
+      "symbol": "SEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32135/large/IMG_20231004_163306_491.jpg?1696589011"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1d1498166ddceee616a6d99868e1e0677300056f",
+      "name": "Space Token",
+      "symbol": "SPACE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20676/large/jYw3kgsY_400x400.png?1696520076"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9cfb13e6c11054ac9fcb92ba89644f30775436e4",
+      "name": "Bridged Wrapped stETH  Axelar ",
+      "symbol": "AXL-WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32223/large/steth-wei_D_3x.png?1696926841"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x86f65121804d2cdbef79f9f072d4e0c2eebabc08",
+      "name": "Garden",
+      "symbol": "SEED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34671/large/icon.png?1705656915"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd8724322f44e5c58d7a815f542036fb17dbbf839",
+      "name": "Wrapped OETH",
+      "symbol": "WOETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29734/large/woeth-200x200.png?1714796686"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9d0c0675a995d5f12b03e880763f639d0628b5c6",
+      "name": "SuperWalk WALK",
+      "symbol": "WALK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37379/large/superwalk.jpeg?1714213441"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
+      "name": "Pickle Finance",
+      "symbol": "PICKLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12435/large/0M4W6Yr6_400x400.jpg?1696512255"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x284592a004d945f98de5b040808578c61a4bb39a",
+      "name": "AIR",
+      "symbol": "AIR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36113/large/Air_%28AIR%29_1.png?1710487829"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd1e094cabc5acb9d3b0599c3f76f2d01ff8d3563",
+      "name": "VirtuSwap",
+      "symbol": "VRSW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30629/large/VirtuSwap_Logo_Red_200x200.png?1696529502"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x039d2e8f097331278bd6c1415d839310e0d5ece4",
+      "name": "Linda",
+      "symbol": "LINDA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33699/large/linda-logo-200.png?1705166731"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfeb8b6813491bb4fb823b8f451b62ef535420d1",
+      "name": "Zunami USD",
+      "symbol": "ZUNUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37809/large/zunUSD_200x200.png?1715591997"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x83e60b9f7f4db5cdb0877659b1740e73c662c55b",
+      "name": "Pingu Exchange",
+      "symbol": "PINGU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34790/large/icon_primary.png?1706030846"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbc404429558292ee2d769e57d57d6e74bbd2792d",
+      "name": "Savings USX",
+      "symbol": "SUSX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39895/large/IMG_7024.png?1724724019"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbea0005b8599265d41256905a9b3073d397812e4",
+      "name": "Bean",
+      "symbol": "BEAN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18447/large/bean-logo-coingecko.png?1696517934"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x602eb0d99a5e3e76d1510372c4d2020e12eaea8a",
+      "name": "TridentDAO",
+      "symbol": "PSI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28955/large/trident.jpg?1696527928"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8bf591eae535f93a242d5a954d3cde648b48a5a8",
+      "name": "Sumer Money suUSD",
+      "symbol": "SUUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33266/large/Sumer_Money_Logo.jpg?1701321416"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x66e535e8d2ebf13f49f3d49e5c50395a97c137b1",
+      "name": "Molten",
+      "symbol": "MOLTEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36726/large/moltenmesh.png?1712147407"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x255f1b39172f65dc6406b8bee8b08155c45fe1b6",
+      "name": "HarambeCoin",
+      "symbol": "HARAMBE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36043/large/HarambeCoin_full_cameo_200.png?1710400612"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb01cf1be9568f09449382a47cd5bf58e2a9d5922",
+      "name": "Lightspeed",
+      "symbol": "SPEED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51401/large/lightspeed-round-200.png?1731085512"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x872bad41cfc8ba731f811fea8b2d0b9fd6369585",
+      "name": "BattleFly",
+      "symbol": "GFLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28828/large/GFLY_LOGO.png?1696527804"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xef888bca6ab6b1d26dbec977c455388ecd794794",
+      "name": "Rari Governance",
+      "symbol": "RGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12900/large/Rari_Logo_Transparent.png?1696512688"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7712da72127d5dd213b621497d6e4899d5989e5c",
+      "name": "Ryze",
+      "symbol": "RYZE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50814/large/Aryze_Pfp_For_Both.png?1729238552"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1310952bc5594852459ee45bfd0df70b34ac5509",
+      "name": "Parifi",
+      "symbol": "PRF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34710/large/parifi200x200.png?1705894380"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3106e2e148525b3db36795b04691d444c24972fb",
+      "name": "Wrapped Staked LINK",
+      "symbol": "WSTLINK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35678/large/wstlink_logo.png?1709525182"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8b5e4c9a188b1a187f2d1e80b1c2fb17fa2922e1",
+      "name": "GoldenBoys",
+      "symbol": "GOLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31353/large/goldenboys.png?1696530170"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5a7a183b6b44dc4ec2e3d2ef43f98c5152b1d76d",
+      "name": "Inception Restaked ETH",
+      "symbol": "INETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34127/large/inETH.png?1715036464"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6cc5b1fb8c2fd7af1d2858f916f274b8faac82e1",
+      "name": "Ojamu",
+      "symbol": "OJA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18947/large/ojamu-icon-PNK.png?1696518402"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3ed03e95dd894235090b3d4a49e0c3239edce59e",
+      "name": "Blox MYRC",
+      "symbol": "MYRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38632/large/myrc-token-trans-200x200.png?1718172187"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x16a500aec6c37f84447ef04e66c57cfc6254cf92",
+      "name": "Umoja",
+      "symbol": "UMJA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38328/large/Umoja_Logo.png?1717639928"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x488cc08935458403a0458e45e20c0159c8ab2c92",
+      "name": "Futureswap",
+      "symbol": "FST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14520/large/futureswap_logo.png?1696514206"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x80bb30d62a16e1f2084deae84dc293531c3ac3a1",
+      "name": "Granary",
+      "symbol": "GRAIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29740/large/Grain.png?1696528670"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x57f5e098cad7a3d1eed53991d4d66c45c9af7812",
+      "name": "Wrapped USDM",
+      "symbol": "WUSDM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33785/large/wUSDM_PNG_240px.png?1702981552"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xddf7d080c82b8048baae54e376a3406572429b4e",
+      "name": "GODDOG",
+      "symbol": "OOOOOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38157/large/Goddog_logo_for_Coingecko_200x200.png?1716669510"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6bcc14b02cd624ebe1a8a665cb6d4067aa097230",
+      "name": "Foxify",
+      "symbol": "FOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32354/large/Foxify_200x200.png?1697475371"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x352f4bf396a7353a0877f99e99757e5d294df374",
+      "name": "Sundae the Dog",
+      "symbol": "SUNDAE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32010/large/sundae.jpg?1696530808"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x76bc2e765414e6c8b596c0f52c4240f80268f41d",
+      "name": "Unibit",
+      "symbol": "UIBT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36911/large/Unibit.png?1712764033"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3419875b4d3bca7f3fdda2db7a476a79fd31b4fe",
+      "name": "DizzyHavoc",
+      "symbol": "DZHV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35575/large/dizzyhavoc_circle_3_200_200_transparentBg.png?1709194317"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x000d636bd52bfc1b3a699165ef5aa340bea8939c",
+      "name": "Open Dollar Governance",
+      "symbol": "ODG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34689/large/ODG_Token_200_x_200.png?1705853107"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9f41b34f42058a7b74672055a5fae22c4b113fd1",
+      "name": "Yum",
+      "symbol": "YUM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39116/large/yum.png?1720590184"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4727a7d2022e99ee5c298513b730307f458f9b40",
+      "name": "Guberto",
+      "symbol": "GUBERTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50787/large/guberto_%281%29.jpg?1729210166"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x96a993f06951b01430523d0d5590192d650ebf3e",
+      "name": "Revenue Generating USD",
+      "symbol": "RGUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38146/large/rgusd%28200_x_200_px%29.png?1716654569"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc19669a405067927865b40ea045a2baabbbe57f5",
+      "name": "Star",
+      "symbol": "STAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31277/large/coin-icon_Star-200x200.png?1732742256"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9b06f3c5de42d4623d7a2bd940ec735103c68a76",
+      "name": "Volta Club",
+      "symbol": "VOLTA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31602/large/volta-200x200.png?1696530418"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51707dc661630f8fd624b985fa6ef4f1d4d919db",
+      "name": "Unvest",
+      "symbol": "UNV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18119/large/UNV.jpg?1696517622"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6099f4cfeacb9be8d5c3435da0ba2853cd5188e4",
+      "name": "Aryze s Digital Gold",
+      "symbol": "EGOLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50815/large/eGOLD.png?1729238938"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x00000000ea00f3f4000e7ed5ed91965b19f1009b",
+      "name": "Maia",
+      "symbol": "MAIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22502/large/Transparent-04_%281%29_%281%29.png?1725187885"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd4848211b699503c772aa1bc7d33b433c4242ac3",
+      "name": "Equilibria Finance ePENDLE",
+      "symbol": "EPENDLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33379/large/photo_2023-12-02_19-45-14.jpg?1701665986"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf9ca0ec182a94f6231df9b14bd147ef7fb9fa17c",
+      "name": "BONER",
+      "symbol": "BONER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33968/large/unnamed.png?1703575844"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3b475f6f2f41853706afc9fa6a6b8c5df1a2724c",
+      "name": "Zyberswap",
+      "symbol": "ZYB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28943/large/logo_with_bg.png?1696527917"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8ec1877698acf262fe8ad8a295ad94d6ea258988",
+      "name": "Davos xyz USD",
+      "symbol": "DUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28775/large/dusd_logo_200x200.png?1696527754"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0a84edf70f30325151631ce7a61307d1f4d619a3",
+      "name": "BonzAI DePIN",
+      "symbol": "BONZAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36032/large/bonzai.jpeg?1710394145"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x949185d3be66775ea648f4a306740ea9eff9c567",
+      "name": "Yel Finance",
+      "symbol": "YEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17429/large/Logo200.png?1696516976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xed7f000ee335b8199b004cca1c6f36d188cf6cb8",
+      "name": "D2 Finance",
+      "symbol": "D2",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34914/large/D2_Token_Logo.png?1706610408"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0a3bb08b3a15a19b4de82f8acfc862606fb69a2d",
+      "name": "iZUMi Bond USD",
+      "symbol": "IUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25388/large/iusd-logo-symbol-10k%E5%A4%A7%E5%B0%8F.png?1696524521"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf18c263ec50cc211ef3f172228549b6618f10613",
+      "name": "Collab Land",
+      "symbol": "COLLAB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29098/large/collab.png?1696528061"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4cfa50b7ce747e2d61724fcac57f24b748ff2b2a",
+      "name": "Fluid USDC",
+      "symbol": "FUSDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28471/large/fUSDC-200x200.png?1696527465"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x848e0ba28b637e8490d88bae51fa99c87116409b",
+      "name": "Agave",
+      "symbol": "AGVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14146/large/agve.png?1696513865"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x33c88d4cac6ac34f77020915a2a88cd0417dc069",
+      "name": "Autonomous Secure Dollar",
+      "symbol": "USSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39227/large/Avatar_1.png?1721189801"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e0da40b9063dc48364c1c0ffb4ae9d091fc2270",
+      "name": "Edgeware",
+      "symbol": "EDG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8452/large/logo-edgeware.png?1696508638"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x32eb7902d4134bf98a28b963d26de779af92a212",
+      "name": "Dopex Rebate",
+      "symbol": "RDPX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16659/large/rDPX_200x200_Coingecko.png?1696516221"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51fc0f6660482ea73330e414efd7808811a57fa2",
+      "name": "Premia",
+      "symbol": "PREMIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13962/large/apple-touch-icon.png?1696513698"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x079504b86d38119f859c4194765029f692b7b7aa",
+      "name": "Lyra Finance",
+      "symbol": "LYRA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21490/large/Add-a-heading-26.png?1696520850"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfb9fbcb328317123f5275cda30b6589d5841216b",
+      "name": "Antfarm Token",
+      "symbol": "ATF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28821/large/ATF.png?1696527797"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6f5401c53e2769c858665621d22ddbf53d8d27c5",
+      "name": "Connect Financial",
+      "symbol": "CNFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13592/large/cf-logo-iconic-black.png?1696513344"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4d22e37eb4d71d1acc5f4889a65936d2a44a2f15",
+      "name": "Hat",
+      "symbol": "HAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39394/large/Black_circle_%281%29.png?1721976884"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1824a51c106efc27d35a74efb56d9bf54ddb22d4",
+      "name": "Perpy Finance",
+      "symbol": "PRY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29525/large/perpy-icon-dark.png?1696528468"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf8388c2b6edf00e2e27eef5200b1befb24ce141d",
+      "name": "Nola",
+      "symbol": "NOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33708/large/nola.jpg?1702854587"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x17a8541b82bf67e10b0874284b4ae66858cb1fd5",
+      "name": "Possum",
+      "symbol": "PSM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33596/large/PSM.png?1702521046"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9ed7e4b1bff939ad473da5e7a218c771d1569456",
+      "name": "Reunit Wallet",
+      "symbol": "REUNI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29492/large/reunit_200.png?1696528436"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x939727d85d99d0ac339bf1b76dfe30ca27c19067",
+      "name": "SIZE",
+      "symbol": "SIZE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34084/large/adadad.jpg?1703910572"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd3ac016b1b8c80eeadde4d186a9138c9324e4189",
+      "name": "Okcash",
+      "symbol": "OK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/274/large/ok-logo-200px.png?1696501624"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x02150e97271fdc0d6e3a16d9094a0948266f07dd",
+      "name": "Hamachi Finance",
+      "symbol": "HAMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28783/large/icon.png?1696527762"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf29fdf6b7bdffb025d7e6dfdf344992d2d16e249",
+      "name": "Genius X",
+      "symbol": "GENSX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/30904/large/GX_short_logo.png?1696529749"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc72633f995e98ac3bb8a89e6a9c4af335c3d6e44",
+      "name": "Omnisea",
+      "symbol": "OSEA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26475/large/logo-06_%281%29.png?1728502928"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xecf2adaff1de8a512f6e8bfe67a2c836edb25da3",
+      "name": "Wonderful Memories",
+      "symbol": "WMEMO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22392/large/wMEMO.png?1696521735"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x666966ef3925b1c92fa355fda9722899f3e73451",
+      "name": "Stable",
+      "symbol": "STABLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31148/large/stable_200.png?1696529976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xed3fb761414da74b74f33e5c5a1f78104b188dfc",
+      "name": "ArbiNYAN",
+      "symbol": "NYAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18309/large/Qmf8DSV4RbSuVRLJvmj4WwEMjwtYcCd53EFXPPjkEwzx4B.png?1696517801"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x763a716dd74a79d037e57f993fe3047271879bc1",
+      "name": "QODA",
+      "symbol": "QODA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38563/large/LogoMark.png?1718003510"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4d15a3a2286d883af0aa1b3f21367843fac63e07",
+      "name": "Bridged TrueUSD",
+      "symbol": "TUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30837/large/tusd.jpeg?1696529695"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf42e2b8bc2af8b110b65be98db1321b1ab8d44f5",
+      "name": "Donut",
+      "symbol": "DONUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7538/large/Donut.png?1696507804"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x21ccbc5e7f353ec43b2f5b1fb12c3e9d89d30dca",
+      "name": "BlackDragon",
+      "symbol": "BDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13426/large/Black-Dragon-Black.png?1696513186"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35ca1e5a9b1c09fa542fa18d1ba4d61c8edff852",
+      "name": "Schrodi",
+      "symbol": "SCHRODI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36255/large/apzs3q26_200x200.jpg?1710927534"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x67c31056358b8977ea95a3a899dd380d4bced706",
+      "name": "ETHforestAI",
+      "symbol": "ETHFAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29515/large/ethfai_logo.png?1696528459"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1aae7de64d9ae1487e95858bbf98185f21e926fd",
+      "name": "AICORE",
+      "symbol": "AICORE",
+      "decimals": 18
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf19547f9ed24aa66b03c3a552d181ae334fbb8db",
+      "name": "Lodestar",
+      "symbol": "LODE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28218/large/Lodestar_PFP_350x350px.jpg?1696527220"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x26d3c0d9f4cc4c130097b6afdebe4f5e497e6bdf",
+      "name": "Mynth",
+      "symbol": "MNT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/50513/large/mynth-token.png?1728031157"
     }
   ],
-  "timestamp": "2024-12-06T16:15:00.121Z"
+  "timestamp": "2024-12-10T17:05:15.280Z"
 }

--- a/src/public/CoinGecko.42161.json
+++ b/src/public/CoinGecko.42161.json
@@ -1,0 +1,4015 @@
+{
+  "name": "Coingecko top 500 on arbitrum-one",
+  "logoURI": "https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png",
+  "keywords": [
+    "defi"
+  ],
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 42161,
+      "address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+      "name": "USDC",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/6319/thumb/usdc.png?1696506694"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x25d887ce7a35172c62febfd67a1856f20faebb00",
+      "name": "Pepe",
+      "symbol": "PEPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29850/thumb/pepe-token.jpeg?1696528776"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
+      "name": "Chainlink",
+      "symbol": "LINK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/877/thumb/chainlink-new-logo.png?1696502009"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
+      "name": "Curve DAO",
+      "symbol": "CRV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12124/thumb/Curve.png?1696511967"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0",
+      "name": "Uniswap",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12504/thumb/uniswap-logo.png?1720676669"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+      "name": "Arbitrum Bridged WETH  Arbitrum One ",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39713/thumb/WETH.PNG?1723731496"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+      "name": "Arbitrum",
+      "symbol": "ARB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16547/thumb/arb.jpg?1721358242"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xba5ddd1f9d7f570dc94a51479a000e3bce967196",
+      "name": "Aave",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/aave-token-round.png?1720472354"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "name": "LayerZero",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/thumb/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x09199d9a5f4448d0848e4395d065e1ad9c4a1f74",
+      "name": "Bonk",
+      "symbol": "BONK",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28600/thumb/bonk.jpg?1696527587"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+      "name": "Coinbase Wrapped BTC",
+      "symbol": "CBBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/thumb/cbbtc.webp?1726136727"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x289ba1701c2f088cf0faf8b3705246331cb8a839",
+      "name": "Livepeer",
+      "symbol": "LPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/badge-logo-circuit-green.png?1719357686"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+      "name": "Arbitrum Bridged USDT  Arbitrum ",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35073/thumb/logo.png?1707292836"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7189fb5b6504bbff6a852b13b7b82a3c118fdc27",
+      "name": "Ether fi",
+      "symbol": "ETHFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35958/thumb/etherfi.jpeg?1710254562"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60",
+      "name": "Lido DAO",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1696513326"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9623063377ad1b27544c965ccd7342f7ea7e88c7",
+      "name": "The Graph",
+      "symbol": "GRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1696513159"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xca5ca9083702c56b481d1eec86f1776fdbd2e594",
+      "name": "Reserve Rights",
+      "symbol": "RSR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8365/thumb/RSR_Blue_Circle_1000.png?1721777856"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb0ffa8000886e57f86dd5264b9582b2ad87b2b91",
+      "name": "Wormhole",
+      "symbol": "W",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35087/thumb/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1b896893dfc86bb67cf57767298b9073d2c1ba2c",
+      "name": "PancakeSwap",
+      "symbol": "CAKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12632/thumb/pancakeswap-cake-logo_%281%29.png?1696512440"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x354a6da3fcde098f8389cad84b0182725c6c91de",
+      "name": "Compound",
+      "symbol": "COMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10775/thumb/COMP.png?1696510737"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+      "name": "Arbitrum Bridged WBTC  Arbitrum One ",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39532/thumb/wbtc.png?1722810336"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0c880f6761f1af8d9aa9c466984b80dab9a8c9e8",
+      "name": "Pendle",
+      "symbol": "PENDLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15069/thumb/Pendle_Logo_Normal-03.png?1696514728"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x53691596d1bce8cea565b84d4915e69e03d9c99d",
+      "name": "Across Protocol",
+      "symbol": "ACX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/thumb/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
+      "name": "Sushi",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1696512101"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaeaeed23478c3a4b798e4ed40d8b7f41366ae861",
+      "name": "Ankr Network",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1696504928"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x82e3a8f066a6989666b031d916c43672085b1582",
+      "name": "yearn finance",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yearn.jpg?1696511720"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd58d345fd9c82262e087d2d0607624b410d88242",
+      "name": "Tellor Tributes",
+      "symbol": "TRB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1696509713"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+      "name": "Wrapped stETH",
+      "symbol": "WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18834/thumb/wstETH.png?1696518295"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4cb9a7ae498cedcbb5eae9f25736ae7d428c9d66",
+      "name": "Xai",
+      "symbol": "XAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34258/thumb/round_icon_2048_px.png?1719523838"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x46d0ce7de6247b0a95f67b43b589b4041bae7fbe",
+      "name": "Loopring",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/913/thumb/LRC.png?1696502034"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1a6b3a62391eccaaa992ade44cd4afe6bec8cff1",
+      "name": "UXLINK",
+      "symbol": "UXLINK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39229/thumb/uxlink.jpg?1721201390"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9f07f8a82cb1af1466252e505b7b7ddee103bc91",
+      "name": "Degen  Base ",
+      "symbol": "DEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34515/thumb/android-chrome-512x512.png?1706198225"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+      "name": "Arbitrum Bridged USDC  Arbitrum ",
+      "symbol": "USDCE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/30691/thumb/usdc.png?1696529560"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc87b37a581ec3257b734886d9d3a581f5a9d056c",
+      "name": "Aethir",
+      "symbol": "ATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36179/thumb/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcafcd85d8ca7ad1e1c6f82f651fa15e33aefd07b",
+      "name": "WOO",
+      "symbol": "WOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7",
+      "name": "Frax Share",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/Frax_Shares_icon.png?1696513183"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6694340fc020c5e6b96567843da2df01b2ce1eb6",
+      "name": "Stargate Finance",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1696523595"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfb9e5d956d889d91a82737b9bfcdac1dce3e1449",
+      "name": "Liquity",
+      "symbol": "LQTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/logo_V2.png?1725437146"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x539bde0d7dbd336b79148aa742883198bbf60342",
+      "name": "Treasure",
+      "symbol": "MAGIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18623/thumb/magic.png?1696518095"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+      "name": "CARV",
+      "symbol": "CARV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/thumb/CARV_%281%29.png?1728418485"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
+      "name": "GMX",
+      "symbol": "GMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18323/thumb/arbit.png?1696517814"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x23ee2343b892b1bb63503a4fabc840e0e2c6810f",
+      "name": "Axelar",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/thumb/V-65_xQ1_400x400.jpeg?1696526329"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x61a1ff55c5216b636a294a07d77c6f4df10d3b56",
+      "name": "ApeX",
+      "symbol": "APEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25266/thumb/CxpMECpk_400x400_%281%29.png?1696524406"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xda0a57b710768ae17941a9fa33f8b720c8bd9ddd",
+      "name": "Marlin",
+      "symbol": "POND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/200x200.png?1706115827"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04",
+      "name": "CoW Protocol",
+      "symbol": "COW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/thumb/CoW-token_logo.png?1719524382"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3082cc23568ea640225c2467653db90e9250aaa0",
+      "name": "Radiant Capital",
+      "symbol": "RDNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26536/thumb/Radiant-Logo-200x200.png?1696525610"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35751007a407ca6feffe80b3cb397736d2cf4dbe",
+      "name": "Wrapped eETH",
+      "symbol": "WEETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33033/thumb/weETH.png?1701438396"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x753d224bcf9aafacd81558c32341416df61d3dac",
+      "name": "Perpetual Protocol",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3e6648c5a70a150a88bce65f4ad4d506fe15d2af",
+      "name": "Spell",
+      "symbol": "SPELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1696515477"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa68ec98d7ca870cf1dd0b00ebbb7c4bf60a8e74d",
+      "name": "Biconomy",
+      "symbol": "BICO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1696520444"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfa641051ba0a0ad1b0acf549a89536a0d76472e",
+      "name": "Badger",
+      "symbol": "BADGER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1696513059"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x69eb4fa4a2fbd498c257c57ea8b7655a2559a581",
+      "name": "DODO",
+      "symbol": "DODO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12651/thumb/dodo_logo.png?1696512458"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3a8b787f78d775aecfeea15706d4221b40f345ab",
+      "name": "Celer Network",
+      "symbol": "CELR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1696504978"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe4dddfe67e7164b0fe14e218d80dc4c08edc01cb",
+      "name": "Kyber Network Crystal",
+      "symbol": "KNC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14899/thumb/RwdVsGcw_400x400.jpg?1696514562"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x371c7ec6d8039ff7933a2aa28eb827ffe1f52f07",
+      "name": "JOE",
+      "symbol": "JOE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17569/thumb/LFJ_JOE_Logo.png?1727200941"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xda661fa59320b808c5a6d23579fcfedf1fd3cf36",
+      "name": "Mobox",
+      "symbol": "MBOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14751/thumb/mobox.PNG?1696514420"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x319f865b287fcc10b30d8ce6144e8b6d1b476999",
+      "name": "Cartesi",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/Cartesi_Logo.png?1696510982"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e200fe2f3efb977d5fd9c430a41531fb04d97b8",
+      "name": "Orderly Network",
+      "symbol": "ORDER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38501/thumb/Orderly_Network_Coingecko_200*200.png?1717751359"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40",
+      "name": "tBTC",
+      "symbol": "TBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+      "name": "Balancer",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1696511572"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x080f6aed32fc474dd5717105dba5ea57268f46eb",
+      "name": "Synapse",
+      "symbol": "SYN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/synapse_social_icon.png?1696517540"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb766039cc6db368759c1e56b79affe831d0cc507",
+      "name": "Rocket Pool",
+      "symbol": "RPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2090/thumb/rocket_pool_%28RPL%29.png?1696503058"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x17fc002b466eec40dae837fc4be5c67993ddbd6f",
+      "name": "Frax",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/FRAX_icon.png?1696513182"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x09e18590e8f76b6cf471b3cd75fe1a1a9d2b2c2b",
+      "name": "ArbDoge AI",
+      "symbol": "AIDOGE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29852/thumb/photo_2023-04-18_14-25-28.jpg?1696528778"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf3c091ed43de9c270593445163a41a876a0bb3dd",
+      "name": "Orbs",
+      "symbol": "ORBS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4630/thumb/Orbs.jpg?1696505200"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc1eb7689147c81ac840d4ff0d298489fc7986d52",
+      "name": "Venus",
+      "symbol": "XVS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12677/thumb/XVS_Token.jpg?1727454303"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa0b862f60edef4452f25b4160f177db44deb6cf1",
+      "name": "Gnosis",
+      "symbol": "GNO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/662/thumb/logo_square_simple_300px.png?1696501854"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
+      "name": "Axelar Bridged USDC",
+      "symbol": "AXLUSDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26476/thumb/uausdc_D_3x.png?1696525548"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x498bf2b1e120fed3ad3d42ea2165e9b73f99c1e5",
+      "name": "crvUSD",
+      "symbol": "CRVUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/thumb/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35f1c5cb7fb977e669fd244c567da99d8a3a6850",
+      "name": "Usual USD",
+      "symbol": "USD0",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38272/thumb/USD0LOGO.png?1716962811"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1debd73e752beaf79865fd6446b0c970eae7732f",
+      "name": "Coinbase Wrapped Staked ETH",
+      "symbol": "CBETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/thumb/cbeth.png?1709186989"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/thumb/Ezeth_logo_circle.png?1713496404"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8f5c1a99b1df736ad685006cb6adca7b7ae4b514",
+      "name": "Enzyme",
+      "symbol": "MLN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/Enzyme_Icon_Secondary.png?1696501803"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
+      "name": "Telos",
+      "symbol": "TLOS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7588/thumb/tlos_png.png?1722391289"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x18c11fd286c5ec11c3b683caa813b77f5163a122",
+      "name": "Gains Network",
+      "symbol": "GNS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19737/thumb/logo.png?1696519161"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+      "name": "MakerDAO Arbitrum Bridged DAI  Arbitrum",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39790/thumb/dai.png?1724111653"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3b60ff35d3f7f62d636b067dd0dc0dfdad670e4e",
+      "name": "Milady Meme Coin",
+      "symbol": "LADYS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30194/thumb/LADYS_Clean.png?1725897475"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35e050d3c0ec2d29d269a8ecea763a183bdf9a9d",
+      "name": "Ondo US Dollar Yield",
+      "symbol": "USDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31700/thumb/usdy_%281%29.png?1696530524"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcaa38bcc8fb3077975bbe217acfaa449e6596a84",
+      "name": "DAO Maker",
+      "symbol": "DAO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13915/thumb/4.jpg?1727532864"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8",
+      "name": "Rocket Pool ETH",
+      "symbol": "RETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20764/thumb/reth.png?1696520159"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0d81e50bc677fa67341c44d7eaa9228dee64a4e1",
+      "name": "BarnBridge",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1696512604"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
+      "name": "Pocket Network",
+      "symbol": "POKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22506/thumb/POKT.jpg?1703257310"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7e7a7c916c19a45769f6bdaf91087f93c6c12f78",
+      "name": "Eigenpie",
+      "symbol": "EGP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37810/thumb/eigenpie.jpeg?1715597613"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf4d48ce3ee1ac3651998971541badbb9a14d7234",
+      "name": "Cream",
+      "symbol": "CREAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11976/thumb/Cream.png?1696511834"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3647c54c4c2c65bc7a2d63c0da2809b399dbbdc0",
+      "name": "Solv Protocol SolvBTC",
+      "symbol": "SOLVBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36800/thumb/solvBTC.png?1719810684"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
+      "name": "World Mobile Token",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/thumb/1000097112.png?1727698144"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x772598e9e62155d7fdfe65fdf01eb5a53a8465be",
+      "name": "Empyreal",
+      "symbol": "EMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31374/thumb/logomainblacktransparent.png?1719953450"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
+      "name": "Port3 Network",
+      "symbol": "PORT3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33383/thumb/port3-bc-200x200.png?1710075114"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdadeca1167fe47499e53eb50f261103630974905",
+      "name": "Neuron",
+      "symbol": "NRN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38838/thumb/Nrn_with_gradient_-NEW_TO_BE_UPDATED.png?1728551601"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+      "name": "Bridged USDe",
+      "symbol": "USDE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39962/thumb/usde.png?1724952425"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/thumb/9.png?1727331352"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa23e44aea714fbbc08ef28340d78067b9a8cad73",
+      "name": "Lybra",
+      "symbol": "LBR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29958/thumb/New_LBR_V2.png?1696528884"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6a9896837021ea3ed83f623f655c119c54abe02c",
+      "name": "ChainBounty",
+      "symbol": "BOUNTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3369/thumb/Chainbounty_logomark_256px.png?1731462528"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6a7661795c374c0bfc635934efaddff3a7ee23b6",
+      "name": "DOLA",
+      "symbol": "DOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/thumb/dola.png?1696513984"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
+      "name": "Ignition FBTC",
+      "symbol": "FBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39182/thumb/FBTC_LOGO.png?1720850455"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x386601d1e55c48e759bbf57c56015aad0d7f1b56",
+      "name": "Worldwide USD",
+      "symbol": "WUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/thumb/WUSD%282%29.png?1715042139"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xae6aab43c4f3e0cea4ab83752c278f8debaba689",
+      "name": "dForce",
+      "symbol": "DF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9709/thumb/xlGxxIjI_400x400.jpg?1696509776"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5575552988a3a80504bbaeb1311674fcfd40ad4b",
+      "name": "Sperax",
+      "symbol": "SPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12232/thumb/sperax_logo.jpg?1696512065"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbc011a12da28e8f0f528d9ee5e7039e22f91cf18",
+      "name": "Swell Ethereum",
+      "symbol": "SWETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30326/thumb/_lB7zEtS_400x400.jpg?1696529227"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2b65f9d2e4b84a2df6ff0525741b75d1276a9c2f",
+      "name": "Staked USD0",
+      "symbol": "USD0++",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39169/thumb/0x35d8949372d46b7a3d5a56006ae77b215fc69bc0.png?1720798057"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x560363bda52bc6a44ca6c8c9b4a5fadbda32fa60",
+      "name": "Seedify fund",
+      "symbol": "SFUND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14614/thumb/Favicon_Icon.png?1696514292"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x221c5799209132766a01c4cbed0d28600d282b41",
+      "name": "Bitrium",
+      "symbol": "BTRM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39118/thumb/20240709-160716.png?1720593799"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3088e120b220e67a2e092f5da8cdf02ea0170f6a",
+      "name": "Finanx AI",
+      "symbol": "FNXAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51119/thumb/200x200.png?1730126766"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x680447595e8b7b3aa1b43beb9f6098c79ac2ab3f",
+      "name": "USDD",
+      "symbol": "USDD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25380/thumb/UUSD.jpg?1696524513"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x178412e79c25968a32e89b11f63b33f733770c2a",
+      "name": "Frax Ether",
+      "symbol": "FRXETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28284/thumb/frxETH_icon.png?1696527284"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7dff72693f6a4149b17e7c6314655f6a9f7c8b33",
+      "name": "GHO",
+      "symbol": "GHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30663/thumb/gho-token-logo.png?1720517092"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0c5fa0e07949f941a6c2c29a008252db1527d6ee",
+      "name": "Opulous",
+      "symbol": "OPUL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16548/thumb/opulous.PNG?1696516110"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb0ecc6ac0073c063dcfc026ccdc9039cae2998e1",
+      "name": "A3S",
+      "symbol": "AA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32133/thumb/A3S.jpg?1696588511"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x95146881b86b3ee99e63705ec87afe29fcc044d9",
+      "name": "Vertex",
+      "symbol": "VRTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27927/thumb/vrtx.png?1696526947"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x99f40b01ba9c469193b360f72740e416b17ac332",
+      "name": "MATH",
+      "symbol": "MATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1696511257"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xabd587f2607542723b17f14d00d99b987c29b074",
+      "name": "SmarDex",
+      "symbol": "SDEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29470/thumb/SDEX_logo_transparent_outside_240x240.png?1696930070"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x59062301fb510f4ea2417b67404cb16d31e604ba",
+      "name": "LogX Network",
+      "symbol": "LOGX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50226/thumb/Token_200px.png?1726556358"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8",
+      "name": "Everclear",
+      "symbol": "NEXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31293/thumb/photo_2024-06-03_12-14-59.png?1717638614"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4425742f1ec8d98779690b5a3a6276db85ddc01a",
+      "name": "Own The Doge",
+      "symbol": "DOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18111/thumb/Doge.png?1696517615"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x93b346b6bc2548da6a1e7d98e9a421b42541425b",
+      "name": "Liquity USD",
+      "symbol": "LUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1696514341"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2172fad929e857ddfd7ddc31e24904438434cb0b",
+      "name": "Babypie Wrapped BTC",
+      "symbol": "MBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/50314/thumb/mbtc_%281%29.png?1727079604"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x80137510979822322193fc997d400d5a6c747bf7",
+      "name": "StakeStone ETH",
+      "symbol": "STONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33103/thumb/200_200.png?1702602672"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+      "name": "Mountain Protocol USD",
+      "symbol": "USDM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31719/thumb/usdm.png?1696530540"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9dce8e754913d928eb39bc4fc3cf047e364f7f2c",
+      "name": "Bloktopia",
+      "symbol": "BLOK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18819/thumb/logo-bholdus-6.png?1696518281"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8b0e6f19ee57089f7649a455d89d7bc6314d04e8",
+      "name": "Dream Machine Token",
+      "symbol": "DMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30505/thumb/dmt.png?1696529391"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf525e73bdeb4ac1b0e741af3ed8a8cbb43ab0756",
+      "name": "KiboShib",
+      "symbol": "KIBSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29335/thumb/foto_no_exif_%2811%29%282%29_%281%29.png?1696528285"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x12275dcb9048680c4be40942ea4d92c74c63b844",
+      "name": "Electronic USD",
+      "symbol": "EUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28445/thumb/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd74f5255d557944cf7dd0e45ff521520002d5748",
+      "name": "Sperax USD",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21973/thumb/USDs_logo_1000X1000.png?1696521321"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3d9907f9a368ad0a51be60f7da3b97cf940982d8",
+      "name": "Camelot Token",
+      "symbol": "GRAIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28416/thumb/vj5DIMhP_400x400.jpeg?1696527414"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x06e90a57d1ece8752d6ce92d1ad348ead5eae4f4",
+      "name": "Real Smurf Cat",
+      "symbol": "SMURFCAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31751/thumb/SMURFCAT.png?1708079642"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd56734d7f9979dd94fae3d67c7e928234e71cd4c",
+      "name": "Bridged TIA  Hyperlane ",
+      "symbol": "TIAN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/33199/thumb/tia.n.png?1701047832"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x346c574c56e1a4aaa8dc88cda8f7eb12b39947ab",
+      "name": "Solv Protocol SolvBTC BBN",
+      "symbol": "SOLVBTCBBN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39384/thumb/unnamed.png?1721961640"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe22c452bd2ade15dfc8ad98286bc6bdf0c9219b7",
+      "name": "Polytrade",
+      "symbol": "TRADE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16416/thumb/Logo_colored_200.png?1696516012"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x94fcd9c18f99538c0f7c61c5500ca79f0d5c4dab",
+      "name": "Kima Network",
+      "symbol": "KIMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50764/thumb/K-logo-01.png?1729053099"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
+      "name": "PAW",
+      "symbol": "PAW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28946/thumb/PawLogo.png?1699394612"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x580e933d90091b9ce380740e3a4a39c67eb85b4c",
+      "name": "GameSwift",
+      "symbol": "GSWIFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30949/thumb/GameSwift_Token.png?1696529788"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3124678d62d2aa1f615b54525310fbfda6dcf7ae",
+      "name": "Sensay",
+      "symbol": "SNSY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36121/thumb/sensay.jpeg?1710495398"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6b021b3f68491974be6d4009fee61a4e3c708fd6",
+      "name": "Fuse",
+      "symbol": "FUSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/thumb/fuse.png?1696510348"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11bf4f05eb28b802ed3ab672594decb20ffe2313",
+      "name": "Aurory",
+      "symbol": "AURY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19324/thumb/Ico_Blanc_%281%29.png?1713464485"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe80772eaf6e2e18b651f160bc9158b2a5cafca65",
+      "name": "Overnight fi USD   Arbitrum One ",
+      "symbol": "USD+",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39630/thumb/usd_plus.png?1723181710"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x88a269df8fe7f53e590c561954c52fccc8ec0cfb",
+      "name": "Ninja Squad Token",
+      "symbol": "NST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22248/thumb/nst-logo-200x200.png?1711559985"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9e758b8a98a42d612b3d38b66a22074dc03d7370",
+      "name": "Symbiosis",
+      "symbol": "SIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20805/thumb/SymbiosisFinance_logo-150x150.jpeg?1696520198"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x95ab45875cffdba1e5f451b950bc2e42c0053f39",
+      "name": "Staked Frax Ether",
+      "symbol": "SFRXETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28285/thumb/sfrxETH_icon.png?1696527285"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1c43d05be7e5b54d506e3ddb6f0305e8a66cd04e",
+      "name": "ZTX",
+      "symbol": "ZTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32340/thumb/CoinGecko_200_x_200.jpg?1697466589"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x93fa0b88c0c78e45980fa74cdd87469311b7b3e4",
+      "name": "XBorg",
+      "symbol": "XBG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39830/thumb/XBorg_Logo.png?1724209192"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd77b108d4f6cefaa0cae9506a934e825becca46e",
+      "name": "WINR Protocol",
+      "symbol": "WINR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29340/thumb/WINR.png?1696528290"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca",
+      "name": "Kujira",
+      "symbol": "KUJI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20685/thumb/kuji-200x200.png?1696520085"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf0cb2dc0db5e6c66b9a70ac27b06b878da017028",
+      "name": "Olympus",
+      "symbol": "OHM",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/14483/thumb/token_OHM_%281%29.png?1696514169"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7be5dd337cc6ce3e474f64e2a92a566445290864",
+      "name": "OpenLeverage",
+      "symbol": "OLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26098/thumb/256x256_OLE_Token_Logo.png?1696525189"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf929de51d91c77e42f5090069e0ad7a09e513c73",
+      "name": "ShapeShift FOX",
+      "symbol": "FOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/fox_token.png?1728373561"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa5312c3e42a82d459162b2a3bd7ffc4f9099b911",
+      "name": "GALAXIS Token",
+      "symbol": "GALAXIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36221/thumb/500x500.png?1714755244"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x00cbcf7b3d37844e44b888bc747bdd75fcf4e555",
+      "name": "xPet tech",
+      "symbol": "XPET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33553/thumb/xpet_token.jpeg?1702428894"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb08d8becab1bf76a9ce3d2d5fa946f65ec1d3e83",
+      "name": "GammaSwap",
+      "symbol": "GS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29222/thumb/newLogo2.png?1731702645"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x046029f68b0e00ebec2e394d17f70ec848fcf1d2",
+      "name": "Stable com USD3",
+      "symbol": "USD3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39865/thumb/2024-04-stable_com-usd3_coin.png?1724379520"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x619c82392cb6e41778b7d088860fea8447941f4c",
+      "name": "Army of Fortune Gem",
+      "symbol": "AFG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35084/thumb/Token_GEM_AOFVERSE.png?1707317138"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe10d4a4255d2d35c9e23e2c4790e073046fbaf5c",
+      "name": "LandX Governance Token",
+      "symbol": "LNDX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/33565/thumb/LNDX-200.png?1702445947"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3b58a4c865b568a2f6a957c264f6b50cba35d8ce",
+      "name": "SuperWalk GRND",
+      "symbol": "GRND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27186/thumb/GRND_3x.png?1696526235"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc760f9782f8cea5b06d862574464729537159966",
+      "name": "Contango",
+      "symbol": "TANGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50721/thumb/400x400_-_Tango_%281%29.png?1729251498"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc24a365a870821eb83fd216c9596edd89479d8d7",
+      "name": "GAM3S GG",
+      "symbol": "G3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35662/thumb/G3_logo.jpg?1709454143"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd6cf874e24a9f5f43075142101a6b13735cdd424",
+      "name": "CoinbarPay",
+      "symbol": "CBPAY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38794/thumb/cbpay-icon_resized2.png?1729148991"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4186bfc76e2e237523cbc30fd220fe055156b41f",
+      "name": "KelpDAO Bridged rsETH  Arbitrum ",
+      "symbol": "RSETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39543/thumb/rseth.png?1722849891"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xca4e51f6ad4afd9d1068e5899de9dd7d73f3463d",
+      "name": "Aark Digital",
+      "symbol": "AARK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37813/thumb/aark.png?1715599394"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7b5eb3940021ec0e8e463d5dbb4b7b09a89ddf96",
+      "name": "Wombat Exchange",
+      "symbol": "WOM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26946/thumb/Wombat_Token.png?1696526001"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x24ef78c7092d255ed14a0281ac1800c359af3afe",
+      "name": "Rabbit Wallet",
+      "symbol": "RAB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29433/thumb/200x200.png?1696528381"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xacc51ffdef63fb0c014c882267c3a17261a5ed50",
+      "name": "Stryke",
+      "symbol": "SYK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36531/thumb/stryke.jpeg?1711704094"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x050c24dbf1eec17babe5fc585f06116a259cc77a",
+      "name": "dlcBTC",
+      "symbol": "DLCBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/37289/thumb/dlcBTC_ico_200px.png?1713946623"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
+      "name": "Osaka Protocol",
+      "symbol": "OSAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30911/thumb/OSAK_LOGO_200x200.png?1723662197"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2680e82fb8beb5a153a67fe687ffa67abb6b9013",
+      "name": "Swarm Markets",
+      "symbol": "SMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17488/thumb/swarm-SMT-token-symbol_200x200.png?1696517029"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfa296fca3c7dba4a92a42ec0b5e2138da3b29050",
+      "name": "AiShiba",
+      "symbol": "SHIBAI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29898/thumb/Fotor_AI%EF%BC%882%EF%BC%89.png?1696528822"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa4f63404b58c3efd9db6d53352bd386ffa174e5a",
+      "name": "Miracle Play",
+      "symbol": "MPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32653/thumb/MPT.png?1698895300"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe0ee18eacafddaeb38f8907c74347c44385578ab",
+      "name": "AxonDAO Governance Token",
+      "symbol": "AXGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35290/thumb/AXGT-logo-7.png?1708076161"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51c601dc278eb2cfea8e52c4caa35b3d6a9a2c26",
+      "name": "Chainge",
+      "symbol": "XCHNG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16526/thumb/chainge.jpeg?1708099639"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
+      "name": "Gyroscope GYD",
+      "symbol": "GYD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33428/thumb/GYD-gradient_resized_transparent.png?1702316822"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x16f1967565aad72dd77588a332ce445e7cef752b",
+      "name": "crow with knife",
+      "symbol": "CAW",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/36067/thumb/200px.png?1710405601"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x18c14c2d707b2212e17d1579789fc06010cfca23",
+      "name": "ETHPlus",
+      "symbol": "ETH+",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38061/thumb/ETH__Logo.png?1716440789"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55",
+      "name": "Dopex",
+      "symbol": "DPX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16652/thumb/DPX_%281%29.png?1696516213"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xadd5620057336f868eae78a451c503ae7b576bad",
+      "name": "enqAI",
+      "symbol": "ENQAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29908/thumb/icon.png?1702507913"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x088cd8f5ef3652623c22d48b1605dcfe860cd704",
+      "name": "Vela Token",
+      "symbol": "VELA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28739/thumb/VELA_logo_-_no_background.png?1696527719"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x330bd769382cfc6d50175903434ccc8d206dcae5",
+      "name": "Kleros",
+      "symbol": "PNK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3833/thumb/kleros.png?1696504500"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
+      "name": "Wagmi",
+      "symbol": "WAGMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31887/thumb/wagmi_token_logo.png?1696530698"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8697841b82c71fcbd9e58c15f6de68cd1c63fd02",
+      "name": "NutCoin",
+      "symbol": "NUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37569/thumb/icon-2_200x200.png?1714886224"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdcbf4cb83d27c408b30dd7f39bfcabd7176b1ba3",
+      "name": "OpenOcean",
+      "symbol": "OOE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17014/thumb/ooe_log.png?1696516578"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13278cd824d33a7adb9f0a9a84aca7c0d2deebf7",
+      "name": "Tarot",
+      "symbol": "TAROT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31800/thumb/TAROT.jpg?1696530615"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
+      "name": "Truflation",
+      "symbol": "TRUF",
+      "decimals": 15,
+      "logoURI": "https://assets.coingecko.com/coins/images/36642/thumb/truflation.jpg?1733315818"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa61f74247455a40b01b0559ff6274441fafa22a3",
+      "name": "Magpie",
+      "symbol": "MGP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27972/thumb/MagpieLogo.png?1696526991"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9f6abbf0ba6b5bfa27f4deb6597cc6ec20573fda",
+      "name": "Ferrum Network",
+      "symbol": "FRM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8251/thumb/FRM.png?1696508455"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x27bc2757fab0b8ab406016d1f71d8123452095d3",
+      "name": "Landshare",
+      "symbol": "LAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17507/thumb/Landshare.png?1696517046"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
+      "name": "Any Inu",
+      "symbol": "AI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34126/thumb/anyinulogo200.png?1704174269"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0534d7272a8e4f24d269b56605f2bf6cf3271891",
+      "name": "U Coin",
+      "symbol": "U",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51359/thumb/coingecko.png?1730877953"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdfb8be6f8c87f74295a87de951974362cedcfa30",
+      "name": "Edge Matrix Computing",
+      "symbol": "EMC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34461/thumb/cgc.jpg?1725022711"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x55678cd083fcdc2947a0df635c93c838c89454a3",
+      "name": "Tokenlon",
+      "symbol": "LON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13454/thumb/lon_logo.png?1696513217"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x60d01ec2d5e98ac51c8b4cf84dfcce98d527c747",
+      "name": "iZUMi Finance",
+      "symbol": "IZI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21791/thumb/izumi-logo-symbol.png?1696521144"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbad58ed9b5f26a002ea250d7a60dc6729a4a2403",
+      "name": "Paribus",
+      "symbol": "PBX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18410/thumb/paribus.PNG?1696517900"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4a24b101728e07a52053c13fb4db2bcf490cabc3",
+      "name": "Arbius",
+      "symbol": "AIUS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35246/thumb/arbius-200x-logo.png?1707987961"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x74ccbe53f77b08632ce0cb91d3a545bf6b8e0979",
+      "name": "Fantom Bomb",
+      "symbol": "BOMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24109/thumb/logo-blue.png?1696523301"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x24404dc041d74cd03cfe28855f555559390c931b",
+      "name": "r CryptoCurrency Moons",
+      "symbol": "MOON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11222/thumb/Moons.png?1696511153"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x02cea97794d2cfb5f560e1ff4e9c59d1bec75969",
+      "name": "VNX Swiss Franc",
+      "symbol": "VCHF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29547/thumb/VNXCHF_%282%29.png?1696528488"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a",
+      "name": "Alchemix USD",
+      "symbol": "ALUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14114/thumb/Alchemix_USD.png?1696513835"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
+      "name": "Dexalot",
+      "symbol": "ALOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24188/thumb/logo_200x200.png?1696523376"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7ce746b45eabd0c4321538dec1b849c79a9a8476",
+      "name": "DSLA Protocol",
+      "symbol": "DSLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6694/thumb/dsla_logo-squared_200x200.png?1696507035"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x10aaed289a7b1b0155bf4b86c862f297e84465e0",
+      "name": "Rubic",
+      "symbol": "RBC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/rubic.png?1696512437"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfa5ed56a203466cbbc2430a43c66b9d8723528e7",
+      "name": "EURA",
+      "symbol": "EURA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/thumb/agEUR-4.png?1710726218"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13a7dedb7169a17be92b0e3c7c2315b46f4772b3",
+      "name": "Boop",
+      "symbol": "BOOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33874/thumb/Boop_resized.png?1703144302"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5117f4ad0bc70dbb3b05bf39a1ec1ee40dd67654",
+      "name": "Avive",
+      "symbol": "AVIVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33697/thumb/avive_token.png?1702814979"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9578a9937dff45b4e29e49120ab83cb806f1aa4f",
+      "name": "AITom",
+      "symbol": "AITOM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32013/thumb/aitom.png?1696530811"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6c511dc18572d31c2c3f7b1505cb2bbc08282fcc",
+      "name": "Aipocalypto",
+      "symbol": "AIPO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51400/thumb/aipo.png?1731084580"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa58663faef461761e44066ea26c1fcddf2927b80",
+      "name": "Kommunitas",
+      "symbol": "KOM",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17483/thumb/Kommunitas_HD.png?1726922129"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x87aaffdf26c6885f6010219208d5b161ec7609c0",
+      "name": "Equation",
+      "symbol": "EQU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32592/thumb/equation_logo.png?1699220377"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x75ec618a817eb0a4a7e44ac3dfc64c963daf921a",
+      "name": "Token7007",
+      "symbol": "7007",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50293/thumb/token7007.png?1726931640"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xee0a242f28034fce0bdfac33c0ad2a58ec35fd38",
+      "name": "Rosa Inu",
+      "symbol": "ROSA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37963/thumb/ROSA_TOKEN_3.png?1716183016"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1b7ad346b6ff2d196daa8e78aed86baa6d7e3b02",
+      "name": "VitAI",
+      "symbol": "VITAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52350/thumb/aadadsadasdas.png?1733162989"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3d15fd46ce9e551498328b1c83071d9509e2c3a0",
+      "name": "Universal ETH",
+      "symbol": "UNIETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28477/thumb/uniETH_200.png?1696527471"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xedd6ca8a4202d4a36611e2fff109648c4863ae19",
+      "name": "Maha",
+      "symbol": "MAHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13404/thumb/black.png?1724679606"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x60bf4e7cf16ff34513514b968483b54beff42a81",
+      "name": "ViciCoin",
+      "symbol": "VCNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31305/thumb/ViciCoin_-_small.png?1696530124"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3212dc0f8c834e4de893532d27cc9b6001684db0",
+      "name": "Pear Protocol",
+      "symbol": "PEAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50484/thumb/pearlogo.jpg?1727897446"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf1264873436a0771e440e2b28072fafcc5eebd01",
+      "name": "Kenshi",
+      "symbol": "KNS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30759/thumb/kenshi.jpg?1696529628"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
+      "name": "Seedworld",
+      "symbol": "SWORLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51000/thumb/IMG_2798.PNG?1729685531"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdb40357fbc1eb1038c5df94c1cd7b7fd3f434480",
+      "name": "SpunkySDX",
+      "symbol": "SSDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52469/thumb/spunkysdx.png?1733412208"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1bc8bf18256d8b45d8367aac50fe2e24fc6aa8ca",
+      "name": "Vestate",
+      "symbol": "VES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35475/thumb/IMG_0759.png?1708772732"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcf934e2402a5e072928a39a956964eb8f2b5b79c",
+      "name": "PoolTogether",
+      "symbol": "POOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14003/thumb/PoolTogether.png?1696513732"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11920f139a3121c2836e01551d43f95b3c31159c",
+      "name": "YieldBricks",
+      "symbol": "YBR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51471/thumb/fjord-token-logo-darkbg.png?1731384618"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3269a3c00ab86c753856fd135d97b87facb0d848",
+      "name": "Florence Finance Medici",
+      "symbol": "FFM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34382/thumb/M_PNG_200x200_copy.png?1704779326"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb6093b61544572ab42a0e43af08abafd41bf25a6",
+      "name": "WeatherXM",
+      "symbol": "WXM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38154/thumb/weatherxm-network-logo.png?1716668976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4d840b741bc05fde325d4ec0b4cfcd0cea237e4e",
+      "name": "Quantlytica",
+      "symbol": "QTLX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50217/thumb/eebgcbNa_400x400.jpg?1726443400"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb9600c807f069d27f92a2a65b48f12eeef7e2007",
+      "name": "Altranium",
+      "symbol": "ALTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38301/thumb/altr.jpg?1717034749"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x894134a25a5fac1c2c26f1d8fbf05111a3cb9487",
+      "name": "Grai",
+      "symbol": "GRAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30427/thumb/GRAI_Token.png?1696529315"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc9c4fd7579133701fa2769b6955e7e56bb386db1",
+      "name": "Bridge Oracle",
+      "symbol": "BRG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12512/thumb/brg.png?1696512327"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "name": "Hop Protocol",
+      "symbol": "HOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25445/thumb/hop.png?1696524577"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2b41806cbf1ffb3d9e31a9ece6b738bf9d6f645f",
+      "name": "ENO",
+      "symbol": "ENO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26501/thumb/Logo_%281%29.png?1709565574"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7ba4a00d54a07461d9db2aef539e91409943adc9",
+      "name": "Stake DAO",
+      "symbol": "SDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13724/thumb/stakedao_logo.jpg?1696513468"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x092baadb7def4c3981454dd9c0a0d7ff07bcfc86",
+      "name": "MorpheusAI",
+      "symbol": "MOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37969/thumb/MOR200X200.png?1716327119"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3096e7bfd0878cc65be71f8899bc4cfb57187ba3",
+      "name": "Xend Finance",
+      "symbol": "RWA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14496/thumb/WeChat_Image_20210325163206.png?1696514181"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418",
+      "name": "Ramses Exchange",
+      "symbol": "RAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29420/thumb/newram.png?1708427055"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x69420f9e38a4e60a62224c489be4bf7a94402496",
+      "name": "Defi money",
+      "symbol": "MONEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39230/thumb/Token_2x-1.png?1725438128"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb688ba096b7bb75d7841e47163cd12d18b36a5bf",
+      "name": "mPendle",
+      "symbol": "MPENDLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31918/thumb/mPendle.png?1696530726"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd6b3d81868770083307840f513a3491960b95cb6",
+      "name": "Credbull",
+      "symbol": "CBL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39396/thumb/2024-11-15_06.09.28.jpg?1731735429"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbe5acfd64358805616b5cbd5277b9a85011d7cf1",
+      "name": "Pichi Finance",
+      "symbol": "PCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39683/thumb/Group_1000003884.png?1723654999"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1c986661170c1834db49c3830130d4038eeeb866",
+      "name": "Aperture Finance",
+      "symbol": "APTR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37940/thumb/icon_white.png?1715967425"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2297aebd383787a160dd0d9f71508148769342e3",
+      "name": "Avalanche Bridged BTC  Arbitrum One ",
+      "symbol": "BTCB",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/51135/thumb/avalanche-core.png?1730195092"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc4cbd54ffa7a6a142fd73554cc6c23dd95cd8e01",
+      "name": " GAME Token",
+      "symbol": "GAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38429/thumb/_GAME_Token.png?1717497071"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x847503fbf003ce8b005546aa3c03b80b7c2f9771",
+      "name": "Byte",
+      "symbol": "BYTE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/33527/thumb/Byte200.jpeg?1702138460"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3bd2dfd03bc7c3011ed7fb8c4d0949b382726cee",
+      "name": "Roobee",
+      "symbol": "ROOBEE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8791/thumb/Group_11.png?1696508946"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9e20461bc2c4c980f62f1b279d71734207a6a356",
+      "name": "OmniCat",
+      "symbol": "OMNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33917/thumb/omnicatlogo.png?1717544778"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x83d6c8c06ac276465e4c92e7ac8c23740f435140",
+      "name": "HMX",
+      "symbol": "HMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31206/thumb/HMXlogo_CG.png?1696530033"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xadf5dd3e51bf28ab4f07e684ecf5d00691818790",
+      "name": "ICHI",
+      "symbol": "ICHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13119/thumb/ICHI_%28Round%29.jpg?1696512907"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x000000000026839b3f4181f2cf69336af6153b99",
+      "name": "Reboot",
+      "symbol": "GG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31228/thumb/gg_cyan_black_square.png?1703749951"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe82335d58abb1cd44cd5f47cf7f5b378e4c32f05",
+      "name": "SuperCells",
+      "symbol": "SCT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38800/thumb/photo_2024-09-24_18-31-07.jpg?1728417418"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa0995d43901551601060447f9abf93ebc277cec2",
+      "name": "HIPPOP",
+      "symbol": "HIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37854/thumb/KakaoTalk_Image_2024-05-14-16-50-31.png?1715781999"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2ac2b254bc18cd4999f64773a966e4f4869c34ee",
+      "name": "Penpie",
+      "symbol": "PNP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30760/thumb/PNP_Token.png?1696529629"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb299751b088336e165da313c33e3195b8c6663a6",
+      "name": "StarHeroes",
+      "symbol": "STAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34147/thumb/Screenshot_2024-03-08_180444.png?1709892309"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
+      "name": "Nya",
+      "symbol": "NYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40082/thumb/nya.jpg?1725523655"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4883c8f0529f37e40ebea870f3c13cdfad5d01f8",
+      "name": "VNX EURO",
+      "symbol": "VEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29351/thumb/VNXEUR_%281%29.png?1696528300"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0cbd6fadcf8096cc9a43d90b45f65826102e3ece",
+      "name": "CheckDot",
+      "symbol": "CDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20370/thumb/token-200x200_%281%29.png?1696519781"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf6dae0d2be4993b00a2673360820af6bafd53887",
+      "name": "Launchpool",
+      "symbol": "LPOOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14041/thumb/dGUvV0HQ_400x400.jpg?1696513767"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb2f30a7c980f052f02563fb518dcc39e6bf38175",
+      "name": "Synthetix USDx",
+      "symbol": "USDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51047/thumb/USDX.jpg?1729845921"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5d4974f8543bc78d43fd1044ecfdb9d85482aa21",
+      "name": "Bitbama",
+      "symbol": "BAMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36686/thumb/photo_2024-03-31_14-20-41.jpg?1712073912"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x982239d38af50b0168da33346d85fb12929c4c07",
+      "name": "Arbitrove Governance Token",
+      "symbol": "TROVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29017/thumb/trove.png?1696527988"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6b2a01a5f79deb4c2f3c0eda7b01df456fbd726a",
+      "name": "Universal BTC",
+      "symbol": "UNIBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39599/thumb/uniBTC_200px.png?1723064455"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6db8b088c4d41d622b44cd81b900ba690f2d496c",
+      "name": "Impossible Finance Launchpad",
+      "symbol": "IDIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17803/thumb/IDIA.png?1696517325"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xffa188493c15dfaf2c206c97d8633377847b6a52",
+      "name": "Wefi",
+      "symbol": "WEFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30540/thumb/wefi.png?1696529412"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
+      "name": "Glo Dollar",
+      "symbol": "USDGLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29319/thumb/GLO_logo_pine_on_cyan_1_3.png?1716971065"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xafafd68afe3fe65d376eec9eab1802616cfaccb8",
+      "name": "Solv Protocol SolvBTC ENA",
+      "symbol": "SOLVBTCENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38931/thumb/BTC_ena.png?1719562313"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6fd58f5a2f3468e35feb098b5f59f04157002407",
+      "name": "POGAI",
+      "symbol": "POGAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30116/thumb/pogai.jpeg?1696529039"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4a7779abed707a9c7deadbbef5c15f3e52370a99",
+      "name": "Flame",
+      "symbol": "FLAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34280/thumb/20240104-164053.jpg?1704452348"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x431402e8b9de9aa016c743880e04e517074d8cec",
+      "name": "Hegic",
+      "symbol": "HEGIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12454/thumb/new.png?1696512274"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f7d7806f4eb90d63b0b278daf32a2db2c2001bd",
+      "name": "BonusBlock",
+      "symbol": "BONUS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36364/thumb/Coingecko_logo.png?1711336118"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdc8184ba488e949815d4aafb35b3c56ad03b4179",
+      "name": "Roseon",
+      "symbol": "ROSX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29698/thumb/roseon.png?1696528631"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x45d9831d8751b2325f3dbf48db748723726e1c8c",
+      "name": "EverValue Coin",
+      "symbol": "EVA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50997/thumb/EVA_Logo_-_with_dark_background_-_200x200.png?1729720258"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8d9ba570d6cb60c7e3e0f31343efe75ab8e65fb1",
+      "name": "Governance OHM",
+      "symbol": "GOHM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21129/thumb/token_wsOHM_logo.png?1696520508"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x21e60ee73f17ac0a411ae5d690f908c3ed66fe12",
+      "name": "Deri Protocol",
+      "symbol": "DERI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13931/thumb/200vs200.jpg?1696513670"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe85b662fe97e8562f4099d8a1d5a92d4b453bf30",
+      "name": "Thales",
+      "symbol": "THALES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18388/thumb/CLVZJN_C_400x400.png?1696517879"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1dd6b5f9281c6b4f043c02a83a46c2772024636c",
+      "name": "Lumi Finance LUAUSD",
+      "symbol": "LUAUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33503/thumb/LUAUSD.png?1702038709"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2c7941a0fe9c52223b229747322af16160161c98",
+      "name": "Jarvis",
+      "symbol": "JARVIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35812/thumb/jarvis.png?1709873633"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa586b3b80d7e3e8d439e25fbc16bc5bcee3e2c85",
+      "name": "Codyfight",
+      "symbol": "CTOK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23592/thumb/ctok.jpg?1715904249"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x569deb225441fd18bde18aed53e2ec7eb4e10d93",
+      "name": "Your Futures Exchange",
+      "symbol": "YFX",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/15654/thumb/yfx.PNG?1696515285"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x10393c20975cf177a3513071bc110f7962cd67da",
+      "name": "Jones DAO",
+      "symbol": "JONES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23290/thumb/3c8c2ed8-afb3-4b67-9937-5493acd88b50.jpg?1696522508"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x965d00aa7abc62ca10132e641d08593435ac811d",
+      "name": "KAP Games",
+      "symbol": "KAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27682/thumb/KAP_Logo.png?1696526710"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3404149e9ee6f17fb41db1ce593ee48fbdcd9506",
+      "name": "Hydranet",
+      "symbol": "HDN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25177/thumb/HDXdarkblueInv.png?1696524322"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xee9801669c6138e84bd50deb500827b776777d28",
+      "name": "O3 Swap",
+      "symbol": "O3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15460/thumb/o3.png?1696515107"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
+      "name": "Magic Internet Money  Arbitrum ",
+      "symbol": "MIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37324/thumb/mim.png?1714016666"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
+      "name": "Ankr Staked ETH",
+      "symbol": "ANKRETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13403/thumb/aETHc.png?1696513165"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x55ff62567f09906a85183b866df84bf599a4bf70",
+      "name": "Kromatika",
+      "symbol": "KROM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20541/thumb/KROM_Transparent.png?1696519948"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
+      "name": "Lava Network",
+      "symbol": "LAVA",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37354/thumb/lava_logo.png?1714098423"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x711b771c7c443ebb695e4b3495c337fdaf37be11",
+      "name": "Dackie USD",
+      "symbol": "DCKUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39966/thumb/Dackie_USD_Stablecoin.png?1724957262"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf763fa322dc58dee588252fafee5f448e863b633",
+      "name": "Carbon Protocol",
+      "symbol": "SWTH",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/3645/thumb/SWTH_Symbol_Origin.png?1696504327"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1d987200df3b744cfa9c14f713f5334cb4bc4d5d",
+      "name": "REKT",
+      "symbol": "REKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29954/thumb/New_Project_%288%29.png?1696528881"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb64e280e9d1b5dbec4accedb2257a87b400db149",
+      "name": "Level",
+      "symbol": "LVL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28628/thumb/Token.png?1696527613"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9e523234d36973f9e38642886197d023c88e307e",
+      "name": "Darwinia Network",
+      "symbol": "RING",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9443/thumb/RING.png?1696509535"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb6212b633c941e9be168c4b9c2d9e785f1cd42fb",
+      "name": "Bitoro",
+      "symbol": "BTORO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50334/thumb/bitoro-logo-highres.jpg?1727306095"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x816e21c33fa5f8440ebcdf6e01d39314541bea72",
+      "name": "LiquidDriver",
+      "symbol": "LQDR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15782/thumb/LQDR_Glowing_Icon.png?1696515405"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7c8a1a80fdd00c9cccd6ebd573e9ecb49bfa2a59",
+      "name": "AI CODE",
+      "symbol": "AICODE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30057/thumb/AICODE.png?1696528979"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0000206329b97db379d5e1bf586bbdb969c63274",
+      "name": "USDA",
+      "symbol": "USDA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34510/thumb/agUSD-coingecko.png?1705288392"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7a2c1b8e26c48a5b73816b7ec826fd4053f5f34b",
+      "name": "GoSleep ZZZ",
+      "symbol": "ZZZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29901/thumb/ZZZ200_200.png?1696528830"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa970af1a584579b618be4d69ad6f73459d112f95",
+      "name": "sUSD",
+      "symbol": "SUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1696505546"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb829b68f57cc546da7e5806a929e53be32a4625d",
+      "name": "Axelar Wrapped Ether",
+      "symbol": "AXLETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28171/thumb/weth-wei_D_3x.png?1696527174"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+      "name": "MUX Protocol",
+      "symbol": "MCB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11796/thumb/mux.jpg?1696511672"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb52bd62ee0cf462fa9ccbda4bf27fe84d9ab6cf7",
+      "name": "Clipper SAIL",
+      "symbol": "SAIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31380/thumb/SAIL-Logo.png?1696530197"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf061956612b3dc79fd285d3d51bc128f2ea87740",
+      "name": "YfDAI finance",
+      "symbol": "YF-DAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12385/thumb/1619048513068.png?1696512208"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
+      "name": "Overnight Finance",
+      "symbol": "OVN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31970/thumb/OVN.png?1696959174"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb1bc21f748ae2be95674876710bc6d78235480e0",
+      "name": "Hord",
+      "symbol": "HORD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14972/thumb/HORD_TOKEN_%281%29_1.png?1705414356"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x429fed88f10285e61b12bdf00848315fbdfcc341",
+      "name": "THORWallet DEX",
+      "symbol": "TGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21843/thumb/tgt_logo.png?1696521198"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb00eaedb98f1e30ad545703d8ff14b24d109514f",
+      "name": "Yaku",
+      "symbol": "YAKU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26785/thumb/yaku_logo.png?1706636424"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbcf339df10d78f2b44aa760ead0f715a7a7d7269",
+      "name": "Guardian GUARD",
+      "symbol": "GUARD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17995/thumb/LS_wolfDen_logo.0025_Light_200x200.png?1696517512"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x47c337bd5b9344a6f3d6f58c474d9d8cd419d8ca",
+      "name": "DackieSwap",
+      "symbol": "DACKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30752/thumb/dackieswap_large.png?1707290196"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e51ac49bc5e2d87e0ef713e9e5ab2d71ef4f336",
+      "name": "Celo  Wormhole ",
+      "symbol": "CELO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32400/thumb/celo_wh.png?1698055352"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xee0b14e8fc86691cf6ee42b9954985b4cf968534",
+      "name": "ZenPandaCoin",
+      "symbol": "ZPC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30269/thumb/panda.png?1696529176"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x306fd3e7b169aa4ee19412323e1a5995b8c1a1f4",
+      "name": "Black Agnus",
+      "symbol": "FTW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50170/thumb/32x32.png?1727177729"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x43c25f828390de5a3648864eb485cc523e039e67",
+      "name": "Hello Pets",
+      "symbol": "PET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14354/thumb/hello_pets.jpg?1696514040"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3de81ce90f5a27c5e6a5adb04b54aba488a6d14e",
+      "name": "DeltaPrime",
+      "symbol": "PRIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39234/thumb/PRIME.jpg?1721240215"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x53bcf6698c911b2a7409a740eacddb901fc2a2c6",
+      "name": "Kabosu  Arbitrum ",
+      "symbol": "KABOSU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30320/thumb/IMG_20230510_204814_554_copy_200x200.jpg?1696529222"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf50874f8246776ca4b89eef471e718f70f38458f",
+      "name": "Arbswap",
+      "symbol": "ARBS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30565/thumb/Arb-Logo_Circle_DARK_LOGO_ONLY.png?1696529436"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc3abc47863524ced8daf3ef98d74dd881e131c38",
+      "name": "Lumi Finance",
+      "symbol": "LUA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33502/thumb/LUA.png?1702038548"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4dd40ec670722067241b4396dbd253c38dd820b5",
+      "name": "MTMS Network",
+      "symbol": "MTMS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39043/thumb/Logo-MTMS.png?1720067131"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7ae9ab13fc8945323b778b3f8678145e80ec2efb",
+      "name": "WorldBrain Coin",
+      "symbol": "WBC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39650/thumb/Frame_48096646.png?1723455673"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xeb4d25db65dcef52380c99ba7e1344c820ecb1fc",
+      "name": "X World Games",
+      "symbol": "XWG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17847/thumb/200_200_%281%29_%281%29.png?1696790226"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5",
+      "name": "Smolcoin",
+      "symbol": "SMOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33951/thumb/Smol_Coin_Icon.png?1703558329"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbc4c97fb9befaa8b41448e1dfcc5236da543217f",
+      "name": "SpaceCatch",
+      "symbol": "CATCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36632/thumb/Logomark_colours.png?1712022405"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0341c0c0ec423328621788d4854119b97f44e391",
+      "name": "Silo Finance",
+      "symbol": "SILO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21454/thumb/y0iYKZOv_400x400.png?1696520816"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x71eeba415a523f5c952cc2f06361d5443545ad28",
+      "name": "XDAO",
+      "symbol": "XDAO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27363/thumb/token_2.png?1696526408"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+      "name": "Gains Network USDC",
+      "symbol": "GUSDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39042/thumb/logo_gUSDC.png?1720066451"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x06d65ec13465ac5a4376dc101e1141252c4addf8",
+      "name": "Zunami ETH",
+      "symbol": "ZUNETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37835/thumb/zunETH_200x200.png?1715741123"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x188fb5f5ae5bbe4154d5778f2bbb2fb985c94d25",
+      "name": "OpenBlox",
+      "symbol": "OBX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26150/thumb/OBX_token-black_background_preview.png?1696525239"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3405e88af759992937b84e58f2fe691ef0eea320",
+      "name": "Frax Price Index Share",
+      "symbol": "FPIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24944/thumb/FPIS_icon.png?1696524099"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xad4b9c1fbf4923061814dd9d5732eb703faa53d4",
+      "name": "Wicrypt",
+      "symbol": "WNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21223/thumb/wicrypt.PNG?1696520597"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2b089381f53525451fe5115f23e9d2cc92d7ff1d",
+      "name": "Digital Reserve Currency",
+      "symbol": "DRC",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/12802/thumb/DRC_Logo.jpg?1696512595"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2ea0be86990e8dac0d09e4316bb92086f304622d",
+      "name": "TheStandard USD",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50381/thumb/USDs-200x200.png?1727411027"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4debfb9ed639144cf1e401674af361ffffcefb58",
+      "name": "CADAI",
+      "symbol": "CADAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38713/thumb/CADAI_Token_Logo.png?1718404394"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe3b3fe7bca19ca77ad877a5bebab186becfad906",
+      "name": "Staked FRAX",
+      "symbol": "SFRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35383/thumb/sfrax.png?1708445569"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x20547341e58fb558637fa15379c92e11f7b7f710",
+      "name": "Mozaic",
+      "symbol": "MOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30100/thumb/Main_Logo_1-200x200jpg.jpg?1696529024"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x130096af9163b185cae4a833f856760199fc6ceb",
+      "name": "FU Money",
+      "symbol": "FU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38629/thumb/FU_logo_black.png?1718170125"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x34229b3f16fbcdfa8d8d9d17c0852f9496f4c7bb",
+      "name": "IPOR",
+      "symbol": "IPOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28373/thumb/IPOR-token-200x200.png?1696527376"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfbcfe8873fe28dfa25f1099282b088d52bbad9c",
+      "name": "Equilibria Finance",
+      "symbol": "EQB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30645/thumb/QLLK8pmR_400x400.jpg?1696529516"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x86f65121804d2cdbef79f9f072d4e0c2eebabc08",
+      "name": "Garden",
+      "symbol": "SEED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34671/thumb/icon.png?1705656915"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc19669a405067927865b40ea045a2baabbbe57f5",
+      "name": "Star",
+      "symbol": "STAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31277/thumb/coin-icon_Star-200x200.png?1732742256"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x439c0cf1038f8002a4cad489b427e217ba4b42ad",
+      "name": "GNB",
+      "symbol": "GNB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38687/thumb/GINAICNLOGO.png?1718344439"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcf985aba4647a432e60efceeb8054bbd64244305",
+      "name": "EUROe Stablecoin",
+      "symbol": "EUROE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28913/thumb/euroe-200x200-round.png?1696527889"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x999faf0af2ff109938eefe6a7bf91ca56f0d07e1",
+      "name": "Ledgity Token",
+      "symbol": "LDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35046/thumb/ldy-token.png?1707204910"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x589d35656641d6ab57a545f08cf473ecd9b6d5f7",
+      "name": "GYEN",
+      "symbol": "GYEN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1696513909"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x346e74dc9935a9b02eb34fb84658a66010fa056d",
+      "name": "Zunami Governance Token",
+      "symbol": "ZUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38298/thumb/ZUN_200x200.png?1717194404"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9cf7eebb75b751dc8fdd2268ae8c9b570b4c97b9",
+      "name": "NULL MATRIX",
+      "symbol": "NULL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51086/thumb/dark.png?1732460149"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x299142a6370e1912156e53fbd4f25d7ba49ddcc5",
+      "name": "AI Meta Club",
+      "symbol": "AMC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31919/thumb/aimeta.jpg?1696530728"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb1084db8d3c05cebd5fa9335df95ee4b8a0edc30",
+      "name": "Overnight fi USDT ",
+      "symbol": "USDT+",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/30168/thumb/USDT_.png?1696529088"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x32eb7902d4134bf98a28b963d26de779af92a212",
+      "name": "Dopex Rebate",
+      "symbol": "RDPX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16659/thumb/rDPX_200x200_Coingecko.png?1696516221"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11bbf12363dc8375b78d2719395d505f52a02f68",
+      "name": "Router Protocol  OLD ",
+      "symbol": "ROUTE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13709/thumb/router.jpg?1722424977"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbea0005b8599265d41256905a9b3073d397812e4",
+      "name": "Bean",
+      "symbol": "BEAN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18447/thumb/bean-logo-coingecko.png?1696517934"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6bcc14b02cd624ebe1a8a665cb6d4067aa097230",
+      "name": "Foxify",
+      "symbol": "FOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32354/thumb/Foxify_200x200.png?1697475371"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbcd4d5ac29e06e4973a1ddcd782cd035d04bc0b7",
+      "name": "Quick Intel",
+      "symbol": "QKNTL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29605/thumb/IMG_6589D0616DF1-1.jpeg?1696528542"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7fb7ede54259cb3d4e1eaf230c7e2b1ffc951e9a",
+      "name": "Numa",
+      "symbol": "NUMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35807/thumb/numa200.png?1709845645"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8cf7e3aa6faf6ae180e5ec3f0fb95081c2086ebe",
+      "name": "SX Network",
+      "symbol": "SX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34934/thumb/sx-ntework.jpeg?1706699134"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6dd963c510c2d2f09d5eddb48ede45fed063eb36",
+      "name": "FactorDAO",
+      "symbol": "FCTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29018/thumb/FactorLogo.png?1696527989"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x93ca0d85837ff83158cd14d65b169cdb223b1921",
+      "name": "Eclipse Fi",
+      "symbol": "ECLIP",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31815/thumb/ECLIP_token_logo.png?1696530629"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf3527ef8de265eaa3716fb312c12847bfba66cef",
+      "name": "usdx money USDX",
+      "symbol": "USDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50360/thumb/USDX200px.png?1731906044"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd3188e0df68559c0b63361f6160c57ad88b239d8",
+      "name": "Astra DAO",
+      "symbol": "ASTRADAO",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/32870/thumb/ASTRADAO.jpg?1699673097"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9fb9a33956351cf4fa040f65a13b835a3c8764e3",
+      "name": "Multichain",
+      "symbol": "MULTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1696521430"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13461c85887e85fdc942ac94c4d2699995ad1960",
+      "name": "Cradles",
+      "symbol": "CRDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33084/thumb/cradles_icon.png?1700601703"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x655a6beebf2361a19549a99486ff65f709bd2646",
+      "name": "LilAI",
+      "symbol": "LILAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30621/thumb/LogoLilai_CoinGecko.png?1696529495"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x79ead7a012d97ed8deece279f9bc39e264d7eef9",
+      "name": "Bonsai",
+      "symbol": "BONSAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37883/thumb/bonsai.jpeg?1715840730"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3f56e0c36d275367b8c502090edf38289b3dea0d",
+      "name": "MAI  Arbitrum ",
+      "symbol": "MIMATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35517/thumb/mimatic-red.png?1709005586"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa71e2738704e367798baa2755af5a10499634953",
+      "name": "Avarik Saga",
+      "symbol": "AVRK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51914/thumb/Logo500x500.png?1732258561"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f4db37d7beb31f445307782bc3da0f18df13696",
+      "name": "Yield Yak",
+      "symbol": "YAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17654/thumb/yieldyak.png?1696517185"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf5a27e55c748bcddbfea5477cb9ae924f0f7fd2e",
+      "name": "TheStandard Token",
+      "symbol": "TST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20598/thumb/TheStandard-logo_variation-01.png?1696520005"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1bd013bd089c2b6b2d30a0e0b545810a5844e761",
+      "name": "OtterHome",
+      "symbol": "HOME",
+      "decimals": 16,
+      "logoURI": "https://assets.coingecko.com/coins/images/30740/thumb/LOGO.png?1696529610"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x27f485b62c4a7e635f561a87560adf5090239e93",
+      "name": "DFX Finance",
+      "symbol": "DFX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14091/thumb/DFX.png?1696513813"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x872bad41cfc8ba731f811fea8b2d0b9fd6369585",
+      "name": "BattleFly",
+      "symbol": "GFLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28828/thumb/GFLY_LOGO.png?1696527804"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x577fd586c9e6ba7f2e85e025d5824dbe19896656",
+      "name": "Synonym Finance",
+      "symbol": "SYNO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35065/thumb/SYNO-token.png?1707241258"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1a5b0aaf478bf1fda7b934c76e7692d722982a6d",
+      "name": "Buffer Token",
+      "symbol": "BFR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18540/thumb/Qk6pjeZ3_400x400.jpg?1696518020"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xde70aed3d14d39b4955147efcf272334bdb75ab5",
+      "name": "YachtingVerse",
+      "symbol": "YACHT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32858/thumb/aMmNwBTH_400x400.jpg?1699666370"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xddd6ebd74684318fa912084a41a01f11b6c277f7",
+      "name": "WorkoutApp",
+      "symbol": "WRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37270/thumb/wrt.jpg?1713888102"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4b019aaa21e98e212d31e54c843e73ff34d25717",
+      "name": "TUX Project",
+      "symbol": "TUXC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37537/thumb/tuxc.jpg?1714687219"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
+      "name": "BetSwirl",
+      "symbol": "BETS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26618/thumb/icon_200.png?1696525691"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x56659245931cb6920e39c189d2a0e7dd0da2d57b",
+      "name": "Impermax",
+      "symbol": "IBEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27606/thumb/IqwOmX-c_400x400.jpeg?1696526637"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xef04804e1e474d3f9b73184d7ef5d786f3fce930",
+      "name": "Wall Street Games",
+      "symbol": "WSG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36483/thumb/wsg.jpeg?1711539007"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xafe8107123eefd62469474dec9680860b890e5b6",
+      "name": "Oil Token",
+      "symbol": "OIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39504/thumb/logo_oil_200%D1%85200.png?1722581566"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x949185d3be66775ea648f4a306740ea9eff9c567",
+      "name": "Yel Finance",
+      "symbol": "YEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17429/thumb/Logo200.png?1696516976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
+      "name": "Pickle Finance",
+      "symbol": "PICKLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12435/thumb/0M4W6Yr6_400x400.jpg?1696512255"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0002bcdaf53f4889bf2f43a3252d7c03fe1b80bc",
+      "name": "GorplesCoin",
+      "symbol": "GORPLES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38681/thumb/Round_Avatar.png?1720520435"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x54bdbf3ce36f451ec61493236b8e6213ac87c0f6",
+      "name": "Radpie",
+      "symbol": "RDP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34052/thumb/Radpie_token_3_2.png?1704672743"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x80dd74145b8bb10cef01bf914f796bd8b54d7809",
+      "name": "Hepton",
+      "symbol": "HTE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30274/thumb/HTECoingecko.png?1696529180"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6dbf2155b0636cb3fd5359fccefb8a2c02b6cb51",
+      "name": "Plutus RDNT",
+      "symbol": "PLSRDNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30635/thumb/plsRDNT.png?1696529508"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51fc0f6660482ea73330e414efd7808811a57fa2",
+      "name": "Premia",
+      "symbol": "PREMIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13962/thumb/apple-touch-icon.png?1696513698"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9cce9ae579142e372a8959285e3a5a2e211904f7",
+      "name": "DGWToken",
+      "symbol": "DGW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39642/thumb/1000146817.jpg?1723410321"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x249c48e22e95514ca975de31f473f30c2f3c0916",
+      "name": "USDFI",
+      "symbol": "USDFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31149/thumb/USDFI_200.png?1696529977"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa334884bf6b0a066d553d19e507315e839409e62",
+      "name": "Ethos Reserve Note",
+      "symbol": "ERN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29744/thumb/ERN200x200.png?1696528676"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x64343594ab9b56e99087bfa6f2335db24c2d1f17",
+      "name": "Vesta Stable",
+      "symbol": "VST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23621/thumb/vesta.png?1696522826"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa9011ee5796be43123651181dc75c0e72bb1191c",
+      "name": "NeuroPulse AI",
+      "symbol": "NPAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31848/thumb/NPAI.png?1700257725"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9cfb13e6c11054ac9fcb92ba89644f30775436e4",
+      "name": "Bridged Wrapped stETH  Axelar ",
+      "symbol": "AXL-WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32223/thumb/steth-wei_D_3x.png?1696926841"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8bf591eae535f93a242d5a954d3cde648b48a5a8",
+      "name": "Sumer Money suUSD",
+      "symbol": "SUUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33266/thumb/Sumer_Money_Logo.jpg?1701321416"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xecc68d0451e20292406967fe7c04280e5238ac7d",
+      "name": "Axelar Bridged Frax Ether",
+      "symbol": "AXLFRXETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38976/thumb/Screen_Shot_2024-06-18_at_12.55.54_PM_2.png?1719714886"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x221a0f68770658c15b525d0f89f5da2baab5f321",
+      "name": "Open Dollar",
+      "symbol": "OD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38630/thumb/OD_Token_200_x_200.png?1718170821"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd4848211b699503c772aa1bc7d33b433c4242ac3",
+      "name": "Equilibria Finance ePENDLE",
+      "symbol": "EPENDLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33379/thumb/photo_2023-12-02_19-45-14.jpg?1701665986"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x07e49d5de43dda6162fa28d24d5935c151875283",
+      "name": "CVI",
+      "symbol": "GOVI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13875/thumb/GOVI.png?1696513619"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe4421566a501045ae4285996577a36f6cf074190",
+      "name": "Ice",
+      "symbol": "ICE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35093/thumb/ICE_LOGO.jpg?1707363813"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x498c620c7c91c6eba2e3cd5485383f41613b7eb6",
+      "name": "Alongside Crypto Market Index",
+      "symbol": "AMKT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28496/thumb/22999.png?1696527488"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x31c91d8fb96bff40955dd2dbc909b36e8b104dde",
+      "name": "Poison Finance",
+      "symbol": "POION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28630/thumb/poisonlogo160x160.png?1696527614"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd978f8489e1245568704407a479a71fcce2afe8f",
+      "name": "ApeSwap",
+      "symbol": "BANANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14870/thumb/banana.png?1696514534"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x079504b86d38119f859c4194765029f692b7b7aa",
+      "name": "Lyra Finance",
+      "symbol": "LYRA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21490/thumb/Add-a-heading-26.png?1696520850"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xafccb724e3aec1657fc9514e3e53a0e71e80622d",
+      "name": "Vaultka",
+      "symbol": "VKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32408/thumb/VKA_logo_PNG.png?1698057073"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8347dff20de05b11c0781aaea90d5bee46c30252",
+      "name": "Playahh App",
+      "symbol": "PLAH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40098/thumb/logoPlayahh10.png?1725632328"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x155f0dd04424939368972f4e1838687d6a831151",
+      "name": "ArbiDoge",
+      "symbol": "ADOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18333/thumb/Screen-Shot-2021-09-04-at-11-59-16-AM.png?1696517824"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0caadd427a6feb5b5fc1137eb05aa7ddd9c08ce9",
+      "name": "VEE",
+      "symbol": "VEE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52199/thumb/1000002075.png?1732732974"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x83e60b9f7f4db5cdb0877659b1740e73c662c55b",
+      "name": "Pingu Exchange",
+      "symbol": "PINGU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34790/thumb/icon_primary.png?1706030846"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfd2fb8de10ec41ddd898a8c7fa70d8fc100834c4",
+      "name": "Bitci DOGE",
+      "symbol": "BOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38048/thumb/DOGE_TOKEN_200.png?1716401036"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdb298285fe4c5410b05390ca80e8fbe9de1f259b",
+      "name": "handle fi",
+      "symbol": "FOREX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18533/thumb/handle.fiFOREXLogoDark200x200.png?1696518013"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f90122bf0700f9e7e1f688fe926940e8839f353",
+      "name": "Curve fi USDC USDT",
+      "symbol": "2CRV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28365/thumb/curve2.png?1696527368"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xed5740209fcf6974d6f3a5f11e295b5e468ac27c",
+      "name": "KEWL EXCHANGE",
+      "symbol": "KWL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36883/thumb/yamuk.png?1712649510"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xccd05a0fcfc1380e9da27862adb2198e58e0d66f",
+      "name": "ANIMA",
+      "symbol": "ANIMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30377/thumb/anima_logo_yellow.png?1696529271"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd45e486a90ebb84e9336d371a35dcb021424b96c",
+      "name": "Superpower Squad",
+      "symbol": "SQUAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28466/thumb/SQUAD200X200.png?1696527460"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x45940000009600102a1c002f0097c4a500fa00ab",
+      "name": "Hermes Protocol",
+      "symbol": "HERMES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24251/thumb/Transparent-13_%281%29_%281%29.png?1725188033"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6f5401c53e2769c858665621d22ddbf53d8d27c5",
+      "name": "Connect Financial",
+      "symbol": "CNFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13592/thumb/cf-logo-iconic-black.png?1696513344"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x16a500aec6c37f84447ef04e66c57cfc6254cf92",
+      "name": "Umoja",
+      "symbol": "UMJA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38328/thumb/Umoja_Logo.png?1717639928"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x00000000ea00f3f4000e7ed5ed91965b19f1009b",
+      "name": "Maia",
+      "symbol": "MAIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22502/thumb/Transparent-04_%281%29_%281%29.png?1725187885"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x65c936f008bc34fe819bce9fa5afd9dc2d49977f",
+      "name": "Y2K",
+      "symbol": "Y2K",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28542/thumb/l7jRo-5-_400x400.jpg?1696527534"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2fac624899a844e0628bfdcc70efcd25f6e90b95",
+      "name": "Youwho",
+      "symbol": "YOU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25353/thumb/youwho_200.png?1696524487"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x323665443cef804a3b5206103304bd4872ea4253",
+      "name": "Verified USD",
+      "symbol": "USDV",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/32948/thumb/usdv_%281%29.png?1699933314"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6612ce012ba5574a2ecea3a825c1ddf641f78623",
+      "name": "Dorado Finance",
+      "symbol": "DORAB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38347/thumb/Dorado_Logo.png?1717143752"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb9af4762c039d63e30039f1712dfab77026408c7",
+      "name": "BullBear AI",
+      "symbol": "AIBB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30096/thumb/ICON_200.png?1696529020"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x643b34980e635719c15a2d4ce69571a258f940e9",
+      "name": "The Standard EURO",
+      "symbol": "EUROS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32231/thumb/EUROs-coingecko.png?1696936278"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3b475f6f2f41853706afc9fa6a6b8c5df1a2724c",
+      "name": "Zyberswap",
+      "symbol": "ZYB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28943/thumb/logo_with_bg.png?1696527917"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8038f3c971414fd1fc220ba727f2d4a0fc98cb65",
+      "name": "dHEDGE DAO",
+      "symbol": "DHT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12508/thumb/dht.png?1696512323"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+      "name": "usdx money Staked USDX",
+      "symbol": "SUSDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50836/thumb/sUSDX200px.png?1731906119"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6b5b5eac259e883b484ed879d43dd4d616a90e65",
+      "name": "The Knowers",
+      "symbol": "KNOW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36964/thumb/63_%281%29.png?1712907583"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1d1498166ddceee616a6d99868e1e0677300056f",
+      "name": "Space Token",
+      "symbol": "SPACE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20676/thumb/jYw3kgsY_400x400.png?1696520076"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x59debed8d46a0cb823d8be8b957add987ead39aa",
+      "name": "Quack Token",
+      "symbol": "QUACK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31436/thumb/0x639C0D019C257966C4907bD4E68E3F349bB58109.png?1696530251"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdc8b6b6beab4d5034ae91b7a1cf7d05a41f0d239",
+      "name": "Gemach",
+      "symbol": "GMAC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32334/thumb/gmac-200x200.png?1697452788"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0bbf664d46becc28593368c97236faa0fb397595",
+      "name": "KNOX Dollar",
+      "symbol": "KNOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38074/thumb/knox%28200_x_200_px%29.png?1716449113"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x641441c631e2f909700d2f41fd87f0aa6a6b4edb",
+      "name": "dForce USD",
+      "symbol": "USX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17422/thumb/usx_32.png?1696516969"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x36295e7de7024362ad95bb8be93d6d6d21d7f6c1",
+      "name": "XGPU AI",
+      "symbol": "XGPU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37453/thumb/xgpu.png?1714448873"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f5373ae26c3e8ffc4c77b7255df7ec1a9af52a6",
+      "name": "Bridged Tether  Axelar ",
+      "symbol": "AXLUSDT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31002/thumb/uusdt_D_3x.png?1696529840"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9b06f3c5de42d4623d7a2bd940ec735103c68a76",
+      "name": "Volta Club",
+      "symbol": "VOLTA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31602/thumb/volta-200x200.png?1696530418"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7a5d193fe4ed9098f7eadc99797087c96b002907",
+      "name": "Plutus ARB",
+      "symbol": "PLSARB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30636/thumb/plsARB.png?1696529509"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbbea044f9e7c0520195e49ad1e561572e7e1b948",
+      "name": "Mizar",
+      "symbol": "MZR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23272/thumb/V1DTptkT_400x400.jpg?1696522492"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf42e2b8bc2af8b110b65be98db1321b1ab8d44f5",
+      "name": "Donut",
+      "symbol": "DONUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7538/thumb/Donut.png?1696507804"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe20b9e246db5a0d21bf9209e4858bc9a3ff7a034",
+      "name": "Wrapped Banano",
+      "symbol": "WBAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32617/thumb/WBAN.jpg?1698749253"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd1e094cabc5acb9d3b0599c3f76f2d01ff8d3563",
+      "name": "VirtuSwap",
+      "symbol": "VRSW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30629/thumb/VirtuSwap_Logo_Red_200x200.png?1696529502"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9d0c0675a995d5f12b03e880763f639d0628b5c6",
+      "name": "SuperWalk WALK",
+      "symbol": "WALK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37379/thumb/superwalk.jpeg?1714213441"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e0da40b9063dc48364c1c0ffb4ae9d091fc2270",
+      "name": "Edgeware",
+      "symbol": "EDG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8452/thumb/logo-edgeware.png?1696508638"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa3210cd727fe6daf8386af5623ba51a367e46263",
+      "name": "Basket",
+      "symbol": "BSKT",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/34661/thumb/BSKT_Logo.png?1705636891"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9500ba777560daf9d3ab148ea1cf1ed39df9ebdb",
+      "name": "STYLE Token",
+      "symbol": "STYLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37507/thumb/Token_Logo__STYLE.png?1729579902"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3ed03e95dd894235090b3d4a49e0c3239edce59e",
+      "name": "Blox MYRC",
+      "symbol": "MYRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38632/thumb/myrc-token-trans-200x200.png?1718172187"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x666966ef3925b1c92fa355fda9722899f3e73451",
+      "name": "Stable",
+      "symbol": "STABLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31148/thumb/stable_200.png?1696529976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb01cf1be9568f09449382a47cd5bf58e2a9d5922",
+      "name": "Lightspeed",
+      "symbol": "SPEED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51401/thumb/lightspeed-round-200.png?1731085512"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x180f7cf38805d1be95c7632f653e26b0838e2969",
+      "name": "XDEFI",
+      "symbol": "XDEFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19524/thumb/xdefi.jpg?1723436519"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd26b0c6ef8581e921ae41c66e508c62a581b709d",
+      "name": "Sexone",
+      "symbol": "SEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32135/thumb/IMG_20231004_163306_491.jpg?1696589011"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4727a7d2022e99ee5c298513b730307f458f9b40",
+      "name": "Guberto",
+      "symbol": "GUBERTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50787/thumb/guberto_%281%29.jpg?1729210166"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x284592a004d945f98de5b040808578c61a4bb39a",
+      "name": "AIR",
+      "symbol": "AIR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36113/thumb/Air_%28AIR%29_1.png?1710487829"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f850b0ab1988dd17b69ac564c1e2857949e4dee",
+      "name": "Lift Dollar",
+      "symbol": "USDL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38484/thumb/USDL-Token-200px.png?1725022887"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4d15a3a2286d883af0aa1b3f21367843fac63e07",
+      "name": "Bridged TrueUSD",
+      "symbol": "TUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30837/thumb/tusd.jpeg?1696529695"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4cfa50b7ce747e2d61724fcac57f24b748ff2b2a",
+      "name": "Fluid USDC",
+      "symbol": "FUSDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28471/thumb/fUSDC-200x200.png?1696527465"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd44257dde89ca53f1471582f718632e690e46dc2",
+      "name": "S",
+      "symbol": "S",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50350/thumb/s.jpg?1727249471"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0a3bb08b3a15a19b4de82f8acfc862606fb69a2d",
+      "name": "iZUMi Bond USD",
+      "symbol": "IUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25388/thumb/iusd-logo-symbol-10k%E5%A4%A7%E5%B0%8F.png?1696524521"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfb930d1a28990820c98144201637c99bea8cb91c",
+      "name": "Bumper",
+      "symbol": "BUMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17822/thumb/Bumper_-__Icon_-_256x256.png?1715280092"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x123389c2f0e9194d9ba98c21e63c375b67614108",
+      "name": "EthereumMax",
+      "symbol": "EMAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15540/thumb/EMAX-Coin-Final2000x.png?1696515181"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x30dcba0405004cf124045793e1933c798af9e66a",
+      "name": "Yieldification",
+      "symbol": "YDF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26699/thumb/logo.png?1696525772"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee",
+      "name": "Aave v3 DAI",
+      "symbol": "ADAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32886/thumb/dai.png?1699769446"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x17a8541b82bf67e10b0874284b4ae66858cb1fd5",
+      "name": "Possum",
+      "symbol": "PSM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33596/thumb/PSM.png?1702521046"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf80d589b3dbe130c270a69f1a69d050f268786df",
+      "name": "Datamine FLUX",
+      "symbol": "FLUX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11756/thumb/fluxres.png?1696511637"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf7693c6fd9a7172d537fa75d133d309501cbd657",
+      "name": "Web3 No Value",
+      "symbol": "W3N",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32083/thumb/WechatIMG718.jpg?1710596218"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3419875b4d3bca7f3fdda2db7a476a79fd31b4fe",
+      "name": "DizzyHavoc",
+      "symbol": "DZHV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35575/thumb/dizzyhavoc_circle_3_200_200_transparentBg.png?1709194317"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x07dd5beaffb65b8ff2e575d500bdf324a05295dc",
+      "name": "ArbiPad",
+      "symbol": "ARBI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30275/thumb/ARBI_Logo.png?1696529181"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x602eb0d99a5e3e76d1510372c4d2020e12eaea8a",
+      "name": "TridentDAO",
+      "symbol": "PSI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28955/thumb/trident.jpg?1696527928"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6cc5b1fb8c2fd7af1d2858f916f274b8faac82e1",
+      "name": "Ojamu",
+      "symbol": "OJA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18947/thumb/ojamu-icon-PNK.png?1696518402"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x352f4bf396a7353a0877f99e99757e5d294df374",
+      "name": "Sundae the Dog",
+      "symbol": "SUNDAE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32010/thumb/sundae.jpg?1696530808"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5a7a183b6b44dc4ec2e3d2ef43f98c5152b1d76d",
+      "name": "Inception Restaked ETH",
+      "symbol": "INETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34127/thumb/inETH.png?1715036464"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x96a993f06951b01430523d0d5590192d650ebf3e",
+      "name": "Revenue Generating USD",
+      "symbol": "RGUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38146/thumb/rgusd%28200_x_200_px%29.png?1716654569"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd5954c3084a1ccd70b4da011e67760b8e78aee84",
+      "name": "Arbidex",
+      "symbol": "ARX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29506/thumb/tokenlogo.png?1696528451"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x848e0ba28b637e8490d88bae51fa99c87116409b",
+      "name": "Agave",
+      "symbol": "AGVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14146/thumb/agve.png?1696513865"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf65247b6ed3e7fdbac313959b3f62475fbb5f8e4",
+      "name": "Brightpool Finance BRIX",
+      "symbol": "BRIX",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37446/thumb/IMAGE_2024-04-29_13_55_38.jpg?1714446963"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9ed7e4b1bff939ad473da5e7a218c771d1569456",
+      "name": "Reunit Wallet",
+      "symbol": "REUNI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29492/thumb/reunit_200.png?1696528436"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9f41b34f42058a7b74672055a5fae22c4b113fd1",
+      "name": "Yum",
+      "symbol": "YUM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39116/thumb/yum.png?1720590184"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb4bbfe92702730ef7f1d28e4b9e42381182f48a5",
+      "name": "Hold VIP",
+      "symbol": "HOLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30129/thumb/RteOSWQ__400x400.jpg?1696529050"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc72633f995e98ac3bb8a89e6a9c4af335c3d6e44",
+      "name": "Omnisea",
+      "symbol": "OSEA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26475/thumb/logo-06_%281%29.png?1728502928"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x76bc2e765414e6c8b596c0f52c4240f80268f41d",
+      "name": "Unibit",
+      "symbol": "UIBT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36911/thumb/Unibit.png?1712764033"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x57f5e098cad7a3d1eed53991d4d66c45c9af7812",
+      "name": "Wrapped USDM",
+      "symbol": "WUSDM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33785/thumb/wUSDM_PNG_240px.png?1702981552"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3106e2e148525b3db36795b04691d444c24972fb",
+      "name": "Wrapped Staked LINK",
+      "symbol": "WSTLINK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35678/thumb/wstlink_logo.png?1709525182"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x004626a008b1acdc4c74ab51644093b155e59a23",
+      "name": "Angle Staked EURA",
+      "symbol": "STEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32036/thumb/stEUR-x4.png?1696530832"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xed7f000ee335b8199b004cca1c6f36d188cf6cb8",
+      "name": "D2 Finance",
+      "symbol": "D2",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34914/thumb/D2_Token_Logo.png?1706610408"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5429706887fcb58a595677b73e9b0441c25d993d",
+      "name": "UniDex",
+      "symbol": "UNIDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13178/thumb/unidx.png?1696512961"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51318b7d00db7acc4026c88c3952b66278b6a67f",
+      "name": "PlutusDAO",
+      "symbol": "PLS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25326/thumb/M6nUndNU_400x400.jpg?1696524461"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2c650dab03a59332e2e0c0c4a7f726913e5028c1",
+      "name": "Tapioca DAO Token",
+      "symbol": "TAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38756/thumb/TAPP.png?1718729124"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xddf7d080c82b8048baae54e376a3406572429b4e",
+      "name": "GODDOG",
+      "symbol": "OOOOOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38157/thumb/Goddog_logo_for_Coingecko_200x200.png?1716669510"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8b5e4c9a188b1a187f2d1e80b1c2fb17fa2922e1",
+      "name": "GoldenBoys",
+      "symbol": "GOLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31353/thumb/goldenboys.png?1696530170"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4d22e37eb4d71d1acc5f4889a65936d2a44a2f15",
+      "name": "Hat",
+      "symbol": "HAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39394/thumb/Black_circle_%281%29.png?1721976884"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6688b00f0c23a4a546beaae51a7c90c439895d48",
+      "name": "Tarot V1",
+      "symbol": "TAROT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17881/thumb/tarot-200px.png?1696517403"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x47de40ec7aa115fbc1f7b99ca4effc46a113de9b",
+      "name": "ZAI Stablecoin",
+      "symbol": "USDZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39733/thumb/Group_4.png?1723771588"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4d01397994aa636bdcc65c9e8024bc497498c3bb",
+      "name": "Mchain Network",
+      "symbol": "MARK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37447/thumb/mchain.png?1714447037"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4568ca00299819998501914690d6010ae48a59ba",
+      "name": "Army of Fortune Metaverse",
+      "symbol": "AFC",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/32577/thumb/UI_Icon_Coin_Token_AFC_200x200.png?1698558434"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd7a892f28dedc74e6b7b33f93be08abfc394a360",
+      "name": "Crypto Index Pool",
+      "symbol": "CIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32504/thumb/photo_6176746894382970935_y_%281%29.jpg?1698313185"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7cb16cb78ea464ad35c8a50abf95dff3c9e09d5d",
+      "name": "0xBitcoin",
+      "symbol": "0XBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/4454/thumb/0xbtc.png?1696505045"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1b8d516e2146d7a32aca0fcbf9482db85fd42c3a",
+      "name": "AlphaScan AI",
+      "symbol": "ASCN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31180/thumb/AlphaScan_logo.jpg?1696530008"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf29fdf6b7bdffb025d7e6dfdf344992d2d16e249",
+      "name": "Genius X",
+      "symbol": "GENSX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/30904/thumb/GX_short_logo.png?1696529749"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf8388c2b6edf00e2e27eef5200b1befb24ce141d",
+      "name": "Nola",
+      "symbol": "NOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33708/thumb/nola.jpg?1702854587"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe934ab7e98d81e39477b1e47b961876c2d902598",
+      "name": "Nola",
+      "symbol": "NOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37420/thumb/NOLA.png?1714377065"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x66e535e8d2ebf13f49f3d49e5c50395a97c137b1",
+      "name": "Molten",
+      "symbol": "MOLTEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36726/thumb/moltenmesh.png?1712147407"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x59a729658e9245b0cf1f8cb9fb37945d2b06ea27",
+      "name": "GenomesDAO GENE",
+      "symbol": "GENE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20807/thumb/1637683704200x200.png?1696520200"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x21ccbc5e7f353ec43b2f5b1fb12c3e9d89d30dca",
+      "name": "BlackDragon",
+      "symbol": "BDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13426/thumb/Black-Dragon-Black.png?1696513186"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1824a51c106efc27d35a74efb56d9bf54ddb22d4",
+      "name": "Perpy Finance",
+      "symbol": "PRY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29525/thumb/perpy-icon-dark.png?1696528468"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9b3fa2a7c3eb36d048a5d38d81e7fafc6bc47b25",
+      "name": "Aluna",
+      "symbol": "ALN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14379/thumb/uaLoLU8c_400x400_%281%29.png?1696514071"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd3ac016b1b8c80eeadde4d186a9138c9324e4189",
+      "name": "Okcash",
+      "symbol": "OK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/274/thumb/ok-logo-200px.png?1696501624"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd08c3f25862077056cb1b710937576af899a4959",
+      "name": "Inception stETH",
+      "symbol": "INSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34954/thumb/Group_14.png?1706773546"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6aa395f06986ea4efe0a4630c7865c1eb08d5e7e",
+      "name": "Jarvis Reward",
+      "symbol": "JRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10390/thumb/cfeii0y.png?1696510389"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8ec1877698acf262fe8ad8a295ad94d6ea258988",
+      "name": "Davos xyz USD",
+      "symbol": "DUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28775/thumb/dusd_logo_200x200.png?1696527754"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xef888bca6ab6b1d26dbec977c455388ecd794794",
+      "name": "Rari Governance",
+      "symbol": "RGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1696512688"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x28514bd097d5f9ecea778cc7a4ca4bac5fedb0b6",
+      "name": "BOO",
+      "symbol": "BOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34234/thumb/boo_coin_%28200%29.png?1704306085"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x326c33fd1113c1f29b35b4407f3d6312a8518431",
+      "name": "Strips Finance",
+      "symbol": "STRP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18327/thumb/Logo-Strips-200-x-200px---without-words.png?1696517818"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa2f9ecf83a48b86265ff5fd36cdbaaa1f349916c",
+      "name": "Goons of Balatroon",
+      "symbol": "GOB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27104/thumb/TokenLogo200x200.png?1702250134"
+    }
+  ],
+  "timestamp": "2024-12-06T16:10:22.485Z"
+}

--- a/src/public/CoinGecko.42161.json
+++ b/src/public/CoinGecko.42161.json
@@ -16,7 +16,7 @@
       "name": "USDC",
       "symbol": "USDC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/6319/thumb/usdc.png?1696506694"
+      "logoURI": "https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696506694"
     },
     {
       "chainId": 42161,
@@ -24,7 +24,7 @@
       "name": "Pepe",
       "symbol": "PEPE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29850/thumb/pepe-token.jpeg?1696528776"
+      "logoURI": "https://assets.coingecko.com/coins/images/29850/large/pepe-token.jpeg?1696528776"
     },
     {
       "chainId": 42161,
@@ -32,7 +32,7 @@
       "name": "Chainlink",
       "symbol": "LINK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/877/thumb/chainlink-new-logo.png?1696502009"
+      "logoURI": "https://assets.coingecko.com/coins/images/877/large/chainlink-new-logo.png?1696502009"
     },
     {
       "chainId": 42161,
@@ -40,7 +40,7 @@
       "name": "Curve DAO",
       "symbol": "CRV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12124/thumb/Curve.png?1696511967"
+      "logoURI": "https://assets.coingecko.com/coins/images/12124/large/Curve.png?1696511967"
     },
     {
       "chainId": 42161,
@@ -48,7 +48,7 @@
       "name": "Uniswap",
       "symbol": "UNI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12504/thumb/uniswap-logo.png?1720676669"
+      "logoURI": "https://assets.coingecko.com/coins/images/12504/large/uniswap-logo.png?1720676669"
     },
     {
       "chainId": 42161,
@@ -56,7 +56,7 @@
       "name": "Arbitrum Bridged WETH  Arbitrum One ",
       "symbol": "WETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39713/thumb/WETH.PNG?1723731496"
+      "logoURI": "https://assets.coingecko.com/coins/images/39713/large/WETH.PNG?1723731496"
     },
     {
       "chainId": 42161,
@@ -64,7 +64,7 @@
       "name": "Arbitrum",
       "symbol": "ARB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16547/thumb/arb.jpg?1721358242"
+      "logoURI": "https://assets.coingecko.com/coins/images/16547/large/arb.jpg?1721358242"
     },
     {
       "chainId": 42161,
@@ -72,15 +72,7 @@
       "name": "Aave",
       "symbol": "AAVE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/aave-token-round.png?1720472354"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
-      "name": "LayerZero",
-      "symbol": "ZRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28206/thumb/ftxG9_TJ_400x400.jpeg?1696527208"
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/large/aave-token-round.png?1720472354"
     },
     {
       "chainId": 42161,
@@ -88,7 +80,15 @@
       "name": "Bonk",
       "symbol": "BONK",
       "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/28600/thumb/bonk.jpg?1696527587"
+      "logoURI": "https://assets.coingecko.com/coins/images/28600/large/bonk.jpg?1696527587"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "name": "LayerZero",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
     },
     {
       "chainId": 42161,
@@ -96,7 +96,7 @@
       "name": "Coinbase Wrapped BTC",
       "symbol": "CBBTC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/40143/thumb/cbbtc.webp?1726136727"
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
     },
     {
       "chainId": 42161,
@@ -104,15 +104,7 @@
       "name": "Livepeer",
       "symbol": "LPT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/badge-logo-circuit-green.png?1719357686"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
-      "name": "Arbitrum Bridged USDT  Arbitrum ",
-      "symbol": "USDT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35073/thumb/logo.png?1707292836"
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/large/badge-logo-circuit-green.png?1719357686"
     },
     {
       "chainId": 42161,
@@ -120,7 +112,15 @@
       "name": "Ether fi",
       "symbol": "ETHFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35958/thumb/etherfi.jpeg?1710254562"
+      "logoURI": "https://assets.coingecko.com/coins/images/35958/large/etherfi.jpeg?1710254562"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+      "name": "Arbitrum Bridged USDT  Arbitrum ",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35073/large/logo.png?1707292836"
     },
     {
       "chainId": 42161,
@@ -128,7 +128,7 @@
       "name": "Lido DAO",
       "symbol": "LDO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1696513326"
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1696513326"
     },
     {
       "chainId": 42161,
@@ -136,7 +136,7 @@
       "name": "The Graph",
       "symbol": "GRT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1696513159"
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/large/Graph_Token.png?1696513159"
     },
     {
       "chainId": 42161,
@@ -144,7 +144,7 @@
       "name": "Reserve Rights",
       "symbol": "RSR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8365/thumb/RSR_Blue_Circle_1000.png?1721777856"
+      "logoURI": "https://assets.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
     },
     {
       "chainId": 42161,
@@ -152,7 +152,7 @@
       "name": "Wormhole",
       "symbol": "W",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35087/thumb/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
+      "logoURI": "https://assets.coingecko.com/coins/images/35087/large/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
     },
     {
       "chainId": 42161,
@@ -160,7 +160,7 @@
       "name": "PancakeSwap",
       "symbol": "CAKE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12632/thumb/pancakeswap-cake-logo_%281%29.png?1696512440"
+      "logoURI": "https://assets.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
     },
     {
       "chainId": 42161,
@@ -168,7 +168,7 @@
       "name": "Compound",
       "symbol": "COMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10775/thumb/COMP.png?1696510737"
+      "logoURI": "https://assets.coingecko.com/coins/images/10775/large/COMP.png?1696510737"
     },
     {
       "chainId": 42161,
@@ -176,7 +176,7 @@
       "name": "Arbitrum Bridged WBTC  Arbitrum One ",
       "symbol": "WBTC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39532/thumb/wbtc.png?1722810336"
+      "logoURI": "https://assets.coingecko.com/coins/images/39532/large/wbtc.png?1722810336"
     },
     {
       "chainId": 42161,
@@ -184,7 +184,7 @@
       "name": "Pendle",
       "symbol": "PENDLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15069/thumb/Pendle_Logo_Normal-03.png?1696514728"
+      "logoURI": "https://assets.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
     },
     {
       "chainId": 42161,
@@ -192,7 +192,7 @@
       "name": "Across Protocol",
       "symbol": "ACX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28161/thumb/across-200x200.png?1696527165"
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
     },
     {
       "chainId": 42161,
@@ -200,7 +200,7 @@
       "name": "Sushi",
       "symbol": "SUSHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1696512101"
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/large/512x512_Logo_no_chop.png?1696512101"
     },
     {
       "chainId": 42161,
@@ -208,7 +208,7 @@
       "name": "Ankr Network",
       "symbol": "ANKR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1696504928"
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1696504928"
     },
     {
       "chainId": 42161,
@@ -216,7 +216,7 @@
       "name": "yearn finance",
       "symbol": "YFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yearn.jpg?1696511720"
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/large/yearn.jpg?1696511720"
     },
     {
       "chainId": 42161,
@@ -224,7 +224,7 @@
       "name": "Tellor Tributes",
       "symbol": "TRB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1696509713"
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/large/Blk_icon_current.png?1696509713"
     },
     {
       "chainId": 42161,
@@ -232,7 +232,7 @@
       "name": "Wrapped stETH",
       "symbol": "WSTETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18834/thumb/wstETH.png?1696518295"
+      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
     },
     {
       "chainId": 42161,
@@ -240,7 +240,7 @@
       "name": "Xai",
       "symbol": "XAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34258/thumb/round_icon_2048_px.png?1719523838"
+      "logoURI": "https://assets.coingecko.com/coins/images/34258/large/round_icon_2048_px.png?1719523838"
     },
     {
       "chainId": 42161,
@@ -248,7 +248,7 @@
       "name": "Loopring",
       "symbol": "LRC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/913/thumb/LRC.png?1696502034"
+      "logoURI": "https://assets.coingecko.com/coins/images/913/large/LRC.png?1696502034"
     },
     {
       "chainId": 42161,
@@ -256,7 +256,7 @@
       "name": "UXLINK",
       "symbol": "UXLINK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39229/thumb/uxlink.jpg?1721201390"
+      "logoURI": "https://assets.coingecko.com/coins/images/39229/large/uxlink.jpg?1721201390"
     },
     {
       "chainId": 42161,
@@ -264,7 +264,7 @@
       "name": "Degen  Base ",
       "symbol": "DEGEN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34515/thumb/android-chrome-512x512.png?1706198225"
+      "logoURI": "https://assets.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
     },
     {
       "chainId": 42161,
@@ -272,7 +272,7 @@
       "name": "Arbitrum Bridged USDC  Arbitrum ",
       "symbol": "USDCE",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/30691/thumb/usdc.png?1696529560"
+      "logoURI": "https://assets.coingecko.com/coins/images/30691/large/usdc.png?1696529560"
     },
     {
       "chainId": 42161,
@@ -280,7 +280,7 @@
       "name": "Aethir",
       "symbol": "ATH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36179/thumb/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
+      "logoURI": "https://assets.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
     },
     {
       "chainId": 42161,
@@ -288,7 +288,7 @@
       "name": "WOO",
       "symbol": "WOO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
     },
     {
       "chainId": 42161,
@@ -296,7 +296,7 @@
       "name": "Frax Share",
       "symbol": "FXS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/Frax_Shares_icon.png?1696513183"
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1696513183"
     },
     {
       "chainId": 42161,
@@ -304,15 +304,7 @@
       "name": "Stargate Finance",
       "symbol": "STG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1696523595"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfb9e5d956d889d91a82737b9bfcdac1dce3e1449",
-      "name": "Liquity",
-      "symbol": "LQTY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/logo_V2.png?1725437146"
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
     },
     {
       "chainId": 42161,
@@ -320,7 +312,7 @@
       "name": "Treasure",
       "symbol": "MAGIC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18623/thumb/magic.png?1696518095"
+      "logoURI": "https://assets.coingecko.com/coins/images/18623/large/magic.png?1696518095"
     },
     {
       "chainId": 42161,
@@ -328,7 +320,7 @@
       "name": "CARV",
       "symbol": "CARV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37689/thumb/CARV_%281%29.png?1728418485"
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
     },
     {
       "chainId": 42161,
@@ -336,7 +328,15 @@
       "name": "GMX",
       "symbol": "GMX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18323/thumb/arbit.png?1696517814"
+      "logoURI": "https://assets.coingecko.com/coins/images/18323/large/arbit.png?1696517814"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfb9e5d956d889d91a82737b9bfcdac1dce3e1449",
+      "name": "Liquity",
+      "symbol": "LQTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14665/large/logo_V2.png?1725437146"
     },
     {
       "chainId": 42161,
@@ -344,7 +344,7 @@
       "name": "Axelar",
       "symbol": "AXL",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/27277/thumb/V-65_xQ1_400x400.jpeg?1696526329"
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg?1696526329"
     },
     {
       "chainId": 42161,
@@ -352,7 +352,7 @@
       "name": "ApeX",
       "symbol": "APEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25266/thumb/CxpMECpk_400x400_%281%29.png?1696524406"
+      "logoURI": "https://assets.coingecko.com/coins/images/25266/large/CxpMECpk_400x400_%281%29.png?1696524406"
     },
     {
       "chainId": 42161,
@@ -360,7 +360,7 @@
       "name": "Marlin",
       "symbol": "POND",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/200x200.png?1706115827"
+      "logoURI": "https://assets.coingecko.com/coins/images/8903/large/200x200.png?1706115827"
     },
     {
       "chainId": 42161,
@@ -368,7 +368,7 @@
       "name": "CoW Protocol",
       "symbol": "COW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24384/thumb/CoW-token_logo.png?1719524382"
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
     },
     {
       "chainId": 42161,
@@ -376,7 +376,7 @@
       "name": "Radiant Capital",
       "symbol": "RDNT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26536/thumb/Radiant-Logo-200x200.png?1696525610"
+      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
     },
     {
       "chainId": 42161,
@@ -384,7 +384,7 @@
       "name": "Wrapped eETH",
       "symbol": "WEETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33033/thumb/weETH.png?1701438396"
+      "logoURI": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
     },
     {
       "chainId": 42161,
@@ -392,7 +392,7 @@
       "name": "Perpetual Protocol",
       "symbol": "PERP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
     },
     {
       "chainId": 42161,
@@ -400,7 +400,7 @@
       "name": "Spell",
       "symbol": "SPELL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1696515477"
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/large/abracadabra-3.png?1696515477"
     },
     {
       "chainId": 42161,
@@ -408,7 +408,7 @@
       "name": "Biconomy",
       "symbol": "BICO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1696520444"
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/large/biconomy_logo.jpg?1696520444"
     },
     {
       "chainId": 42161,
@@ -416,15 +416,7 @@
       "name": "Badger",
       "symbol": "BADGER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1696513059"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x69eb4fa4a2fbd498c257c57ea8b7655a2559a581",
-      "name": "DODO",
-      "symbol": "DODO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12651/thumb/dodo_logo.png?1696512458"
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1696513059"
     },
     {
       "chainId": 42161,
@@ -432,7 +424,15 @@
       "name": "Celer Network",
       "symbol": "CELR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1696504978"
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/large/Celr.png?1696504978"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x69eb4fa4a2fbd498c257c57ea8b7655a2559a581",
+      "name": "DODO",
+      "symbol": "DODO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12651/large/dodo_logo.png?1696512458"
     },
     {
       "chainId": 42161,
@@ -440,7 +440,7 @@
       "name": "Kyber Network Crystal",
       "symbol": "KNC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14899/thumb/RwdVsGcw_400x400.jpg?1696514562"
+      "logoURI": "https://assets.coingecko.com/coins/images/14899/large/RwdVsGcw_400x400.jpg?1696514562"
     },
     {
       "chainId": 42161,
@@ -448,7 +448,7 @@
       "name": "JOE",
       "symbol": "JOE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17569/thumb/LFJ_JOE_Logo.png?1727200941"
+      "logoURI": "https://assets.coingecko.com/coins/images/17569/large/LFJ_JOE_Logo.png?1727200941"
     },
     {
       "chainId": 42161,
@@ -456,7 +456,7 @@
       "name": "Mobox",
       "symbol": "MBOX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14751/thumb/mobox.PNG?1696514420"
+      "logoURI": "https://assets.coingecko.com/coins/images/14751/large/mobox.PNG?1696514420"
     },
     {
       "chainId": 42161,
@@ -464,7 +464,7 @@
       "name": "Cartesi",
       "symbol": "CTSI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/Cartesi_Logo.png?1696510982"
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
     },
     {
       "chainId": 42161,
@@ -472,7 +472,7 @@
       "name": "Orderly Network",
       "symbol": "ORDER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38501/thumb/Orderly_Network_Coingecko_200*200.png?1717751359"
+      "logoURI": "https://assets.coingecko.com/coins/images/38501/large/Orderly_Network_Coingecko_200*200.png?1717751359"
     },
     {
       "chainId": 42161,
@@ -480,7 +480,7 @@
       "name": "tBTC",
       "symbol": "TBTC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
     },
     {
       "chainId": 42161,
@@ -488,7 +488,7 @@
       "name": "Balancer",
       "symbol": "BAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1696511572"
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
     },
     {
       "chainId": 42161,
@@ -496,7 +496,7 @@
       "name": "Synapse",
       "symbol": "SYN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/synapse_social_icon.png?1696517540"
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/large/synapse_social_icon.png?1696517540"
     },
     {
       "chainId": 42161,
@@ -504,7 +504,7 @@
       "name": "Rocket Pool",
       "symbol": "RPL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2090/thumb/rocket_pool_%28RPL%29.png?1696503058"
+      "logoURI": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
     },
     {
       "chainId": 42161,
@@ -512,15 +512,7 @@
       "name": "Frax",
       "symbol": "FRAX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/FRAX_icon.png?1696513182"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x09e18590e8f76b6cf471b3cd75fe1a1a9d2b2c2b",
-      "name": "ArbDoge AI",
-      "symbol": "AIDOGE",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29852/thumb/photo_2023-04-18_14-25-28.jpg?1696528778"
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1696513182"
     },
     {
       "chainId": 42161,
@@ -528,7 +520,15 @@
       "name": "Orbs",
       "symbol": "ORBS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4630/thumb/Orbs.jpg?1696505200"
+      "logoURI": "https://assets.coingecko.com/coins/images/4630/large/Orbs.jpg?1696505200"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x09e18590e8f76b6cf471b3cd75fe1a1a9d2b2c2b",
+      "name": "ArbDoge AI",
+      "symbol": "AIDOGE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29852/large/photo_2023-04-18_14-25-28.jpg?1696528778"
     },
     {
       "chainId": 42161,
@@ -536,7 +536,7 @@
       "name": "Venus",
       "symbol": "XVS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12677/thumb/XVS_Token.jpg?1727454303"
+      "logoURI": "https://assets.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
     },
     {
       "chainId": 42161,
@@ -544,15 +544,7 @@
       "name": "Gnosis",
       "symbol": "GNO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/662/thumb/logo_square_simple_300px.png?1696501854"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
-      "name": "Axelar Bridged USDC",
-      "symbol": "AXLUSDC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/26476/thumb/uausdc_D_3x.png?1696525548"
+      "logoURI": "https://assets.coingecko.com/coins/images/662/large/logo_square_simple_300px.png?1696501854"
     },
     {
       "chainId": 42161,
@@ -560,7 +552,15 @@
       "name": "crvUSD",
       "symbol": "CRVUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30118/thumb/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/large/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
+      "name": "Axelar Bridged USDC",
+      "symbol": "AXLUSDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26476/large/uausdc_D_3x.png?1696525548"
     },
     {
       "chainId": 42161,
@@ -568,7 +568,7 @@
       "name": "Usual USD",
       "symbol": "USD0",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38272/thumb/USD0LOGO.png?1716962811"
+      "logoURI": "https://assets.coingecko.com/coins/images/38272/large/USD0LOGO.png?1716962811"
     },
     {
       "chainId": 42161,
@@ -576,15 +576,7 @@
       "name": "Coinbase Wrapped Staked ETH",
       "symbol": "CBETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27008/thumb/cbeth.png?1709186989"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
-      "name": "Renzo Restaked ETH",
-      "symbol": "EZETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34753/thumb/Ezeth_logo_circle.png?1713496404"
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1709186989"
     },
     {
       "chainId": 42161,
@@ -592,7 +584,7 @@
       "name": "Enzyme",
       "symbol": "MLN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/Enzyme_Icon_Secondary.png?1696501803"
+      "logoURI": "https://assets.coingecko.com/coins/images/605/large/Enzyme_Icon_Secondary.png?1696501803"
     },
     {
       "chainId": 42161,
@@ -600,7 +592,15 @@
       "name": "Telos",
       "symbol": "TLOS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7588/thumb/tlos_png.png?1722391289"
+      "logoURI": "https://assets.coingecko.com/coins/images/7588/large/tlos_png.png?1722391289"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
     },
     {
       "chainId": 42161,
@@ -608,7 +608,7 @@
       "name": "Gains Network",
       "symbol": "GNS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19737/thumb/logo.png?1696519161"
+      "logoURI": "https://assets.coingecko.com/coins/images/19737/large/logo.png?1696519161"
     },
     {
       "chainId": 42161,
@@ -616,7 +616,7 @@
       "name": "MakerDAO Arbitrum Bridged DAI  Arbitrum",
       "symbol": "DAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39790/thumb/dai.png?1724111653"
+      "logoURI": "https://assets.coingecko.com/coins/images/39790/large/dai.png?1724111653"
     },
     {
       "chainId": 42161,
@@ -624,63 +624,7 @@
       "name": "Milady Meme Coin",
       "symbol": "LADYS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30194/thumb/LADYS_Clean.png?1725897475"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x35e050d3c0ec2d29d269a8ecea763a183bdf9a9d",
-      "name": "Ondo US Dollar Yield",
-      "symbol": "USDY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31700/thumb/usdy_%281%29.png?1696530524"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xcaa38bcc8fb3077975bbe217acfaa449e6596a84",
-      "name": "DAO Maker",
-      "symbol": "DAO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13915/thumb/4.jpg?1727532864"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8",
-      "name": "Rocket Pool ETH",
-      "symbol": "RETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20764/thumb/reth.png?1696520159"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0d81e50bc677fa67341c44d7eaa9228dee64a4e1",
-      "name": "BarnBridge",
-      "symbol": "BOND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1696512604"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
-      "name": "Pocket Network",
-      "symbol": "POKT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/22506/thumb/POKT.jpg?1703257310"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7e7a7c916c19a45769f6bdaf91087f93c6c12f78",
-      "name": "Eigenpie",
-      "symbol": "EGP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37810/thumb/eigenpie.jpeg?1715597613"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf4d48ce3ee1ac3651998971541badbb9a14d7234",
-      "name": "Cream",
-      "symbol": "CREAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11976/thumb/Cream.png?1696511834"
+      "logoURI": "https://assets.coingecko.com/coins/images/30194/large/LADYS_Clean.png?1725897475"
     },
     {
       "chainId": 42161,
@@ -688,7 +632,55 @@
       "name": "Solv Protocol SolvBTC",
       "symbol": "SOLVBTC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36800/thumb/solvBTC.png?1719810684"
+      "logoURI": "https://assets.coingecko.com/coins/images/36800/large/solvBTC.png?1719810684"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35e050d3c0ec2d29d269a8ecea763a183bdf9a9d",
+      "name": "Ondo US Dollar Yield",
+      "symbol": "USDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31700/large/usdy_%281%29.png?1696530524"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcaa38bcc8fb3077975bbe217acfaa449e6596a84",
+      "name": "DAO Maker",
+      "symbol": "DAO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13915/large/4.jpg?1727532864"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0d81e50bc677fa67341c44d7eaa9228dee64a4e1",
+      "name": "BarnBridge",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/large/barnbridge.jpg?1696512604"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
+      "name": "Pocket Network",
+      "symbol": "POKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7e7a7c916c19a45769f6bdaf91087f93c6c12f78",
+      "name": "Eigenpie",
+      "symbol": "EGP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37810/large/eigenpie.jpeg?1715597613"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf4d48ce3ee1ac3651998971541badbb9a14d7234",
+      "name": "Cream",
+      "symbol": "CREAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11976/large/Cream.png?1696511834"
     },
     {
       "chainId": 42161,
@@ -696,7 +688,7 @@
       "name": "World Mobile Token",
       "symbol": "WMTX",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17333/thumb/1000097112.png?1727698144"
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
     },
     {
       "chainId": 42161,
@@ -704,143 +696,7 @@
       "name": "Empyreal",
       "symbol": "EMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31374/thumb/logomainblacktransparent.png?1719953450"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
-      "name": "Port3 Network",
-      "symbol": "PORT3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33383/thumb/port3-bc-200x200.png?1710075114"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdadeca1167fe47499e53eb50f261103630974905",
-      "name": "Neuron",
-      "symbol": "NRN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38838/thumb/Nrn_with_gradient_-NEW_TO_BE_UPDATED.png?1728551601"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
-      "name": "Bridged USDe",
-      "symbol": "USDE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39962/thumb/usde.png?1724952425"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
-      "name": "OX Coin",
-      "symbol": "OX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35365/thumb/9.png?1727331352"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa23e44aea714fbbc08ef28340d78067b9a8cad73",
-      "name": "Lybra",
-      "symbol": "LBR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29958/thumb/New_LBR_V2.png?1696528884"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6a9896837021ea3ed83f623f655c119c54abe02c",
-      "name": "ChainBounty",
-      "symbol": "BOUNTY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3369/thumb/Chainbounty_logomark_256px.png?1731462528"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6a7661795c374c0bfc635934efaddff3a7ee23b6",
-      "name": "DOLA",
-      "symbol": "DOLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14287/thumb/dola.png?1696513984"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
-      "name": "Ignition FBTC",
-      "symbol": "FBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39182/thumb/FBTC_LOGO.png?1720850455"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x386601d1e55c48e759bbf57c56015aad0d7f1b56",
-      "name": "Worldwide USD",
-      "symbol": "WUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35358/thumb/WUSD%282%29.png?1715042139"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xae6aab43c4f3e0cea4ab83752c278f8debaba689",
-      "name": "dForce",
-      "symbol": "DF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9709/thumb/xlGxxIjI_400x400.jpg?1696509776"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x5575552988a3a80504bbaeb1311674fcfd40ad4b",
-      "name": "Sperax",
-      "symbol": "SPA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12232/thumb/sperax_logo.jpg?1696512065"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbc011a12da28e8f0f528d9ee5e7039e22f91cf18",
-      "name": "Swell Ethereum",
-      "symbol": "SWETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30326/thumb/_lB7zEtS_400x400.jpg?1696529227"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2b65f9d2e4b84a2df6ff0525741b75d1276a9c2f",
-      "name": "Staked USD0",
-      "symbol": "USD0++",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39169/thumb/0x35d8949372d46b7a3d5a56006ae77b215fc69bc0.png?1720798057"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x560363bda52bc6a44ca6c8c9b4a5fadbda32fa60",
-      "name": "Seedify fund",
-      "symbol": "SFUND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14614/thumb/Favicon_Icon.png?1696514292"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x221c5799209132766a01c4cbed0d28600d282b41",
-      "name": "Bitrium",
-      "symbol": "BTRM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39118/thumb/20240709-160716.png?1720593799"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3088e120b220e67a2e092f5da8cdf02ea0170f6a",
-      "name": "Finanx AI",
-      "symbol": "FNXAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51119/thumb/200x200.png?1730126766"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x680447595e8b7b3aa1b43beb9f6098c79ac2ab3f",
-      "name": "USDD",
-      "symbol": "USDD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25380/thumb/UUSD.jpg?1696524513"
+      "logoURI": "https://assets.coingecko.com/coins/images/31374/large/logomainblacktransparent.png?1719953450"
     },
     {
       "chainId": 42161,
@@ -848,119 +704,135 @@
       "name": "Frax Ether",
       "symbol": "FRXETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28284/thumb/frxETH_icon.png?1696527284"
+      "logoURI": "https://assets.coingecko.com/coins/images/28284/large/frxETH_icon.png?1696527284"
     },
     {
       "chainId": 42161,
-      "address": "0x7dff72693f6a4149b17e7c6314655f6a9f7c8b33",
-      "name": "GHO",
-      "symbol": "GHO",
+      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
+      "name": "Port3 Network",
+      "symbol": "PORT3",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30663/thumb/gho-token-logo.png?1720517092"
+      "logoURI": "https://assets.coingecko.com/coins/images/33383/large/port3-bc-200x200.png?1710075114"
     },
     {
       "chainId": 42161,
-      "address": "0x0c5fa0e07949f941a6c2c29a008252db1527d6ee",
-      "name": "Opulous",
-      "symbol": "OPUL",
+      "address": "0xdadeca1167fe47499e53eb50f261103630974905",
+      "name": "Neuron",
+      "symbol": "NRN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16548/thumb/opulous.PNG?1696516110"
+      "logoURI": "https://assets.coingecko.com/coins/images/38838/large/Nrn_with_gradient_-NEW_TO_BE_UPDATED.png?1728551601"
     },
     {
       "chainId": 42161,
-      "address": "0xb0ecc6ac0073c063dcfc026ccdc9039cae2998e1",
-      "name": "A3S",
-      "symbol": "AA",
+      "address": "0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8",
+      "name": "Rocket Pool ETH",
+      "symbol": "RETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32133/thumb/A3S.jpg?1696588511"
+      "logoURI": "https://assets.coingecko.com/coins/images/20764/large/reth.png?1696520159"
     },
     {
       "chainId": 42161,
-      "address": "0x95146881b86b3ee99e63705ec87afe29fcc044d9",
-      "name": "Vertex",
-      "symbol": "VRTX",
+      "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+      "name": "Bridged USDe",
+      "symbol": "USDE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27927/thumb/vrtx.png?1696526947"
+      "logoURI": "https://assets.coingecko.com/coins/images/39962/large/usde.png?1724952425"
     },
     {
       "chainId": 42161,
-      "address": "0x99f40b01ba9c469193b360f72740e416b17ac332",
-      "name": "MATH",
-      "symbol": "MATH",
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1696511257"
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
     },
     {
       "chainId": 42161,
-      "address": "0xabd587f2607542723b17f14d00d99b987c29b074",
-      "name": "SmarDex",
-      "symbol": "SDEX",
+      "address": "0x6a9896837021ea3ed83f623f655c119c54abe02c",
+      "name": "ChainBounty",
+      "symbol": "BOUNTY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29470/thumb/SDEX_logo_transparent_outside_240x240.png?1696930070"
+      "logoURI": "https://assets.coingecko.com/coins/images/3369/large/Chainbounty_logomark_256px.png?1731462528"
     },
     {
       "chainId": 42161,
-      "address": "0x59062301fb510f4ea2417b67404cb16d31e604ba",
-      "name": "LogX Network",
-      "symbol": "LOGX",
+      "address": "0xa23e44aea714fbbc08ef28340d78067b9a8cad73",
+      "name": "Lybra",
+      "symbol": "LBR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50226/thumb/Token_200px.png?1726556358"
+      "logoURI": "https://assets.coingecko.com/coins/images/29958/large/New_LBR_V2.png?1696528884"
     },
     {
       "chainId": 42161,
-      "address": "0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8",
-      "name": "Everclear",
-      "symbol": "NEXT",
+      "address": "0x6a7661795c374c0bfc635934efaddff3a7ee23b6",
+      "name": "DOLA",
+      "symbol": "DOLA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31293/thumb/photo_2024-06-03_12-14-59.png?1717638614"
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
     },
     {
       "chainId": 42161,
-      "address": "0x4425742f1ec8d98779690b5a3a6276db85ddc01a",
-      "name": "Own The Doge",
-      "symbol": "DOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18111/thumb/Doge.png?1696517615"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x93b346b6bc2548da6a1e7d98e9a421b42541425b",
-      "name": "Liquity USD",
-      "symbol": "LUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1696514341"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2172fad929e857ddfd7ddc31e24904438434cb0b",
-      "name": "Babypie Wrapped BTC",
-      "symbol": "MBTC",
+      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
+      "name": "Ignition FBTC",
+      "symbol": "FBTC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/50314/thumb/mbtc_%281%29.png?1727079604"
+      "logoURI": "https://assets.coingecko.com/coins/images/39182/large/FBTC_LOGO.png?1720850455"
     },
     {
       "chainId": 42161,
-      "address": "0x80137510979822322193fc997d400d5a6c747bf7",
-      "name": "StakeStone ETH",
-      "symbol": "STONE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33103/thumb/200_200.png?1702602672"
+      "address": "0x386601d1e55c48e759bbf57c56015aad0d7f1b56",
+      "name": "Worldwide USD",
+      "symbol": "WUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
     },
     {
       "chainId": 42161,
-      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
-      "name": "Mountain Protocol USD",
-      "symbol": "USDM",
+      "address": "0xae6aab43c4f3e0cea4ab83752c278f8debaba689",
+      "name": "dForce",
+      "symbol": "DF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31719/thumb/usdm.png?1696530540"
+      "logoURI": "https://assets.coingecko.com/coins/images/9709/large/xlGxxIjI_400x400.jpg?1696509776"
     },
     {
       "chainId": 42161,
-      "address": "0x9dce8e754913d928eb39bc4fc3cf047e364f7f2c",
-      "name": "Bloktopia",
-      "symbol": "BLOK",
+      "address": "0x5575552988a3a80504bbaeb1311674fcfd40ad4b",
+      "name": "Sperax",
+      "symbol": "SPA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18819/thumb/logo-bholdus-6.png?1696518281"
+      "logoURI": "https://assets.coingecko.com/coins/images/12232/large/sperax_logo.jpg?1696512065"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbc011a12da28e8f0f528d9ee5e7039e22f91cf18",
+      "name": "Swell Ethereum",
+      "symbol": "SWETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30326/large/_lB7zEtS_400x400.jpg?1696529227"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2b65f9d2e4b84a2df6ff0525741b75d1276a9c2f",
+      "name": "Staked USD0",
+      "symbol": "USD0++",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39169/large/0x35d8949372d46b7a3d5a56006ae77b215fc69bc0.png?1720798057"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x560363bda52bc6a44ca6c8c9b4a5fadbda32fa60",
+      "name": "Seedify fund",
+      "symbol": "SFUND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14614/large/Favicon_Icon.png?1696514292"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x221c5799209132766a01c4cbed0d28600d282b41",
+      "name": "Bitrium",
+      "symbol": "BTRM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39118/large/20240709-160716.png?1720593799"
     },
     {
       "chainId": 42161,
@@ -968,151 +840,47 @@
       "name": "Dream Machine Token",
       "symbol": "DMT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30505/thumb/dmt.png?1696529391"
+      "logoURI": "https://assets.coingecko.com/coins/images/30505/large/dmt.png?1696529391"
     },
     {
       "chainId": 42161,
-      "address": "0xf525e73bdeb4ac1b0e741af3ed8a8cbb43ab0756",
-      "name": "KiboShib",
-      "symbol": "KIBSHI",
+      "address": "0x3088e120b220e67a2e092f5da8cdf02ea0170f6a",
+      "name": "Finanx AI",
+      "symbol": "FNXAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29335/thumb/foto_no_exif_%2811%29%282%29_%281%29.png?1696528285"
+      "logoURI": "https://assets.coingecko.com/coins/images/51119/large/200x200.png?1730126766"
     },
     {
       "chainId": 42161,
-      "address": "0x12275dcb9048680c4be40942ea4d92c74c63b844",
-      "name": "Electronic USD",
-      "symbol": "EUSD",
+      "address": "0x0c5fa0e07949f941a6c2c29a008252db1527d6ee",
+      "name": "Opulous",
+      "symbol": "OPUL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28445/thumb/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
+      "logoURI": "https://assets.coingecko.com/coins/images/16548/large/opulous.PNG?1696516110"
     },
     {
       "chainId": 42161,
-      "address": "0xd74f5255d557944cf7dd0e45ff521520002d5748",
-      "name": "Sperax USD",
-      "symbol": "USDS",
+      "address": "0x7dff72693f6a4149b17e7c6314655f6a9f7c8b33",
+      "name": "GHO",
+      "symbol": "GHO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21973/thumb/USDs_logo_1000X1000.png?1696521321"
+      "logoURI": "https://assets.coingecko.com/coins/images/30663/large/gho-token-logo.png?1720517092"
     },
     {
       "chainId": 42161,
-      "address": "0x3d9907f9a368ad0a51be60f7da3b97cf940982d8",
-      "name": "Camelot Token",
-      "symbol": "GRAIL",
+      "address": "0x680447595e8b7b3aa1b43beb9f6098c79ac2ab3f",
+      "name": "USDD",
+      "symbol": "USDD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28416/thumb/vj5DIMhP_400x400.jpeg?1696527414"
+      "logoURI": "https://assets.coingecko.com/coins/images/25380/large/UUSD.jpg?1696524513"
     },
     {
       "chainId": 42161,
-      "address": "0x06e90a57d1ece8752d6ce92d1ad348ead5eae4f4",
-      "name": "Real Smurf Cat",
-      "symbol": "SMURFCAT",
+      "address": "0xb0ecc6ac0073c063dcfc026ccdc9039cae2998e1",
+      "name": "A3S",
+      "symbol": "AA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31751/thumb/SMURFCAT.png?1708079642"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd56734d7f9979dd94fae3d67c7e928234e71cd4c",
-      "name": "Bridged TIA  Hyperlane ",
-      "symbol": "TIAN",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/33199/thumb/tia.n.png?1701047832"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x346c574c56e1a4aaa8dc88cda8f7eb12b39947ab",
-      "name": "Solv Protocol SolvBTC BBN",
-      "symbol": "SOLVBTCBBN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39384/thumb/unnamed.png?1721961640"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe22c452bd2ade15dfc8ad98286bc6bdf0c9219b7",
-      "name": "Polytrade",
-      "symbol": "TRADE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16416/thumb/Logo_colored_200.png?1696516012"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x94fcd9c18f99538c0f7c61c5500ca79f0d5c4dab",
-      "name": "Kima Network",
-      "symbol": "KIMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50764/thumb/K-logo-01.png?1729053099"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
-      "name": "PAW",
-      "symbol": "PAW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28946/thumb/PawLogo.png?1699394612"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x580e933d90091b9ce380740e3a4a39c67eb85b4c",
-      "name": "GameSwift",
-      "symbol": "GSWIFT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30949/thumb/GameSwift_Token.png?1696529788"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3124678d62d2aa1f615b54525310fbfda6dcf7ae",
-      "name": "Sensay",
-      "symbol": "SNSY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36121/thumb/sensay.jpeg?1710495398"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6b021b3f68491974be6d4009fee61a4e3c708fd6",
-      "name": "Fuse",
-      "symbol": "FUSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10347/thumb/fuse.png?1696510348"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x11bf4f05eb28b802ed3ab672594decb20ffe2313",
-      "name": "Aurory",
-      "symbol": "AURY",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/19324/thumb/Ico_Blanc_%281%29.png?1713464485"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe80772eaf6e2e18b651f160bc9158b2a5cafca65",
-      "name": "Overnight fi USD   Arbitrum One ",
-      "symbol": "USD+",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39630/thumb/usd_plus.png?1723181710"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x88a269df8fe7f53e590c561954c52fccc8ec0cfb",
-      "name": "Ninja Squad Token",
-      "symbol": "NST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22248/thumb/nst-logo-200x200.png?1711559985"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9e758b8a98a42d612b3d38b66a22074dc03d7370",
-      "name": "Symbiosis",
-      "symbol": "SIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20805/thumb/SymbiosisFinance_logo-150x150.jpeg?1696520198"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x95ab45875cffdba1e5f451b950bc2e42c0053f39",
-      "name": "Staked Frax Ether",
-      "symbol": "SFRXETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28285/thumb/sfrxETH_icon.png?1696527285"
+      "logoURI": "https://assets.coingecko.com/coins/images/32133/large/A3S.jpg?1696588511"
     },
     {
       "chainId": 42161,
@@ -1120,135 +888,215 @@
       "name": "ZTX",
       "symbol": "ZTX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32340/thumb/CoinGecko_200_x_200.jpg?1697466589"
+      "logoURI": "https://assets.coingecko.com/coins/images/32340/large/CoinGecko_200_x_200.jpg?1697466589"
     },
     {
       "chainId": 42161,
-      "address": "0x93fa0b88c0c78e45980fa74cdd87469311b7b3e4",
-      "name": "XBorg",
-      "symbol": "XBG",
+      "address": "0x95146881b86b3ee99e63705ec87afe29fcc044d9",
+      "name": "Vertex",
+      "symbol": "VRTX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39830/thumb/XBorg_Logo.png?1724209192"
+      "logoURI": "https://assets.coingecko.com/coins/images/27927/large/vrtx.png?1696526947"
     },
     {
       "chainId": 42161,
-      "address": "0xd77b108d4f6cefaa0cae9506a934e825becca46e",
-      "name": "WINR Protocol",
-      "symbol": "WINR",
+      "address": "0x99f40b01ba9c469193b360f72740e416b17ac332",
+      "name": "MATH",
+      "symbol": "MATH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29340/thumb/WINR.png?1696528290"
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/large/2020-05-19-token-200.png?1696511257"
     },
     {
       "chainId": 42161,
-      "address": "0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca",
-      "name": "Kujira",
-      "symbol": "KUJI",
+      "address": "0xabd587f2607542723b17f14d00d99b987c29b074",
+      "name": "SmarDex",
+      "symbol": "SDEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29470/large/SDEX_logo_transparent_outside_240x240.png?1696930070"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8",
+      "name": "Everclear",
+      "symbol": "NEXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31293/large/photo_2024-06-03_12-14-59.png?1717638614"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x59062301fb510f4ea2417b67404cb16d31e604ba",
+      "name": "LogX Network",
+      "symbol": "LOGX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50226/large/Token_200px.png?1726556358"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4425742f1ec8d98779690b5a3a6276db85ddc01a",
+      "name": "Own The Doge",
+      "symbol": "DOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18111/large/Doge.png?1696517615"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2172fad929e857ddfd7ddc31e24904438434cb0b",
+      "name": "Babypie Wrapped BTC",
+      "symbol": "MBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/50314/large/mbtc_%281%29.png?1727079604"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x93b346b6bc2548da6a1e7d98e9a421b42541425b",
+      "name": "Liquity USD",
+      "symbol": "LUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1696514341"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x12275dcb9048680c4be40942ea4d92c74c63b844",
+      "name": "Electronic USD",
+      "symbol": "EUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28445/large/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x80137510979822322193fc997d400d5a6c747bf7",
+      "name": "StakeStone ETH",
+      "symbol": "STONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33103/large/200_200.png?1702602672"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+      "name": "Mountain Protocol USD",
+      "symbol": "USDM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31719/large/usdm.png?1696530540"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9dce8e754913d928eb39bc4fc3cf047e364f7f2c",
+      "name": "Bloktopia",
+      "symbol": "BLOK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18819/large/logo-bholdus-6.png?1696518281"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf525e73bdeb4ac1b0e741af3ed8a8cbb43ab0756",
+      "name": "KiboShib",
+      "symbol": "KIBSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29335/large/foto_no_exif_%2811%29%282%29_%281%29.png?1696528285"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd74f5255d557944cf7dd0e45ff521520002d5748",
+      "name": "Sperax USD",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21973/large/USDs_logo_1000X1000.png?1696521321"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3d9907f9a368ad0a51be60f7da3b97cf940982d8",
+      "name": "Camelot Token",
+      "symbol": "GRAIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28416/large/vj5DIMhP_400x400.jpeg?1696527414"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd56734d7f9979dd94fae3d67c7e928234e71cd4c",
+      "name": "Bridged TIA  Hyperlane ",
+      "symbol": "TIAN",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/20685/thumb/kuji-200x200.png?1696520085"
+      "logoURI": "https://assets.coingecko.com/coins/images/33199/large/tia.n.png?1701047832"
     },
     {
       "chainId": 42161,
-      "address": "0xf0cb2dc0db5e6c66b9a70ac27b06b878da017028",
-      "name": "Olympus",
-      "symbol": "OHM",
+      "address": "0x06e90a57d1ece8752d6ce92d1ad348ead5eae4f4",
+      "name": "Real Smurf Cat",
+      "symbol": "SMURFCAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31751/large/SMURFCAT.png?1708079642"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x346c574c56e1a4aaa8dc88cda8f7eb12b39947ab",
+      "name": "Solv Protocol SolvBTC BBN",
+      "symbol": "SOLVBTCBBN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39384/large/unnamed.png?1721961640"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe22c452bd2ade15dfc8ad98286bc6bdf0c9219b7",
+      "name": "Polytrade",
+      "symbol": "TRADE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16416/large/Logo_colored_200.png?1696516012"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
+      "name": "PAW",
+      "symbol": "PAW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28946/large/PawLogo.png?1699394612"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x580e933d90091b9ce380740e3a4a39c67eb85b4c",
+      "name": "GameSwift",
+      "symbol": "GSWIFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30949/large/GameSwift_Token.png?1696529788"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3124678d62d2aa1f615b54525310fbfda6dcf7ae",
+      "name": "Sensay",
+      "symbol": "SNSY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36121/large/sensay.jpeg?1710495398"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6b021b3f68491974be6d4009fee61a4e3c708fd6",
+      "name": "Fuse",
+      "symbol": "FUSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x94fcd9c18f99538c0f7c61c5500ca79f0d5c4dab",
+      "name": "Kima Network",
+      "symbol": "KIMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50764/large/K-logo-01.png?1729053099"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11bf4f05eb28b802ed3ab672594decb20ffe2313",
+      "name": "Aurory",
+      "symbol": "AURY",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/14483/thumb/token_OHM_%281%29.png?1696514169"
+      "logoURI": "https://assets.coingecko.com/coins/images/19324/large/Ico_Blanc_%281%29.png?1713464485"
     },
     {
       "chainId": 42161,
-      "address": "0x7be5dd337cc6ce3e474f64e2a92a566445290864",
-      "name": "OpenLeverage",
-      "symbol": "OLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26098/thumb/256x256_OLE_Token_Logo.png?1696525189"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf929de51d91c77e42f5090069e0ad7a09e513c73",
-      "name": "ShapeShift FOX",
-      "symbol": "FOX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/fox_token.png?1728373561"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa5312c3e42a82d459162b2a3bd7ffc4f9099b911",
-      "name": "GALAXIS Token",
-      "symbol": "GALAXIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36221/thumb/500x500.png?1714755244"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x00cbcf7b3d37844e44b888bc747bdd75fcf4e555",
-      "name": "xPet tech",
-      "symbol": "XPET",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33553/thumb/xpet_token.jpeg?1702428894"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb08d8becab1bf76a9ce3d2d5fa946f65ec1d3e83",
-      "name": "GammaSwap",
-      "symbol": "GS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29222/thumb/newLogo2.png?1731702645"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x046029f68b0e00ebec2e394d17f70ec848fcf1d2",
-      "name": "Stable com USD3",
-      "symbol": "USD3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39865/thumb/2024-04-stable_com-usd3_coin.png?1724379520"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x619c82392cb6e41778b7d088860fea8447941f4c",
-      "name": "Army of Fortune Gem",
-      "symbol": "AFG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35084/thumb/Token_GEM_AOFVERSE.png?1707317138"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe10d4a4255d2d35c9e23e2c4790e073046fbaf5c",
-      "name": "LandX Governance Token",
-      "symbol": "LNDX",
+      "address": "0xe80772eaf6e2e18b651f160bc9158b2a5cafca65",
+      "name": "Overnight fi USD   Arbitrum One ",
+      "symbol": "USD+",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/33565/thumb/LNDX-200.png?1702445947"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3b58a4c865b568a2f6a957c264f6b50cba35d8ce",
-      "name": "SuperWalk GRND",
-      "symbol": "GRND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27186/thumb/GRND_3x.png?1696526235"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc760f9782f8cea5b06d862574464729537159966",
-      "name": "Contango",
-      "symbol": "TANGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50721/thumb/400x400_-_Tango_%281%29.png?1729251498"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc24a365a870821eb83fd216c9596edd89479d8d7",
-      "name": "GAM3S GG",
-      "symbol": "G3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35662/thumb/G3_logo.jpg?1709454143"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd6cf874e24a9f5f43075142101a6b13735cdd424",
-      "name": "CoinbarPay",
-      "symbol": "CBPAY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38794/thumb/cbpay-icon_resized2.png?1729148991"
+      "logoURI": "https://assets.coingecko.com/coins/images/39630/large/usd_plus.png?1723181710"
     },
     {
       "chainId": 42161,
@@ -1256,87 +1104,159 @@
       "name": "KelpDAO Bridged rsETH  Arbitrum ",
       "symbol": "RSETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39543/thumb/rseth.png?1722849891"
+      "logoURI": "https://assets.coingecko.com/coins/images/39543/large/rseth.png?1722849891"
     },
     {
       "chainId": 42161,
-      "address": "0xca4e51f6ad4afd9d1068e5899de9dd7d73f3463d",
-      "name": "Aark Digital",
-      "symbol": "AARK",
+      "address": "0x88a269df8fe7f53e590c561954c52fccc8ec0cfb",
+      "name": "Ninja Squad Token",
+      "symbol": "NST",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37813/thumb/aark.png?1715599394"
+      "logoURI": "https://assets.coingecko.com/coins/images/22248/large/nst-logo-200x200.png?1711559985"
     },
     {
       "chainId": 42161,
-      "address": "0x7b5eb3940021ec0e8e463d5dbb4b7b09a89ddf96",
-      "name": "Wombat Exchange",
-      "symbol": "WOM",
+      "address": "0x9e758b8a98a42d612b3d38b66a22074dc03d7370",
+      "name": "Symbiosis",
+      "symbol": "SIS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26946/thumb/Wombat_Token.png?1696526001"
+      "logoURI": "https://assets.coingecko.com/coins/images/20805/large/SymbiosisFinance_logo-150x150.jpeg?1696520198"
     },
     {
       "chainId": 42161,
-      "address": "0x24ef78c7092d255ed14a0281ac1800c359af3afe",
-      "name": "Rabbit Wallet",
-      "symbol": "RAB",
+      "address": "0x95ab45875cffdba1e5f451b950bc2e42c0053f39",
+      "name": "Staked Frax Ether",
+      "symbol": "SFRXETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29433/thumb/200x200.png?1696528381"
+      "logoURI": "https://assets.coingecko.com/coins/images/28285/large/sfrxETH_icon.png?1696527285"
     },
     {
       "chainId": 42161,
-      "address": "0xacc51ffdef63fb0c014c882267c3a17261a5ed50",
-      "name": "Stryke",
-      "symbol": "SYK",
+      "address": "0x93fa0b88c0c78e45980fa74cdd87469311b7b3e4",
+      "name": "XBorg",
+      "symbol": "XBG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36531/thumb/stryke.jpeg?1711704094"
+      "logoURI": "https://assets.coingecko.com/coins/images/39830/large/XBorg_Logo.png?1724209192"
     },
     {
       "chainId": 42161,
-      "address": "0x050c24dbf1eec17babe5fc585f06116a259cc77a",
-      "name": "dlcBTC",
-      "symbol": "DLCBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/37289/thumb/dlcBTC_ico_200px.png?1713946623"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
-      "name": "Osaka Protocol",
-      "symbol": "OSAK",
+      "address": "0xd77b108d4f6cefaa0cae9506a934e825becca46e",
+      "name": "WINR Protocol",
+      "symbol": "WINR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30911/thumb/OSAK_LOGO_200x200.png?1723662197"
+      "logoURI": "https://assets.coingecko.com/coins/images/29340/large/WINR.png?1696528290"
     },
     {
       "chainId": 42161,
-      "address": "0x2680e82fb8beb5a153a67fe687ffa67abb6b9013",
-      "name": "Swarm Markets",
-      "symbol": "SMT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17488/thumb/swarm-SMT-token-symbol_200x200.png?1696517029"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfa296fca3c7dba4a92a42ec0b5e2138da3b29050",
-      "name": "AiShiba",
-      "symbol": "SHIBAI",
+      "address": "0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca",
+      "name": "Kujira",
+      "symbol": "KUJI",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29898/thumb/Fotor_AI%EF%BC%882%EF%BC%89.png?1696528822"
+      "logoURI": "https://assets.coingecko.com/coins/images/20685/large/kuji-200x200.png?1696520085"
     },
     {
       "chainId": 42161,
-      "address": "0xa4f63404b58c3efd9db6d53352bd386ffa174e5a",
-      "name": "Miracle Play",
-      "symbol": "MPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32653/thumb/MPT.png?1698895300"
+      "address": "0xf0cb2dc0db5e6c66b9a70ac27b06b878da017028",
+      "name": "Olympus",
+      "symbol": "OHM",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/14483/large/token_OHM_%281%29.png?1696514169"
     },
     {
       "chainId": 42161,
-      "address": "0xe0ee18eacafddaeb38f8907c74347c44385578ab",
-      "name": "AxonDAO Governance Token",
-      "symbol": "AXGT",
+      "address": "0xf929de51d91c77e42f5090069e0ad7a09e513c73",
+      "name": "ShapeShift FOX",
+      "symbol": "FOX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35290/thumb/AXGT-logo-7.png?1708076161"
+      "logoURI": "https://assets.coingecko.com/coins/images/9988/large/fox_token.png?1728373561"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7be5dd337cc6ce3e474f64e2a92a566445290864",
+      "name": "OpenLeverage",
+      "symbol": "OLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26098/large/256x256_OLE_Token_Logo.png?1696525189"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa5312c3e42a82d459162b2a3bd7ffc4f9099b911",
+      "name": "GALAXIS Token",
+      "symbol": "GALAXIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36221/large/500x500.png?1714755244"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb08d8becab1bf76a9ce3d2d5fa946f65ec1d3e83",
+      "name": "GammaSwap",
+      "symbol": "GS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29222/large/newLogo2.png?1731702645"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x00cbcf7b3d37844e44b888bc747bdd75fcf4e555",
+      "name": "xPet tech",
+      "symbol": "XPET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33553/large/xpet_token.jpeg?1702428894"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x619c82392cb6e41778b7d088860fea8447941f4c",
+      "name": "Army of Fortune Gem",
+      "symbol": "AFG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35084/large/Token_GEM_AOFVERSE.png?1707317138"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x046029f68b0e00ebec2e394d17f70ec848fcf1d2",
+      "name": "Stable com USD3",
+      "symbol": "USD3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39865/large/2024-04-stable_com-usd3_coin.png?1724379520"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3b58a4c865b568a2f6a957c264f6b50cba35d8ce",
+      "name": "SuperWalk GRND",
+      "symbol": "GRND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27186/large/GRND_3x.png?1696526235"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc760f9782f8cea5b06d862574464729537159966",
+      "name": "Contango",
+      "symbol": "TANGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50721/large/400x400_-_Tango_%281%29.png?1729251498"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc24a365a870821eb83fd216c9596edd89479d8d7",
+      "name": "GAM3S GG",
+      "symbol": "G3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35662/large/G3_logo.jpg?1709454143"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd6cf874e24a9f5f43075142101a6b13735cdd424",
+      "name": "CoinbarPay",
+      "symbol": "CBPAY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38794/large/cbpay-icon_resized2.png?1729148991"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe10d4a4255d2d35c9e23e2c4790e073046fbaf5c",
+      "name": "LandX Governance Token",
+      "symbol": "LNDX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/33565/large/LNDX-200.png?1702445947"
     },
     {
       "chainId": 42161,
@@ -1344,151 +1264,39 @@
       "name": "Chainge",
       "symbol": "XCHNG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16526/thumb/chainge.jpeg?1708099639"
+      "logoURI": "https://assets.coingecko.com/coins/images/16526/large/chainge.jpeg?1708099639"
     },
     {
       "chainId": 42161,
-      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
-      "name": "Gyroscope GYD",
-      "symbol": "GYD",
+      "address": "0xca4e51f6ad4afd9d1068e5899de9dd7d73f3463d",
+      "name": "Aark Digital",
+      "symbol": "AARK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33428/thumb/GYD-gradient_resized_transparent.png?1702316822"
+      "logoURI": "https://assets.coingecko.com/coins/images/37813/large/aark.png?1715599394"
     },
     {
       "chainId": 42161,
-      "address": "0x16f1967565aad72dd77588a332ce445e7cef752b",
-      "name": "crow with knife",
-      "symbol": "CAW",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/36067/thumb/200px.png?1710405601"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x18c14c2d707b2212e17d1579789fc06010cfca23",
-      "name": "ETHPlus",
-      "symbol": "ETH+",
+      "address": "0x24ef78c7092d255ed14a0281ac1800c359af3afe",
+      "name": "Rabbit Wallet",
+      "symbol": "RAB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38061/thumb/ETH__Logo.png?1716440789"
+      "logoURI": "https://assets.coingecko.com/coins/images/29433/large/200x200.png?1696528381"
     },
     {
       "chainId": 42161,
-      "address": "0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55",
-      "name": "Dopex",
-      "symbol": "DPX",
+      "address": "0xacc51ffdef63fb0c014c882267c3a17261a5ed50",
+      "name": "Stryke",
+      "symbol": "SYK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16652/thumb/DPX_%281%29.png?1696516213"
+      "logoURI": "https://assets.coingecko.com/coins/images/36531/large/stryke.jpeg?1711704094"
     },
     {
       "chainId": 42161,
-      "address": "0xadd5620057336f868eae78a451c503ae7b576bad",
-      "name": "enqAI",
-      "symbol": "ENQAI",
+      "address": "0x7b5eb3940021ec0e8e463d5dbb4b7b09a89ddf96",
+      "name": "Wombat Exchange",
+      "symbol": "WOM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29908/thumb/icon.png?1702507913"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x088cd8f5ef3652623c22d48b1605dcfe860cd704",
-      "name": "Vela Token",
-      "symbol": "VELA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28739/thumb/VELA_logo_-_no_background.png?1696527719"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x330bd769382cfc6d50175903434ccc8d206dcae5",
-      "name": "Kleros",
-      "symbol": "PNK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3833/thumb/kleros.png?1696504500"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
-      "name": "Wagmi",
-      "symbol": "WAGMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31887/thumb/wagmi_token_logo.png?1696530698"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8697841b82c71fcbd9e58c15f6de68cd1c63fd02",
-      "name": "NutCoin",
-      "symbol": "NUT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37569/thumb/icon-2_200x200.png?1714886224"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdcbf4cb83d27c408b30dd7f39bfcabd7176b1ba3",
-      "name": "OpenOcean",
-      "symbol": "OOE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17014/thumb/ooe_log.png?1696516578"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x13278cd824d33a7adb9f0a9a84aca7c0d2deebf7",
-      "name": "Tarot",
-      "symbol": "TAROT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31800/thumb/TAROT.jpg?1696530615"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
-      "name": "Truflation",
-      "symbol": "TRUF",
-      "decimals": 15,
-      "logoURI": "https://assets.coingecko.com/coins/images/36642/thumb/truflation.jpg?1733315818"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa61f74247455a40b01b0559ff6274441fafa22a3",
-      "name": "Magpie",
-      "symbol": "MGP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27972/thumb/MagpieLogo.png?1696526991"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9f6abbf0ba6b5bfa27f4deb6597cc6ec20573fda",
-      "name": "Ferrum Network",
-      "symbol": "FRM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8251/thumb/FRM.png?1696508455"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x27bc2757fab0b8ab406016d1f71d8123452095d3",
-      "name": "Landshare",
-      "symbol": "LAND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17507/thumb/Landshare.png?1696517046"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
-      "name": "Any Inu",
-      "symbol": "AI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34126/thumb/anyinulogo200.png?1704174269"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0534d7272a8e4f24d269b56605f2bf6cf3271891",
-      "name": "U Coin",
-      "symbol": "U",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51359/thumb/coingecko.png?1730877953"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdfb8be6f8c87f74295a87de951974362cedcfa30",
-      "name": "Edge Matrix Computing",
-      "symbol": "EMC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34461/thumb/cgc.jpg?1725022711"
+      "logoURI": "https://assets.coingecko.com/coins/images/26946/large/Wombat_Token.png?1696526001"
     },
     {
       "chainId": 42161,
@@ -1496,7 +1304,191 @@
       "name": "Tokenlon",
       "symbol": "LON",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13454/thumb/lon_logo.png?1696513217"
+      "logoURI": "https://assets.coingecko.com/coins/images/13454/large/lon_logo.png?1696513217"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x050c24dbf1eec17babe5fc585f06116a259cc77a",
+      "name": "dlcBTC",
+      "symbol": "DLCBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/37289/large/dlcBTC_ico_200px.png?1713946623"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2680e82fb8beb5a153a67fe687ffa67abb6b9013",
+      "name": "Swarm Markets",
+      "symbol": "SMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17488/large/swarm-SMT-token-symbol_200x200.png?1696517029"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
+      "name": "Osaka Protocol",
+      "symbol": "OSAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30911/large/OSAK_LOGO_200x200.png?1723662197"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa4f63404b58c3efd9db6d53352bd386ffa174e5a",
+      "name": "Miracle Play",
+      "symbol": "MPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32653/large/MPT.png?1698895300"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfa296fca3c7dba4a92a42ec0b5e2138da3b29050",
+      "name": "AiShiba",
+      "symbol": "SHIBAI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29898/large/Fotor_AI%EF%BC%882%EF%BC%89.png?1696528822"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe0ee18eacafddaeb38f8907c74347c44385578ab",
+      "name": "AxonDAO Governance Token",
+      "symbol": "AXGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35290/large/AXGT-logo-7.png?1708076161"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
+      "name": "Gyroscope GYD",
+      "symbol": "GYD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x16f1967565aad72dd77588a332ce445e7cef752b",
+      "name": "crow with knife",
+      "symbol": "CAW",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/36067/large/200px.png?1710405601"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55",
+      "name": "Dopex",
+      "symbol": "DPX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16652/large/DPX_%281%29.png?1696516213"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x18c14c2d707b2212e17d1579789fc06010cfca23",
+      "name": "ETHPlus",
+      "symbol": "ETH+",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38061/large/ETH__Logo.png?1716440789"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xadd5620057336f868eae78a451c503ae7b576bad",
+      "name": "enqAI",
+      "symbol": "ENQAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29908/large/icon.png?1702507913"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x088cd8f5ef3652623c22d48b1605dcfe860cd704",
+      "name": "Vela Token",
+      "symbol": "VELA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28739/large/VELA_logo_-_no_background.png?1696527719"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x330bd769382cfc6d50175903434ccc8d206dcae5",
+      "name": "Kleros",
+      "symbol": "PNK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3833/large/kleros.png?1696504500"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
+      "name": "Wagmi",
+      "symbol": "WAGMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31887/large/wagmi_token_logo.png?1696530698"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdcbf4cb83d27c408b30dd7f39bfcabd7176b1ba3",
+      "name": "OpenOcean",
+      "symbol": "OOE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17014/large/ooe_log.png?1696516578"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8697841b82c71fcbd9e58c15f6de68cd1c63fd02",
+      "name": "NutCoin",
+      "symbol": "NUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37569/large/icon-2_200x200.png?1714886224"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa61f74247455a40b01b0559ff6274441fafa22a3",
+      "name": "Magpie",
+      "symbol": "MGP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27972/large/MagpieLogo.png?1696526991"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
+      "name": "Truflation",
+      "symbol": "TRUF",
+      "decimals": 15,
+      "logoURI": "https://assets.coingecko.com/coins/images/36642/large/truflation.jpg?1733315818"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9f6abbf0ba6b5bfa27f4deb6597cc6ec20573fda",
+      "name": "Ferrum Network",
+      "symbol": "FRM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8251/large/FRM.png?1696508455"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x27bc2757fab0b8ab406016d1f71d8123452095d3",
+      "name": "Landshare",
+      "symbol": "LAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17507/large/Landshare.png?1696517046"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
+      "name": "Any Inu",
+      "symbol": "AI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34126/large/anyinulogo200.png?1704174269"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0534d7272a8e4f24d269b56605f2bf6cf3271891",
+      "name": "U Coin",
+      "symbol": "U",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51359/large/coingecko.png?1730877953"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13278cd824d33a7adb9f0a9a84aca7c0d2deebf7",
+      "name": "Tarot",
+      "symbol": "TAROT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31800/large/TAROT.jpg?1696530615"
     },
     {
       "chainId": 42161,
@@ -1504,7 +1496,15 @@
       "name": "iZUMi Finance",
       "symbol": "IZI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21791/thumb/izumi-logo-symbol.png?1696521144"
+      "logoURI": "https://assets.coingecko.com/coins/images/21791/large/izumi-logo-symbol.png?1696521144"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdfb8be6f8c87f74295a87de951974362cedcfa30",
+      "name": "Edge Matrix Computing",
+      "symbol": "EMC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34461/large/cgc.jpg?1725022711"
     },
     {
       "chainId": 42161,
@@ -1512,7 +1512,7 @@
       "name": "Paribus",
       "symbol": "PBX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18410/thumb/paribus.PNG?1696517900"
+      "logoURI": "https://assets.coingecko.com/coins/images/18410/large/paribus.PNG?1696517900"
     },
     {
       "chainId": 42161,
@@ -1520,7 +1520,7 @@
       "name": "Arbius",
       "symbol": "AIUS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35246/thumb/arbius-200x-logo.png?1707987961"
+      "logoURI": "https://assets.coingecko.com/coins/images/35246/large/arbius-200x-logo.png?1707987961"
     },
     {
       "chainId": 42161,
@@ -1528,15 +1528,7 @@
       "name": "Fantom Bomb",
       "symbol": "BOMB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24109/thumb/logo-blue.png?1696523301"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x24404dc041d74cd03cfe28855f555559390c931b",
-      "name": "r CryptoCurrency Moons",
-      "symbol": "MOON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11222/thumb/Moons.png?1696511153"
+      "logoURI": "https://assets.coingecko.com/coins/images/24109/large/logo-blue.png?1696523301"
     },
     {
       "chainId": 42161,
@@ -1544,15 +1536,15 @@
       "name": "VNX Swiss Franc",
       "symbol": "VCHF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29547/thumb/VNXCHF_%282%29.png?1696528488"
+      "logoURI": "https://assets.coingecko.com/coins/images/29547/large/VNXCHF_%282%29.png?1696528488"
     },
     {
       "chainId": 42161,
-      "address": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a",
-      "name": "Alchemix USD",
-      "symbol": "ALUSD",
+      "address": "0x24404dc041d74cd03cfe28855f555559390c931b",
+      "name": "r CryptoCurrency Moons",
+      "symbol": "MOON",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14114/thumb/Alchemix_USD.png?1696513835"
+      "logoURI": "https://assets.coingecko.com/coins/images/11222/large/Moons.png?1696511153"
     },
     {
       "chainId": 42161,
@@ -1560,103 +1552,7 @@
       "name": "Dexalot",
       "symbol": "ALOT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24188/thumb/logo_200x200.png?1696523376"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7ce746b45eabd0c4321538dec1b849c79a9a8476",
-      "name": "DSLA Protocol",
-      "symbol": "DSLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/6694/thumb/dsla_logo-squared_200x200.png?1696507035"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x10aaed289a7b1b0155bf4b86c862f297e84465e0",
-      "name": "Rubic",
-      "symbol": "RBC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/rubic.png?1696512437"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfa5ed56a203466cbbc2430a43c66b9d8723528e7",
-      "name": "EURA",
-      "symbol": "EURA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19479/thumb/agEUR-4.png?1710726218"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x13a7dedb7169a17be92b0e3c7c2315b46f4772b3",
-      "name": "Boop",
-      "symbol": "BOOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33874/thumb/Boop_resized.png?1703144302"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x5117f4ad0bc70dbb3b05bf39a1ec1ee40dd67654",
-      "name": "Avive",
-      "symbol": "AVIVE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33697/thumb/avive_token.png?1702814979"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9578a9937dff45b4e29e49120ab83cb806f1aa4f",
-      "name": "AITom",
-      "symbol": "AITOM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32013/thumb/aitom.png?1696530811"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6c511dc18572d31c2c3f7b1505cb2bbc08282fcc",
-      "name": "Aipocalypto",
-      "symbol": "AIPO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51400/thumb/aipo.png?1731084580"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa58663faef461761e44066ea26c1fcddf2927b80",
-      "name": "Kommunitas",
-      "symbol": "KOM",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/17483/thumb/Kommunitas_HD.png?1726922129"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x87aaffdf26c6885f6010219208d5b161ec7609c0",
-      "name": "Equation",
-      "symbol": "EQU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32592/thumb/equation_logo.png?1699220377"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x75ec618a817eb0a4a7e44ac3dfc64c963daf921a",
-      "name": "Token7007",
-      "symbol": "7007",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50293/thumb/token7007.png?1726931640"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xee0a242f28034fce0bdfac33c0ad2a58ec35fd38",
-      "name": "Rosa Inu",
-      "symbol": "ROSA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37963/thumb/ROSA_TOKEN_3.png?1716183016"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1b7ad346b6ff2d196daa8e78aed86baa6d7e3b02",
-      "name": "VitAI",
-      "symbol": "VITAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52350/thumb/aadadsadasdas.png?1733162989"
+      "logoURI": "https://assets.coingecko.com/coins/images/24188/large/logo_200x200.png?1696523376"
     },
     {
       "chainId": 42161,
@@ -1664,407 +1560,7 @@
       "name": "Universal ETH",
       "symbol": "UNIETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28477/thumb/uniETH_200.png?1696527471"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xedd6ca8a4202d4a36611e2fff109648c4863ae19",
-      "name": "Maha",
-      "symbol": "MAHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13404/thumb/black.png?1724679606"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x60bf4e7cf16ff34513514b968483b54beff42a81",
-      "name": "ViciCoin",
-      "symbol": "VCNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31305/thumb/ViciCoin_-_small.png?1696530124"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3212dc0f8c834e4de893532d27cc9b6001684db0",
-      "name": "Pear Protocol",
-      "symbol": "PEAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50484/thumb/pearlogo.jpg?1727897446"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf1264873436a0771e440e2b28072fafcc5eebd01",
-      "name": "Kenshi",
-      "symbol": "KNS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30759/thumb/kenshi.jpg?1696529628"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
-      "name": "Seedworld",
-      "symbol": "SWORLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51000/thumb/IMG_2798.PNG?1729685531"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdb40357fbc1eb1038c5df94c1cd7b7fd3f434480",
-      "name": "SpunkySDX",
-      "symbol": "SSDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52469/thumb/spunkysdx.png?1733412208"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1bc8bf18256d8b45d8367aac50fe2e24fc6aa8ca",
-      "name": "Vestate",
-      "symbol": "VES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35475/thumb/IMG_0759.png?1708772732"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xcf934e2402a5e072928a39a956964eb8f2b5b79c",
-      "name": "PoolTogether",
-      "symbol": "POOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14003/thumb/PoolTogether.png?1696513732"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x11920f139a3121c2836e01551d43f95b3c31159c",
-      "name": "YieldBricks",
-      "symbol": "YBR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51471/thumb/fjord-token-logo-darkbg.png?1731384618"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3269a3c00ab86c753856fd135d97b87facb0d848",
-      "name": "Florence Finance Medici",
-      "symbol": "FFM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34382/thumb/M_PNG_200x200_copy.png?1704779326"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb6093b61544572ab42a0e43af08abafd41bf25a6",
-      "name": "WeatherXM",
-      "symbol": "WXM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38154/thumb/weatherxm-network-logo.png?1716668976"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4d840b741bc05fde325d4ec0b4cfcd0cea237e4e",
-      "name": "Quantlytica",
-      "symbol": "QTLX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50217/thumb/eebgcbNa_400x400.jpg?1726443400"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb9600c807f069d27f92a2a65b48f12eeef7e2007",
-      "name": "Altranium",
-      "symbol": "ALTR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38301/thumb/altr.jpg?1717034749"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x894134a25a5fac1c2c26f1d8fbf05111a3cb9487",
-      "name": "Grai",
-      "symbol": "GRAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30427/thumb/GRAI_Token.png?1696529315"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc9c4fd7579133701fa2769b6955e7e56bb386db1",
-      "name": "Bridge Oracle",
-      "symbol": "BRG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12512/thumb/brg.png?1696512327"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-      "name": "Hop Protocol",
-      "symbol": "HOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25445/thumb/hop.png?1696524577"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2b41806cbf1ffb3d9e31a9ece6b738bf9d6f645f",
-      "name": "ENO",
-      "symbol": "ENO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26501/thumb/Logo_%281%29.png?1709565574"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7ba4a00d54a07461d9db2aef539e91409943adc9",
-      "name": "Stake DAO",
-      "symbol": "SDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13724/thumb/stakedao_logo.jpg?1696513468"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x092baadb7def4c3981454dd9c0a0d7ff07bcfc86",
-      "name": "MorpheusAI",
-      "symbol": "MOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37969/thumb/MOR200X200.png?1716327119"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3096e7bfd0878cc65be71f8899bc4cfb57187ba3",
-      "name": "Xend Finance",
-      "symbol": "RWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14496/thumb/WeChat_Image_20210325163206.png?1696514181"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418",
-      "name": "Ramses Exchange",
-      "symbol": "RAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29420/thumb/newram.png?1708427055"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x69420f9e38a4e60a62224c489be4bf7a94402496",
-      "name": "Defi money",
-      "symbol": "MONEY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39230/thumb/Token_2x-1.png?1725438128"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb688ba096b7bb75d7841e47163cd12d18b36a5bf",
-      "name": "mPendle",
-      "symbol": "MPENDLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31918/thumb/mPendle.png?1696530726"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd6b3d81868770083307840f513a3491960b95cb6",
-      "name": "Credbull",
-      "symbol": "CBL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39396/thumb/2024-11-15_06.09.28.jpg?1731735429"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbe5acfd64358805616b5cbd5277b9a85011d7cf1",
-      "name": "Pichi Finance",
-      "symbol": "PCH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39683/thumb/Group_1000003884.png?1723654999"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1c986661170c1834db49c3830130d4038eeeb866",
-      "name": "Aperture Finance",
-      "symbol": "APTR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37940/thumb/icon_white.png?1715967425"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2297aebd383787a160dd0d9f71508148769342e3",
-      "name": "Avalanche Bridged BTC  Arbitrum One ",
-      "symbol": "BTCB",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/51135/thumb/avalanche-core.png?1730195092"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc4cbd54ffa7a6a142fd73554cc6c23dd95cd8e01",
-      "name": " GAME Token",
-      "symbol": "GAME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38429/thumb/_GAME_Token.png?1717497071"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x847503fbf003ce8b005546aa3c03b80b7c2f9771",
-      "name": "Byte",
-      "symbol": "BYTE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/33527/thumb/Byte200.jpeg?1702138460"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3bd2dfd03bc7c3011ed7fb8c4d0949b382726cee",
-      "name": "Roobee",
-      "symbol": "ROOBEE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8791/thumb/Group_11.png?1696508946"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9e20461bc2c4c980f62f1b279d71734207a6a356",
-      "name": "OmniCat",
-      "symbol": "OMNI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33917/thumb/omnicatlogo.png?1717544778"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x83d6c8c06ac276465e4c92e7ac8c23740f435140",
-      "name": "HMX",
-      "symbol": "HMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31206/thumb/HMXlogo_CG.png?1696530033"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xadf5dd3e51bf28ab4f07e684ecf5d00691818790",
-      "name": "ICHI",
-      "symbol": "ICHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13119/thumb/ICHI_%28Round%29.jpg?1696512907"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x000000000026839b3f4181f2cf69336af6153b99",
-      "name": "Reboot",
-      "symbol": "GG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31228/thumb/gg_cyan_black_square.png?1703749951"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe82335d58abb1cd44cd5f47cf7f5b378e4c32f05",
-      "name": "SuperCells",
-      "symbol": "SCT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38800/thumb/photo_2024-09-24_18-31-07.jpg?1728417418"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa0995d43901551601060447f9abf93ebc277cec2",
-      "name": "HIPPOP",
-      "symbol": "HIP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37854/thumb/KakaoTalk_Image_2024-05-14-16-50-31.png?1715781999"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2ac2b254bc18cd4999f64773a966e4f4869c34ee",
-      "name": "Penpie",
-      "symbol": "PNP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30760/thumb/PNP_Token.png?1696529629"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb299751b088336e165da313c33e3195b8c6663a6",
-      "name": "StarHeroes",
-      "symbol": "STAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34147/thumb/Screenshot_2024-03-08_180444.png?1709892309"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
-      "name": "Nya",
-      "symbol": "NYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40082/thumb/nya.jpg?1725523655"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4883c8f0529f37e40ebea870f3c13cdfad5d01f8",
-      "name": "VNX EURO",
-      "symbol": "VEUR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29351/thumb/VNXEUR_%281%29.png?1696528300"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0cbd6fadcf8096cc9a43d90b45f65826102e3ece",
-      "name": "CheckDot",
-      "symbol": "CDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20370/thumb/token-200x200_%281%29.png?1696519781"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf6dae0d2be4993b00a2673360820af6bafd53887",
-      "name": "Launchpool",
-      "symbol": "LPOOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14041/thumb/dGUvV0HQ_400x400.jpg?1696513767"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb2f30a7c980f052f02563fb518dcc39e6bf38175",
-      "name": "Synthetix USDx",
-      "symbol": "USDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51047/thumb/USDX.jpg?1729845921"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x5d4974f8543bc78d43fd1044ecfdb9d85482aa21",
-      "name": "Bitbama",
-      "symbol": "BAMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36686/thumb/photo_2024-03-31_14-20-41.jpg?1712073912"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x982239d38af50b0168da33346d85fb12929c4c07",
-      "name": "Arbitrove Governance Token",
-      "symbol": "TROVE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29017/thumb/trove.png?1696527988"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6b2a01a5f79deb4c2f3c0eda7b01df456fbd726a",
-      "name": "Universal BTC",
-      "symbol": "UNIBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39599/thumb/uniBTC_200px.png?1723064455"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6db8b088c4d41d622b44cd81b900ba690f2d496c",
-      "name": "Impossible Finance Launchpad",
-      "symbol": "IDIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17803/thumb/IDIA.png?1696517325"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xffa188493c15dfaf2c206c97d8633377847b6a52",
-      "name": "Wefi",
-      "symbol": "WEFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30540/thumb/wefi.png?1696529412"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
-      "name": "Glo Dollar",
-      "symbol": "USDGLO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29319/thumb/GLO_logo_pine_on_cyan_1_3.png?1716971065"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xafafd68afe3fe65d376eec9eab1802616cfaccb8",
-      "name": "Solv Protocol SolvBTC ENA",
-      "symbol": "SOLVBTCENA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38931/thumb/BTC_ena.png?1719562313"
+      "logoURI": "https://assets.coingecko.com/coins/images/28477/large/uniETH_200.png?1696527471"
     },
     {
       "chainId": 42161,
@@ -2072,7 +1568,511 @@
       "name": "POGAI",
       "symbol": "POGAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30116/thumb/pogai.jpeg?1696529039"
+      "logoURI": "https://assets.coingecko.com/coins/images/30116/large/pogai.jpeg?1696529039"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7ce746b45eabd0c4321538dec1b849c79a9a8476",
+      "name": "DSLA Protocol",
+      "symbol": "DSLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6694/large/dsla_logo-squared_200x200.png?1696507035"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfa5ed56a203466cbbc2430a43c66b9d8723528e7",
+      "name": "EURA",
+      "symbol": "EURA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/large/agEUR-4.png?1710726218"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x10aaed289a7b1b0155bf4b86c862f297e84465e0",
+      "name": "Rubic",
+      "symbol": "RBC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12629/large/rubic.png?1696512437"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5117f4ad0bc70dbb3b05bf39a1ec1ee40dd67654",
+      "name": "Avive",
+      "symbol": "AVIVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33697/large/avive_token.png?1702814979"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13a7dedb7169a17be92b0e3c7c2315b46f4772b3",
+      "name": "Boop",
+      "symbol": "BOOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33874/large/Boop_resized.png?1703144302"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9578a9937dff45b4e29e49120ab83cb806f1aa4f",
+      "name": "AITom",
+      "symbol": "AITOM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32013/large/aitom.png?1696530811"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a",
+      "name": "Alchemix USD",
+      "symbol": "ALUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14114/large/Alchemix_USD.png?1696513835"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6c511dc18572d31c2c3f7b1505cb2bbc08282fcc",
+      "name": "Aipocalypto",
+      "symbol": "AIPO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51400/large/aipo.png?1731084580"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa58663faef461761e44066ea26c1fcddf2927b80",
+      "name": "Kommunitas",
+      "symbol": "KOM",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17483/large/Kommunitas_HD.png?1726922129"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x87aaffdf26c6885f6010219208d5b161ec7609c0",
+      "name": "Equation",
+      "symbol": "EQU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32592/large/equation_logo.png?1699220377"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x75ec618a817eb0a4a7e44ac3dfc64c963daf921a",
+      "name": "Token7007",
+      "symbol": "7007",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50293/large/token7007.png?1726931640"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xee0a242f28034fce0bdfac33c0ad2a58ec35fd38",
+      "name": "Rosa Inu",
+      "symbol": "ROSA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37963/large/ROSA_TOKEN_3.png?1716183016"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1b7ad346b6ff2d196daa8e78aed86baa6d7e3b02",
+      "name": "VitAI",
+      "symbol": "VITAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52350/large/aadadsadasdas.png?1733162989"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xedd6ca8a4202d4a36611e2fff109648c4863ae19",
+      "name": "Maha",
+      "symbol": "MAHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13404/large/black.png?1724679606"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x60bf4e7cf16ff34513514b968483b54beff42a81",
+      "name": "ViciCoin",
+      "symbol": "VCNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31305/large/ViciCoin_-_small.png?1696530124"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3212dc0f8c834e4de893532d27cc9b6001684db0",
+      "name": "Pear Protocol",
+      "symbol": "PEAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50484/large/pearlogo.jpg?1727897446"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3269a3c00ab86c753856fd135d97b87facb0d848",
+      "name": "Florence Finance Medici",
+      "symbol": "FFM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34382/large/M_PNG_200x200_copy.png?1704779326"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
+      "name": "Seedworld",
+      "symbol": "SWORLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51000/large/IMG_2798.PNG?1729685531"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf1264873436a0771e440e2b28072fafcc5eebd01",
+      "name": "Kenshi",
+      "symbol": "KNS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30759/large/kenshi.jpg?1696529628"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdb40357fbc1eb1038c5df94c1cd7b7fd3f434480",
+      "name": "SpunkySDX",
+      "symbol": "SSDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52469/large/spunkysdx.png?1733412208"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1bc8bf18256d8b45d8367aac50fe2e24fc6aa8ca",
+      "name": "Vestate",
+      "symbol": "VES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35475/large/IMG_0759.png?1708772732"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11920f139a3121c2836e01551d43f95b3c31159c",
+      "name": "YieldBricks",
+      "symbol": "YBR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51471/large/fjord-token-logo-darkbg.png?1731384618"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcf934e2402a5e072928a39a956964eb8f2b5b79c",
+      "name": "PoolTogether",
+      "symbol": "POOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14003/large/PoolTogether.png?1696513732"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb6093b61544572ab42a0e43af08abafd41bf25a6",
+      "name": "WeatherXM",
+      "symbol": "WXM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38154/large/weatherxm-network-logo.png?1716668976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4d840b741bc05fde325d4ec0b4cfcd0cea237e4e",
+      "name": "Quantlytica",
+      "symbol": "QTLX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50217/large/eebgcbNa_400x400.jpg?1726443400"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb9600c807f069d27f92a2a65b48f12eeef7e2007",
+      "name": "Altranium",
+      "symbol": "ALTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38301/large/altr.jpg?1717034749"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x894134a25a5fac1c2c26f1d8fbf05111a3cb9487",
+      "name": "Grai",
+      "symbol": "GRAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30427/large/GRAI_Token.png?1696529315"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x092baadb7def4c3981454dd9c0a0d7ff07bcfc86",
+      "name": "MorpheusAI",
+      "symbol": "MOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37969/large/MOR200X200.png?1716327119"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc9c4fd7579133701fa2769b6955e7e56bb386db1",
+      "name": "Bridge Oracle",
+      "symbol": "BRG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12512/large/brg.png?1696512327"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "name": "Hop Protocol",
+      "symbol": "HOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25445/large/hop.png?1696524577"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2b41806cbf1ffb3d9e31a9ece6b738bf9d6f645f",
+      "name": "ENO",
+      "symbol": "ENO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26501/large/Logo_%281%29.png?1709565574"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7ba4a00d54a07461d9db2aef539e91409943adc9",
+      "name": "Stake DAO",
+      "symbol": "SDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13724/large/stakedao_logo.jpg?1696513468"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3096e7bfd0878cc65be71f8899bc4cfb57187ba3",
+      "name": "Xend Finance",
+      "symbol": "RWA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14496/large/WeChat_Image_20210325163206.png?1696514181"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418",
+      "name": "Ramses Exchange",
+      "symbol": "RAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29420/large/newram.png?1708427055"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb688ba096b7bb75d7841e47163cd12d18b36a5bf",
+      "name": "mPendle",
+      "symbol": "MPENDLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31918/large/mPendle.png?1696530726"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd6b3d81868770083307840f513a3491960b95cb6",
+      "name": "Credbull",
+      "symbol": "CBL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39396/large/2024-11-15_06.09.28.jpg?1731735429"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbe5acfd64358805616b5cbd5277b9a85011d7cf1",
+      "name": "Pichi Finance",
+      "symbol": "PCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39683/large/Group_1000003884.png?1723654999"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1c986661170c1834db49c3830130d4038eeeb866",
+      "name": "Aperture Finance",
+      "symbol": "APTR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37940/large/icon_white.png?1715967425"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x69420f9e38a4e60a62224c489be4bf7a94402496",
+      "name": "Defi money",
+      "symbol": "MONEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39230/large/Token_2x-1.png?1725438128"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc4cbd54ffa7a6a142fd73554cc6c23dd95cd8e01",
+      "name": " GAME Token",
+      "symbol": "GAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38429/large/_GAME_Token.png?1717497071"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2297aebd383787a160dd0d9f71508148769342e3",
+      "name": "Avalanche Bridged BTC  Arbitrum One ",
+      "symbol": "BTCB",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/51135/large/avalanche-core.png?1730195092"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x847503fbf003ce8b005546aa3c03b80b7c2f9771",
+      "name": "Byte",
+      "symbol": "BYTE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/33527/large/Byte200.jpeg?1702138460"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
+      "name": "Nya",
+      "symbol": "NYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40082/large/nya.jpg?1725523655"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3bd2dfd03bc7c3011ed7fb8c4d0949b382726cee",
+      "name": "Roobee",
+      "symbol": "ROOBEE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8791/large/Group_11.png?1696508946"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6b2a01a5f79deb4c2f3c0eda7b01df456fbd726a",
+      "name": "Universal BTC",
+      "symbol": "UNIBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39599/large/uniBTC_200px.png?1723064455"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x83d6c8c06ac276465e4c92e7ac8c23740f435140",
+      "name": "HMX",
+      "symbol": "HMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31206/large/HMXlogo_CG.png?1696530033"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9e20461bc2c4c980f62f1b279d71734207a6a356",
+      "name": "OmniCat",
+      "symbol": "OMNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33917/large/omnicatlogo.png?1717544778"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xadf5dd3e51bf28ab4f07e684ecf5d00691818790",
+      "name": "ICHI",
+      "symbol": "ICHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13119/large/ICHI_%28Round%29.jpg?1696512907"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe82335d58abb1cd44cd5f47cf7f5b378e4c32f05",
+      "name": "SuperCells",
+      "symbol": "SCT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38800/large/photo_2024-09-24_18-31-07.jpg?1728417418"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x000000000026839b3f4181f2cf69336af6153b99",
+      "name": "Reboot",
+      "symbol": "GG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31228/large/gg_cyan_black_square.png?1703749951"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa0995d43901551601060447f9abf93ebc277cec2",
+      "name": "HIPPOP",
+      "symbol": "HIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37854/large/KakaoTalk_Image_2024-05-14-16-50-31.png?1715781999"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2ac2b254bc18cd4999f64773a966e4f4869c34ee",
+      "name": "Penpie",
+      "symbol": "PNP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30760/large/PNP_Token.png?1696529629"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb299751b088336e165da313c33e3195b8c6663a6",
+      "name": "StarHeroes",
+      "symbol": "STAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34147/large/Screenshot_2024-03-08_180444.png?1709892309"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4883c8f0529f37e40ebea870f3c13cdfad5d01f8",
+      "name": "VNX EURO",
+      "symbol": "VEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29351/large/VNXEUR_%281%29.png?1696528300"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf6dae0d2be4993b00a2673360820af6bafd53887",
+      "name": "Launchpool",
+      "symbol": "LPOOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14041/large/dGUvV0HQ_400x400.jpg?1696513767"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0cbd6fadcf8096cc9a43d90b45f65826102e3ece",
+      "name": "CheckDot",
+      "symbol": "CDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20370/large/token-200x200_%281%29.png?1696519781"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb2f30a7c980f052f02563fb518dcc39e6bf38175",
+      "name": "Synthetix USDx",
+      "symbol": "USDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51047/large/USDX.jpg?1729845921"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5d4974f8543bc78d43fd1044ecfdb9d85482aa21",
+      "name": "Bitbama",
+      "symbol": "BAMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36686/large/photo_2024-03-31_14-20-41.jpg?1712073912"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x982239d38af50b0168da33346d85fb12929c4c07",
+      "name": "Arbitrove Governance Token",
+      "symbol": "TROVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29017/large/trove.png?1696527988"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6db8b088c4d41d622b44cd81b900ba690f2d496c",
+      "name": "Impossible Finance Launchpad",
+      "symbol": "IDIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17803/large/IDIA.png?1696517325"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xffa188493c15dfaf2c206c97d8633377847b6a52",
+      "name": "Wefi",
+      "symbol": "WEFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30540/large/wefi.png?1696529412"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
+      "name": "Glo Dollar",
+      "symbol": "USDGLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29319/large/GLO_logo_pine_on_cyan_1_3.png?1716971065"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xafafd68afe3fe65d376eec9eab1802616cfaccb8",
+      "name": "Solv Protocol SolvBTC ENA",
+      "symbol": "SOLVBTCENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38931/large/BTC_ena.png?1719562313"
     },
     {
       "chainId": 42161,
@@ -2080,15 +2080,7 @@
       "name": "Flame",
       "symbol": "FLAME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34280/thumb/20240104-164053.jpg?1704452348"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x431402e8b9de9aa016c743880e04e517074d8cec",
-      "name": "Hegic",
-      "symbol": "HEGIC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12454/thumb/new.png?1696512274"
+      "logoURI": "https://assets.coingecko.com/coins/images/34280/large/20240104-164053.jpg?1704452348"
     },
     {
       "chainId": 42161,
@@ -2096,7 +2088,15 @@
       "name": "BonusBlock",
       "symbol": "BONUS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36364/thumb/Coingecko_logo.png?1711336118"
+      "logoURI": "https://assets.coingecko.com/coins/images/36364/large/Coingecko_logo.png?1711336118"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x431402e8b9de9aa016c743880e04e517074d8cec",
+      "name": "Hegic",
+      "symbol": "HEGIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12454/large/new.png?1696512274"
     },
     {
       "chainId": 42161,
@@ -2104,7 +2104,7 @@
       "name": "Roseon",
       "symbol": "ROSX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29698/thumb/roseon.png?1696528631"
+      "logoURI": "https://assets.coingecko.com/coins/images/29698/large/roseon.png?1696528631"
     },
     {
       "chainId": 42161,
@@ -2112,15 +2112,7 @@
       "name": "EverValue Coin",
       "symbol": "EVA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50997/thumb/EVA_Logo_-_with_dark_background_-_200x200.png?1729720258"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8d9ba570d6cb60c7e3e0f31343efe75ab8e65fb1",
-      "name": "Governance OHM",
-      "symbol": "GOHM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21129/thumb/token_wsOHM_logo.png?1696520508"
+      "logoURI": "https://assets.coingecko.com/coins/images/50997/large/EVA_Logo_-_with_dark_background_-_200x200.png?1729720258"
     },
     {
       "chainId": 42161,
@@ -2128,7 +2120,7 @@
       "name": "Deri Protocol",
       "symbol": "DERI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13931/thumb/200vs200.jpg?1696513670"
+      "logoURI": "https://assets.coingecko.com/coins/images/13931/large/200vs200.jpg?1696513670"
     },
     {
       "chainId": 42161,
@@ -2136,127 +2128,15 @@
       "name": "Thales",
       "symbol": "THALES",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18388/thumb/CLVZJN_C_400x400.png?1696517879"
+      "logoURI": "https://assets.coingecko.com/coins/images/18388/large/CLVZJN_C_400x400.png?1696517879"
     },
     {
       "chainId": 42161,
-      "address": "0x1dd6b5f9281c6b4f043c02a83a46c2772024636c",
-      "name": "Lumi Finance LUAUSD",
-      "symbol": "LUAUSD",
+      "address": "0x8d9ba570d6cb60c7e3e0f31343efe75ab8e65fb1",
+      "name": "Governance OHM",
+      "symbol": "GOHM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33503/thumb/LUAUSD.png?1702038709"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2c7941a0fe9c52223b229747322af16160161c98",
-      "name": "Jarvis",
-      "symbol": "JARVIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35812/thumb/jarvis.png?1709873633"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa586b3b80d7e3e8d439e25fbc16bc5bcee3e2c85",
-      "name": "Codyfight",
-      "symbol": "CTOK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23592/thumb/ctok.jpg?1715904249"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x569deb225441fd18bde18aed53e2ec7eb4e10d93",
-      "name": "Your Futures Exchange",
-      "symbol": "YFX",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/15654/thumb/yfx.PNG?1696515285"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x10393c20975cf177a3513071bc110f7962cd67da",
-      "name": "Jones DAO",
-      "symbol": "JONES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23290/thumb/3c8c2ed8-afb3-4b67-9937-5493acd88b50.jpg?1696522508"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x965d00aa7abc62ca10132e641d08593435ac811d",
-      "name": "KAP Games",
-      "symbol": "KAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27682/thumb/KAP_Logo.png?1696526710"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3404149e9ee6f17fb41db1ce593ee48fbdcd9506",
-      "name": "Hydranet",
-      "symbol": "HDN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25177/thumb/HDXdarkblueInv.png?1696524322"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xee9801669c6138e84bd50deb500827b776777d28",
-      "name": "O3 Swap",
-      "symbol": "O3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15460/thumb/o3.png?1696515107"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
-      "name": "Magic Internet Money  Arbitrum ",
-      "symbol": "MIM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37324/thumb/mim.png?1714016666"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
-      "name": "Ankr Staked ETH",
-      "symbol": "ANKRETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13403/thumb/aETHc.png?1696513165"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x55ff62567f09906a85183b866df84bf599a4bf70",
-      "name": "Kromatika",
-      "symbol": "KROM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20541/thumb/KROM_Transparent.png?1696519948"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
-      "name": "Lava Network",
-      "symbol": "LAVA",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37354/thumb/lava_logo.png?1714098423"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x711b771c7c443ebb695e4b3495c337fdaf37be11",
-      "name": "Dackie USD",
-      "symbol": "DCKUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39966/thumb/Dackie_USD_Stablecoin.png?1724957262"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf763fa322dc58dee588252fafee5f448e863b633",
-      "name": "Carbon Protocol",
-      "symbol": "SWTH",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/3645/thumb/SWTH_Symbol_Origin.png?1696504327"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1d987200df3b744cfa9c14f713f5334cb4bc4d5d",
-      "name": "REKT",
-      "symbol": "REKT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29954/thumb/New_Project_%288%29.png?1696528881"
+      "logoURI": "https://assets.coingecko.com/coins/images/21129/large/token_wsOHM_logo.png?1696520508"
     },
     {
       "chainId": 42161,
@@ -2264,7 +2144,119 @@
       "name": "Level",
       "symbol": "LVL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28628/thumb/Token.png?1696527613"
+      "logoURI": "https://assets.coingecko.com/coins/images/28628/large/Token.png?1696527613"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2c7941a0fe9c52223b229747322af16160161c98",
+      "name": "Jarvis",
+      "symbol": "JARVIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35812/large/jarvis.png?1709873633"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1dd6b5f9281c6b4f043c02a83a46c2772024636c",
+      "name": "Lumi Finance LUAUSD",
+      "symbol": "LUAUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33503/large/LUAUSD.png?1702038709"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x10393c20975cf177a3513071bc110f7962cd67da",
+      "name": "Jones DAO",
+      "symbol": "JONES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23290/large/3c8c2ed8-afb3-4b67-9937-5493acd88b50.jpg?1696522508"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa586b3b80d7e3e8d439e25fbc16bc5bcee3e2c85",
+      "name": "Codyfight",
+      "symbol": "CTOK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23592/large/ctok.jpg?1715904249"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x569deb225441fd18bde18aed53e2ec7eb4e10d93",
+      "name": "Your Futures Exchange",
+      "symbol": "YFX",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/15654/large/yfx.PNG?1696515285"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3404149e9ee6f17fb41db1ce593ee48fbdcd9506",
+      "name": "Hydranet",
+      "symbol": "HDN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25177/large/HDXdarkblueInv.png?1696524322"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xee9801669c6138e84bd50deb500827b776777d28",
+      "name": "O3 Swap",
+      "symbol": "O3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15460/large/o3.png?1696515107"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
+      "name": "Magic Internet Money  Arbitrum ",
+      "symbol": "MIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37324/large/mim.png?1714016666"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
+      "name": "Ankr Staked ETH",
+      "symbol": "ANKRETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13403/large/aETHc.png?1696513165"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x55ff62567f09906a85183b866df84bf599a4bf70",
+      "name": "Kromatika",
+      "symbol": "KROM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20541/large/KROM_Transparent.png?1696519948"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x711b771c7c443ebb695e4b3495c337fdaf37be11",
+      "name": "Dackie USD",
+      "symbol": "DCKUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39966/large/Dackie_USD_Stablecoin.png?1724957262"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
+      "name": "Lava Network",
+      "symbol": "LAVA",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37354/large/lava_logo.png?1714098423"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf763fa322dc58dee588252fafee5f448e863b633",
+      "name": "Carbon Protocol",
+      "symbol": "SWTH",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/3645/large/SWTH_Symbol_Origin.png?1696504327"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1d987200df3b744cfa9c14f713f5334cb4bc4d5d",
+      "name": "REKT",
+      "symbol": "REKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29954/large/New_Project_%288%29.png?1696528881"
     },
     {
       "chainId": 42161,
@@ -2272,7 +2264,7 @@
       "name": "Darwinia Network",
       "symbol": "RING",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9443/thumb/RING.png?1696509535"
+      "logoURI": "https://assets.coingecko.com/coins/images/9443/large/RING.png?1696509535"
     },
     {
       "chainId": 42161,
@@ -2280,7 +2272,7 @@
       "name": "Bitoro",
       "symbol": "BTORO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50334/thumb/bitoro-logo-highres.jpg?1727306095"
+      "logoURI": "https://assets.coingecko.com/coins/images/50334/large/bitoro-logo-highres.jpg?1727306095"
     },
     {
       "chainId": 42161,
@@ -2288,7 +2280,7 @@
       "name": "LiquidDriver",
       "symbol": "LQDR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15782/thumb/LQDR_Glowing_Icon.png?1696515405"
+      "logoURI": "https://assets.coingecko.com/coins/images/15782/large/LQDR_Glowing_Icon.png?1696515405"
     },
     {
       "chainId": 42161,
@@ -2296,7 +2288,7 @@
       "name": "AI CODE",
       "symbol": "AICODE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30057/thumb/AICODE.png?1696528979"
+      "logoURI": "https://assets.coingecko.com/coins/images/30057/large/AICODE.png?1696528979"
     },
     {
       "chainId": 42161,
@@ -2304,7 +2296,7 @@
       "name": "USDA",
       "symbol": "USDA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34510/thumb/agUSD-coingecko.png?1705288392"
+      "logoURI": "https://assets.coingecko.com/coins/images/34510/large/agUSD-coingecko.png?1705288392"
     },
     {
       "chainId": 42161,
@@ -2312,7 +2304,7 @@
       "name": "GoSleep ZZZ",
       "symbol": "ZZZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29901/thumb/ZZZ200_200.png?1696528830"
+      "logoURI": "https://assets.coingecko.com/coins/images/29901/large/ZZZ200_200.png?1696528830"
     },
     {
       "chainId": 42161,
@@ -2320,15 +2312,7 @@
       "name": "sUSD",
       "symbol": "SUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1696505546"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb829b68f57cc546da7e5806a929e53be32a4625d",
-      "name": "Axelar Wrapped Ether",
-      "symbol": "AXLETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28171/thumb/weth-wei_D_3x.png?1696527174"
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/large/sUSD.png?1696505546"
     },
     {
       "chainId": 42161,
@@ -2336,7 +2320,7 @@
       "name": "MUX Protocol",
       "symbol": "MCB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11796/thumb/mux.jpg?1696511672"
+      "logoURI": "https://assets.coingecko.com/coins/images/11796/large/mux.jpg?1696511672"
     },
     {
       "chainId": 42161,
@@ -2344,7 +2328,7 @@
       "name": "Clipper SAIL",
       "symbol": "SAIL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31380/thumb/SAIL-Logo.png?1696530197"
+      "logoURI": "https://assets.coingecko.com/coins/images/31380/large/SAIL-Logo.png?1696530197"
     },
     {
       "chainId": 42161,
@@ -2352,7 +2336,7 @@
       "name": "YfDAI finance",
       "symbol": "YF-DAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12385/thumb/1619048513068.png?1696512208"
+      "logoURI": "https://assets.coingecko.com/coins/images/12385/large/1619048513068.png?1696512208"
     },
     {
       "chainId": 42161,
@@ -2360,7 +2344,7 @@
       "name": "Overnight Finance",
       "symbol": "OVN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31970/thumb/OVN.png?1696959174"
+      "logoURI": "https://assets.coingecko.com/coins/images/31970/large/OVN.png?1696959174"
     },
     {
       "chainId": 42161,
@@ -2368,7 +2352,7 @@
       "name": "Hord",
       "symbol": "HORD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14972/thumb/HORD_TOKEN_%281%29_1.png?1705414356"
+      "logoURI": "https://assets.coingecko.com/coins/images/14972/large/HORD_TOKEN_%281%29_1.png?1705414356"
     },
     {
       "chainId": 42161,
@@ -2376,15 +2360,7 @@
       "name": "THORWallet DEX",
       "symbol": "TGT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21843/thumb/tgt_logo.png?1696521198"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb00eaedb98f1e30ad545703d8ff14b24d109514f",
-      "name": "Yaku",
-      "symbol": "YAKU",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/26785/thumb/yaku_logo.png?1706636424"
+      "logoURI": "https://assets.coingecko.com/coins/images/21843/large/tgt_logo.png?1696521198"
     },
     {
       "chainId": 42161,
@@ -2392,31 +2368,15 @@
       "name": "Guardian GUARD",
       "symbol": "GUARD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17995/thumb/LS_wolfDen_logo.0025_Light_200x200.png?1696517512"
+      "logoURI": "https://assets.coingecko.com/coins/images/17995/large/LS_wolfDen_logo.0025_Light_200x200.png?1696517512"
     },
     {
       "chainId": 42161,
-      "address": "0x47c337bd5b9344a6f3d6f58c474d9d8cd419d8ca",
-      "name": "DackieSwap",
-      "symbol": "DACKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30752/thumb/dackieswap_large.png?1707290196"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4e51ac49bc5e2d87e0ef713e9e5ab2d71ef4f336",
-      "name": "Celo  Wormhole ",
-      "symbol": "CELO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32400/thumb/celo_wh.png?1698055352"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xee0b14e8fc86691cf6ee42b9954985b4cf968534",
-      "name": "ZenPandaCoin",
-      "symbol": "ZPC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30269/thumb/panda.png?1696529176"
+      "address": "0xb00eaedb98f1e30ad545703d8ff14b24d109514f",
+      "name": "Yaku",
+      "symbol": "YAKU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26785/large/yaku_logo.png?1706636424"
     },
     {
       "chainId": 42161,
@@ -2424,7 +2384,31 @@
       "name": "Black Agnus",
       "symbol": "FTW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50170/thumb/32x32.png?1727177729"
+      "logoURI": "https://assets.coingecko.com/coins/images/50170/large/32x32.png?1727177729"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x47c337bd5b9344a6f3d6f58c474d9d8cd419d8ca",
+      "name": "DackieSwap",
+      "symbol": "DACKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30752/large/dackieswap_large.png?1707290196"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e51ac49bc5e2d87e0ef713e9e5ab2d71ef4f336",
+      "name": "Celo  Wormhole ",
+      "symbol": "CELO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32400/large/celo_wh.png?1698055352"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xee0b14e8fc86691cf6ee42b9954985b4cf968534",
+      "name": "ZenPandaCoin",
+      "symbol": "ZPC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30269/large/panda.png?1696529176"
     },
     {
       "chainId": 42161,
@@ -2432,7 +2416,7 @@
       "name": "Hello Pets",
       "symbol": "PET",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14354/thumb/hello_pets.jpg?1696514040"
+      "logoURI": "https://assets.coingecko.com/coins/images/14354/large/hello_pets.jpg?1696514040"
     },
     {
       "chainId": 42161,
@@ -2440,7 +2424,7 @@
       "name": "DeltaPrime",
       "symbol": "PRIME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39234/thumb/PRIME.jpg?1721240215"
+      "logoURI": "https://assets.coingecko.com/coins/images/39234/large/PRIME.jpg?1721240215"
     },
     {
       "chainId": 42161,
@@ -2448,7 +2432,7 @@
       "name": "Kabosu  Arbitrum ",
       "symbol": "KABOSU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30320/thumb/IMG_20230510_204814_554_copy_200x200.jpg?1696529222"
+      "logoURI": "https://assets.coingecko.com/coins/images/30320/large/IMG_20230510_204814_554_copy_200x200.jpg?1696529222"
     },
     {
       "chainId": 42161,
@@ -2456,7 +2440,7 @@
       "name": "Arbswap",
       "symbol": "ARBS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30565/thumb/Arb-Logo_Circle_DARK_LOGO_ONLY.png?1696529436"
+      "logoURI": "https://assets.coingecko.com/coins/images/30565/large/Arb-Logo_Circle_DARK_LOGO_ONLY.png?1696529436"
     },
     {
       "chainId": 42161,
@@ -2464,7 +2448,7 @@
       "name": "Lumi Finance",
       "symbol": "LUA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33502/thumb/LUA.png?1702038548"
+      "logoURI": "https://assets.coingecko.com/coins/images/33502/large/LUA.png?1702038548"
     },
     {
       "chainId": 42161,
@@ -2472,7 +2456,7 @@
       "name": "MTMS Network",
       "symbol": "MTMS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39043/thumb/Logo-MTMS.png?1720067131"
+      "logoURI": "https://assets.coingecko.com/coins/images/39043/large/Logo-MTMS.png?1720067131"
     },
     {
       "chainId": 42161,
@@ -2480,7 +2464,7 @@
       "name": "WorldBrain Coin",
       "symbol": "WBC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39650/thumb/Frame_48096646.png?1723455673"
+      "logoURI": "https://assets.coingecko.com/coins/images/39650/large/Frame_48096646.png?1723455673"
     },
     {
       "chainId": 42161,
@@ -2488,7 +2472,7 @@
       "name": "X World Games",
       "symbol": "XWG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17847/thumb/200_200_%281%29_%281%29.png?1696790226"
+      "logoURI": "https://assets.coingecko.com/coins/images/17847/large/200_200_%281%29_%281%29.png?1696790226"
     },
     {
       "chainId": 42161,
@@ -2496,7 +2480,7 @@
       "name": "Smolcoin",
       "symbol": "SMOL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33951/thumb/Smol_Coin_Icon.png?1703558329"
+      "logoURI": "https://assets.coingecko.com/coins/images/33951/large/Smol_Coin_Icon.png?1703558329"
     },
     {
       "chainId": 42161,
@@ -2504,15 +2488,7 @@
       "name": "SpaceCatch",
       "symbol": "CATCH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36632/thumb/Logomark_colours.png?1712022405"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0341c0c0ec423328621788d4854119b97f44e391",
-      "name": "Silo Finance",
-      "symbol": "SILO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21454/thumb/y0iYKZOv_400x400.png?1696520816"
+      "logoURI": "https://assets.coingecko.com/coins/images/36632/large/Logomark_colours.png?1712022405"
     },
     {
       "chainId": 42161,
@@ -2520,7 +2496,15 @@
       "name": "XDAO",
       "symbol": "XDAO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27363/thumb/token_2.png?1696526408"
+      "logoURI": "https://assets.coingecko.com/coins/images/27363/large/token_2.png?1696526408"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0341c0c0ec423328621788d4854119b97f44e391",
+      "name": "Silo Finance",
+      "symbol": "SILO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21454/large/y0iYKZOv_400x400.png?1696520816"
     },
     {
       "chainId": 42161,
@@ -2528,7 +2512,7 @@
       "name": "Gains Network USDC",
       "symbol": "GUSDC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39042/thumb/logo_gUSDC.png?1720066451"
+      "logoURI": "https://assets.coingecko.com/coins/images/39042/large/logo_gUSDC.png?1720066451"
     },
     {
       "chainId": 42161,
@@ -2536,7 +2520,7 @@
       "name": "Zunami ETH",
       "symbol": "ZUNETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37835/thumb/zunETH_200x200.png?1715741123"
+      "logoURI": "https://assets.coingecko.com/coins/images/37835/large/zunETH_200x200.png?1715741123"
     },
     {
       "chainId": 42161,
@@ -2544,95 +2528,7 @@
       "name": "OpenBlox",
       "symbol": "OBX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26150/thumb/OBX_token-black_background_preview.png?1696525239"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3405e88af759992937b84e58f2fe691ef0eea320",
-      "name": "Frax Price Index Share",
-      "symbol": "FPIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24944/thumb/FPIS_icon.png?1696524099"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xad4b9c1fbf4923061814dd9d5732eb703faa53d4",
-      "name": "Wicrypt",
-      "symbol": "WNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21223/thumb/wicrypt.PNG?1696520597"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2b089381f53525451fe5115f23e9d2cc92d7ff1d",
-      "name": "Digital Reserve Currency",
-      "symbol": "DRC",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/12802/thumb/DRC_Logo.jpg?1696512595"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2ea0be86990e8dac0d09e4316bb92086f304622d",
-      "name": "TheStandard USD",
-      "symbol": "USDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50381/thumb/USDs-200x200.png?1727411027"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4debfb9ed639144cf1e401674af361ffffcefb58",
-      "name": "CADAI",
-      "symbol": "CADAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38713/thumb/CADAI_Token_Logo.png?1718404394"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe3b3fe7bca19ca77ad877a5bebab186becfad906",
-      "name": "Staked FRAX",
-      "symbol": "SFRAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35383/thumb/sfrax.png?1708445569"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x20547341e58fb558637fa15379c92e11f7b7f710",
-      "name": "Mozaic",
-      "symbol": "MOZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30100/thumb/Main_Logo_1-200x200jpg.jpg?1696529024"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x130096af9163b185cae4a833f856760199fc6ceb",
-      "name": "FU Money",
-      "symbol": "FU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38629/thumb/FU_logo_black.png?1718170125"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x34229b3f16fbcdfa8d8d9d17c0852f9496f4c7bb",
-      "name": "IPOR",
-      "symbol": "IPOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28373/thumb/IPOR-token-200x200.png?1696527376"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbfbcfe8873fe28dfa25f1099282b088d52bbad9c",
-      "name": "Equilibria Finance",
-      "symbol": "EQB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30645/thumb/QLLK8pmR_400x400.jpg?1696529516"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x86f65121804d2cdbef79f9f072d4e0c2eebabc08",
-      "name": "Garden",
-      "symbol": "SEED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34671/thumb/icon.png?1705656915"
+      "logoURI": "https://assets.coingecko.com/coins/images/26150/large/OBX_token-black_background_preview.png?1696525239"
     },
     {
       "chainId": 42161,
@@ -2640,7 +2536,95 @@
       "name": "Star",
       "symbol": "STAR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31277/thumb/coin-icon_Star-200x200.png?1732742256"
+      "logoURI": "https://assets.coingecko.com/coins/images/31277/large/coin-icon_Star-200x200.png?1732742256"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3405e88af759992937b84e58f2fe691ef0eea320",
+      "name": "Frax Price Index Share",
+      "symbol": "FPIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24944/large/FPIS_icon.png?1696524099"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xad4b9c1fbf4923061814dd9d5732eb703faa53d4",
+      "name": "Wicrypt",
+      "symbol": "WNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21223/large/wicrypt.PNG?1696520597"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2b089381f53525451fe5115f23e9d2cc92d7ff1d",
+      "name": "Digital Reserve Currency",
+      "symbol": "DRC",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/12802/large/DRC_Logo.jpg?1696512595"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4debfb9ed639144cf1e401674af361ffffcefb58",
+      "name": "CADAI",
+      "symbol": "CADAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38713/large/CADAI_Token_Logo.png?1718404394"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2ea0be86990e8dac0d09e4316bb92086f304622d",
+      "name": "TheStandard USD",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50381/large/USDs-200x200.png?1727411027"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe3b3fe7bca19ca77ad877a5bebab186becfad906",
+      "name": "Staked FRAX",
+      "symbol": "SFRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35383/large/sfrax.png?1708445569"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x34229b3f16fbcdfa8d8d9d17c0852f9496f4c7bb",
+      "name": "IPOR",
+      "symbol": "IPOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png?1696527376"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x20547341e58fb558637fa15379c92e11f7b7f710",
+      "name": "Mozaic",
+      "symbol": "MOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30100/large/Main_Logo_1-200x200jpg.jpg?1696529024"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x130096af9163b185cae4a833f856760199fc6ceb",
+      "name": "FU Money",
+      "symbol": "FU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38629/large/FU_logo_black.png?1718170125"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfbcfe8873fe28dfa25f1099282b088d52bbad9c",
+      "name": "Equilibria Finance",
+      "symbol": "EQB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30645/large/QLLK8pmR_400x400.jpg?1696529516"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x86f65121804d2cdbef79f9f072d4e0c2eebabc08",
+      "name": "Garden",
+      "symbol": "SEED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34671/large/icon.png?1705656915"
     },
     {
       "chainId": 42161,
@@ -2648,7 +2632,15 @@
       "name": "GNB",
       "symbol": "GNB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38687/thumb/GINAICNLOGO.png?1718344439"
+      "logoURI": "https://assets.coingecko.com/coins/images/38687/large/GINAICNLOGO.png?1718344439"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb829b68f57cc546da7e5806a929e53be32a4625d",
+      "name": "Axelar Wrapped Ether",
+      "symbol": "AXLETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28171/large/weth-wei_D_3x.png?1696527174"
     },
     {
       "chainId": 42161,
@@ -2656,7 +2648,7 @@
       "name": "EUROe Stablecoin",
       "symbol": "EUROE",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/28913/thumb/euroe-200x200-round.png?1696527889"
+      "logoURI": "https://assets.coingecko.com/coins/images/28913/large/euroe-200x200-round.png?1696527889"
     },
     {
       "chainId": 42161,
@@ -2664,7 +2656,7 @@
       "name": "Ledgity Token",
       "symbol": "LDY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35046/thumb/ldy-token.png?1707204910"
+      "logoURI": "https://assets.coingecko.com/coins/images/35046/large/ldy-token.png?1707204910"
     },
     {
       "chainId": 42161,
@@ -2672,7 +2664,7 @@
       "name": "GYEN",
       "symbol": "GYEN",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1696513909"
+      "logoURI": "https://assets.coingecko.com/coins/images/14191/large/icon_gyen_200_200.png?1696513909"
     },
     {
       "chainId": 42161,
@@ -2680,15 +2672,7 @@
       "name": "Zunami Governance Token",
       "symbol": "ZUN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38298/thumb/ZUN_200x200.png?1717194404"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9cf7eebb75b751dc8fdd2268ae8c9b570b4c97b9",
-      "name": "NULL MATRIX",
-      "symbol": "NULL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51086/thumb/dark.png?1732460149"
+      "logoURI": "https://assets.coingecko.com/coins/images/38298/large/ZUN_200x200.png?1717194404"
     },
     {
       "chainId": 42161,
@@ -2696,7 +2680,15 @@
       "name": "AI Meta Club",
       "symbol": "AMC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31919/thumb/aimeta.jpg?1696530728"
+      "logoURI": "https://assets.coingecko.com/coins/images/31919/large/aimeta.jpg?1696530728"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9cf7eebb75b751dc8fdd2268ae8c9b570b4c97b9",
+      "name": "NULL MATRIX",
+      "symbol": "NULL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51086/large/dark.png?1732460149"
     },
     {
       "chainId": 42161,
@@ -2704,7 +2696,7 @@
       "name": "Overnight fi USDT ",
       "symbol": "USDT+",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/30168/thumb/USDT_.png?1696529088"
+      "logoURI": "https://assets.coingecko.com/coins/images/30168/large/USDT_.png?1696529088"
     },
     {
       "chainId": 42161,
@@ -2712,7 +2704,7 @@
       "name": "Dopex Rebate",
       "symbol": "RDPX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16659/thumb/rDPX_200x200_Coingecko.png?1696516221"
+      "logoURI": "https://assets.coingecko.com/coins/images/16659/large/rDPX_200x200_Coingecko.png?1696516221"
     },
     {
       "chainId": 42161,
@@ -2720,7 +2712,7 @@
       "name": "Router Protocol  OLD ",
       "symbol": "ROUTE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13709/thumb/router.jpg?1722424977"
+      "logoURI": "https://assets.coingecko.com/coins/images/13709/large/router.jpg?1722424977"
     },
     {
       "chainId": 42161,
@@ -2728,7 +2720,7 @@
       "name": "Bean",
       "symbol": "BEAN",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/18447/thumb/bean-logo-coingecko.png?1696517934"
+      "logoURI": "https://assets.coingecko.com/coins/images/18447/large/bean-logo-coingecko.png?1696517934"
     },
     {
       "chainId": 42161,
@@ -2736,7 +2728,7 @@
       "name": "Foxify",
       "symbol": "FOX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32354/thumb/Foxify_200x200.png?1697475371"
+      "logoURI": "https://assets.coingecko.com/coins/images/32354/large/Foxify_200x200.png?1697475371"
     },
     {
       "chainId": 42161,
@@ -2744,7 +2736,7 @@
       "name": "Quick Intel",
       "symbol": "QKNTL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29605/thumb/IMG_6589D0616DF1-1.jpeg?1696528542"
+      "logoURI": "https://assets.coingecko.com/coins/images/29605/large/IMG_6589D0616DF1-1.jpeg?1696528542"
     },
     {
       "chainId": 42161,
@@ -2752,7 +2744,7 @@
       "name": "Numa",
       "symbol": "NUMA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35807/thumb/numa200.png?1709845645"
+      "logoURI": "https://assets.coingecko.com/coins/images/35807/large/numa200.png?1709845645"
     },
     {
       "chainId": 42161,
@@ -2760,7 +2752,7 @@
       "name": "SX Network",
       "symbol": "SX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34934/thumb/sx-ntework.jpeg?1706699134"
+      "logoURI": "https://assets.coingecko.com/coins/images/34934/large/sx-ntework.jpeg?1706699134"
     },
     {
       "chainId": 42161,
@@ -2768,7 +2760,7 @@
       "name": "FactorDAO",
       "symbol": "FCTR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29018/thumb/FactorLogo.png?1696527989"
+      "logoURI": "https://assets.coingecko.com/coins/images/29018/large/FactorLogo.png?1696527989"
     },
     {
       "chainId": 42161,
@@ -2776,7 +2768,7 @@
       "name": "Eclipse Fi",
       "symbol": "ECLIP",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/31815/thumb/ECLIP_token_logo.png?1696530629"
+      "logoURI": "https://assets.coingecko.com/coins/images/31815/large/ECLIP_token_logo.png?1696530629"
     },
     {
       "chainId": 42161,
@@ -2784,23 +2776,7 @@
       "name": "usdx money USDX",
       "symbol": "USDX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50360/thumb/USDX200px.png?1731906044"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd3188e0df68559c0b63361f6160c57ad88b239d8",
-      "name": "Astra DAO",
-      "symbol": "ASTRADAO",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/32870/thumb/ASTRADAO.jpg?1699673097"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9fb9a33956351cf4fa040f65a13b835a3c8764e3",
-      "name": "Multichain",
-      "symbol": "MULTI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1696521430"
+      "logoURI": "https://assets.coingecko.com/coins/images/50360/large/USDX200px.png?1731906044"
     },
     {
       "chainId": 42161,
@@ -2808,7 +2784,23 @@
       "name": "Cradles",
       "symbol": "CRDS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33084/thumb/cradles_icon.png?1700601703"
+      "logoURI": "https://assets.coingecko.com/coins/images/33084/large/cradles_icon.png?1700601703"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9fb9a33956351cf4fa040f65a13b835a3c8764e3",
+      "name": "Multichain",
+      "symbol": "MULTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22087/large/1_Wyot-SDGZuxbjdkaOeT2-A.png?1696521430"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd3188e0df68559c0b63361f6160c57ad88b239d8",
+      "name": "Astra DAO",
+      "symbol": "ASTRADAO",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/32870/large/ASTRADAO.jpg?1699673097"
     },
     {
       "chainId": 42161,
@@ -2816,7 +2808,7 @@
       "name": "LilAI",
       "symbol": "LILAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30621/thumb/LogoLilai_CoinGecko.png?1696529495"
+      "logoURI": "https://assets.coingecko.com/coins/images/30621/large/LogoLilai_CoinGecko.png?1696529495"
     },
     {
       "chainId": 42161,
@@ -2824,7 +2816,7 @@
       "name": "Bonsai",
       "symbol": "BONSAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37883/thumb/bonsai.jpeg?1715840730"
+      "logoURI": "https://assets.coingecko.com/coins/images/37883/large/bonsai.jpeg?1715840730"
     },
     {
       "chainId": 42161,
@@ -2832,7 +2824,7 @@
       "name": "MAI  Arbitrum ",
       "symbol": "MIMATIC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35517/thumb/mimatic-red.png?1709005586"
+      "logoURI": "https://assets.coingecko.com/coins/images/35517/large/mimatic-red.png?1709005586"
     },
     {
       "chainId": 42161,
@@ -2840,7 +2832,7 @@
       "name": "Avarik Saga",
       "symbol": "AVRK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51914/thumb/Logo500x500.png?1732258561"
+      "logoURI": "https://assets.coingecko.com/coins/images/51914/large/Logo500x500.png?1732258561"
     },
     {
       "chainId": 42161,
@@ -2848,7 +2840,7 @@
       "name": "Yield Yak",
       "symbol": "YAK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17654/thumb/yieldyak.png?1696517185"
+      "logoURI": "https://assets.coingecko.com/coins/images/17654/large/yieldyak.png?1696517185"
     },
     {
       "chainId": 42161,
@@ -2856,7 +2848,7 @@
       "name": "TheStandard Token",
       "symbol": "TST",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20598/thumb/TheStandard-logo_variation-01.png?1696520005"
+      "logoURI": "https://assets.coingecko.com/coins/images/20598/large/TheStandard-logo_variation-01.png?1696520005"
     },
     {
       "chainId": 42161,
@@ -2864,7 +2856,7 @@
       "name": "OtterHome",
       "symbol": "HOME",
       "decimals": 16,
-      "logoURI": "https://assets.coingecko.com/coins/images/30740/thumb/LOGO.png?1696529610"
+      "logoURI": "https://assets.coingecko.com/coins/images/30740/large/LOGO.png?1696529610"
     },
     {
       "chainId": 42161,
@@ -2872,7 +2864,7 @@
       "name": "DFX Finance",
       "symbol": "DFX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14091/thumb/DFX.png?1696513813"
+      "logoURI": "https://assets.coingecko.com/coins/images/14091/large/DFX.png?1696513813"
     },
     {
       "chainId": 42161,
@@ -2880,183 +2872,7 @@
       "name": "BattleFly",
       "symbol": "GFLY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28828/thumb/GFLY_LOGO.png?1696527804"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x577fd586c9e6ba7f2e85e025d5824dbe19896656",
-      "name": "Synonym Finance",
-      "symbol": "SYNO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35065/thumb/SYNO-token.png?1707241258"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1a5b0aaf478bf1fda7b934c76e7692d722982a6d",
-      "name": "Buffer Token",
-      "symbol": "BFR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18540/thumb/Qk6pjeZ3_400x400.jpg?1696518020"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xde70aed3d14d39b4955147efcf272334bdb75ab5",
-      "name": "YachtingVerse",
-      "symbol": "YACHT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32858/thumb/aMmNwBTH_400x400.jpg?1699666370"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xddd6ebd74684318fa912084a41a01f11b6c277f7",
-      "name": "WorkoutApp",
-      "symbol": "WRT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37270/thumb/wrt.jpg?1713888102"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4b019aaa21e98e212d31e54c843e73ff34d25717",
-      "name": "TUX Project",
-      "symbol": "TUXC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37537/thumb/tuxc.jpg?1714687219"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
-      "name": "BetSwirl",
-      "symbol": "BETS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26618/thumb/icon_200.png?1696525691"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x56659245931cb6920e39c189d2a0e7dd0da2d57b",
-      "name": "Impermax",
-      "symbol": "IBEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27606/thumb/IqwOmX-c_400x400.jpeg?1696526637"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xef04804e1e474d3f9b73184d7ef5d786f3fce930",
-      "name": "Wall Street Games",
-      "symbol": "WSG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36483/thumb/wsg.jpeg?1711539007"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xafe8107123eefd62469474dec9680860b890e5b6",
-      "name": "Oil Token",
-      "symbol": "OIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39504/thumb/logo_oil_200%D1%85200.png?1722581566"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x949185d3be66775ea648f4a306740ea9eff9c567",
-      "name": "Yel Finance",
-      "symbol": "YEL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17429/thumb/Logo200.png?1696516976"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
-      "name": "Pickle Finance",
-      "symbol": "PICKLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12435/thumb/0M4W6Yr6_400x400.jpg?1696512255"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0002bcdaf53f4889bf2f43a3252d7c03fe1b80bc",
-      "name": "GorplesCoin",
-      "symbol": "GORPLES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38681/thumb/Round_Avatar.png?1720520435"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x54bdbf3ce36f451ec61493236b8e6213ac87c0f6",
-      "name": "Radpie",
-      "symbol": "RDP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34052/thumb/Radpie_token_3_2.png?1704672743"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x80dd74145b8bb10cef01bf914f796bd8b54d7809",
-      "name": "Hepton",
-      "symbol": "HTE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30274/thumb/HTECoingecko.png?1696529180"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6dbf2155b0636cb3fd5359fccefb8a2c02b6cb51",
-      "name": "Plutus RDNT",
-      "symbol": "PLSRDNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30635/thumb/plsRDNT.png?1696529508"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x51fc0f6660482ea73330e414efd7808811a57fa2",
-      "name": "Premia",
-      "symbol": "PREMIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13962/thumb/apple-touch-icon.png?1696513698"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9cce9ae579142e372a8959285e3a5a2e211904f7",
-      "name": "DGWToken",
-      "symbol": "DGW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39642/thumb/1000146817.jpg?1723410321"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x249c48e22e95514ca975de31f473f30c2f3c0916",
-      "name": "USDFI",
-      "symbol": "USDFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31149/thumb/USDFI_200.png?1696529977"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa334884bf6b0a066d553d19e507315e839409e62",
-      "name": "Ethos Reserve Note",
-      "symbol": "ERN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29744/thumb/ERN200x200.png?1696528676"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x64343594ab9b56e99087bfa6f2335db24c2d1f17",
-      "name": "Vesta Stable",
-      "symbol": "VST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23621/thumb/vesta.png?1696522826"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa9011ee5796be43123651181dc75c0e72bb1191c",
-      "name": "NeuroPulse AI",
-      "symbol": "NPAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31848/thumb/NPAI.png?1700257725"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9cfb13e6c11054ac9fcb92ba89644f30775436e4",
-      "name": "Bridged Wrapped stETH  Axelar ",
-      "symbol": "AXL-WSTETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32223/thumb/steth-wei_D_3x.png?1696926841"
+      "logoURI": "https://assets.coingecko.com/coins/images/28828/large/GFLY_LOGO.png?1696527804"
     },
     {
       "chainId": 42161,
@@ -3064,95 +2880,151 @@
       "name": "Sumer Money suUSD",
       "symbol": "SUUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33266/thumb/Sumer_Money_Logo.jpg?1701321416"
+      "logoURI": "https://assets.coingecko.com/coins/images/33266/large/Sumer_Money_Logo.jpg?1701321416"
     },
     {
       "chainId": 42161,
-      "address": "0xecc68d0451e20292406967fe7c04280e5238ac7d",
-      "name": "Axelar Bridged Frax Ether",
-      "symbol": "AXLFRXETH",
+      "address": "0x577fd586c9e6ba7f2e85e025d5824dbe19896656",
+      "name": "Synonym Finance",
+      "symbol": "SYNO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38976/thumb/Screen_Shot_2024-06-18_at_12.55.54_PM_2.png?1719714886"
+      "logoURI": "https://assets.coingecko.com/coins/images/35065/large/SYNO-token.png?1707241258"
     },
     {
       "chainId": 42161,
-      "address": "0x221a0f68770658c15b525d0f89f5da2baab5f321",
-      "name": "Open Dollar",
-      "symbol": "OD",
+      "address": "0x1a5b0aaf478bf1fda7b934c76e7692d722982a6d",
+      "name": "Buffer Token",
+      "symbol": "BFR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38630/thumb/OD_Token_200_x_200.png?1718170821"
+      "logoURI": "https://assets.coingecko.com/coins/images/18540/large/Qk6pjeZ3_400x400.jpg?1696518020"
     },
     {
       "chainId": 42161,
-      "address": "0xd4848211b699503c772aa1bc7d33b433c4242ac3",
-      "name": "Equilibria Finance ePENDLE",
-      "symbol": "EPENDLE",
+      "address": "0xde70aed3d14d39b4955147efcf272334bdb75ab5",
+      "name": "YachtingVerse",
+      "symbol": "YACHT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33379/thumb/photo_2023-12-02_19-45-14.jpg?1701665986"
+      "logoURI": "https://assets.coingecko.com/coins/images/32858/large/aMmNwBTH_400x400.jpg?1699666370"
     },
     {
       "chainId": 42161,
-      "address": "0x07e49d5de43dda6162fa28d24d5935c151875283",
-      "name": "CVI",
-      "symbol": "GOVI",
+      "address": "0xddd6ebd74684318fa912084a41a01f11b6c277f7",
+      "name": "WorkoutApp",
+      "symbol": "WRT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13875/thumb/GOVI.png?1696513619"
+      "logoURI": "https://assets.coingecko.com/coins/images/37270/large/wrt.jpg?1713888102"
     },
     {
       "chainId": 42161,
-      "address": "0xe4421566a501045ae4285996577a36f6cf074190",
-      "name": "Ice",
-      "symbol": "ICE",
+      "address": "0x4b019aaa21e98e212d31e54c843e73ff34d25717",
+      "name": "TUX Project",
+      "symbol": "TUXC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35093/thumb/ICE_LOGO.jpg?1707363813"
+      "logoURI": "https://assets.coingecko.com/coins/images/37537/large/tuxc.jpg?1714687219"
     },
     {
       "chainId": 42161,
-      "address": "0x498c620c7c91c6eba2e3cd5485383f41613b7eb6",
-      "name": "Alongside Crypto Market Index",
-      "symbol": "AMKT",
+      "address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
+      "name": "BetSwirl",
+      "symbol": "BETS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28496/thumb/22999.png?1696527488"
+      "logoURI": "https://assets.coingecko.com/coins/images/26618/large/icon_200.png?1696525691"
     },
     {
       "chainId": 42161,
-      "address": "0x31c91d8fb96bff40955dd2dbc909b36e8b104dde",
-      "name": "Poison Finance",
-      "symbol": "POION",
+      "address": "0x56659245931cb6920e39c189d2a0e7dd0da2d57b",
+      "name": "Impermax",
+      "symbol": "IBEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28630/thumb/poisonlogo160x160.png?1696527614"
+      "logoURI": "https://assets.coingecko.com/coins/images/27606/large/IqwOmX-c_400x400.jpeg?1696526637"
     },
     {
       "chainId": 42161,
-      "address": "0xd978f8489e1245568704407a479a71fcce2afe8f",
-      "name": "ApeSwap",
-      "symbol": "BANANA",
+      "address": "0xef04804e1e474d3f9b73184d7ef5d786f3fce930",
+      "name": "Wall Street Games",
+      "symbol": "WSG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14870/thumb/banana.png?1696514534"
+      "logoURI": "https://assets.coingecko.com/coins/images/36483/large/wsg.jpeg?1711539007"
     },
     {
       "chainId": 42161,
-      "address": "0x079504b86d38119f859c4194765029f692b7b7aa",
-      "name": "Lyra Finance",
-      "symbol": "LYRA",
+      "address": "0xafe8107123eefd62469474dec9680860b890e5b6",
+      "name": "Oil Token",
+      "symbol": "OIL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21490/thumb/Add-a-heading-26.png?1696520850"
+      "logoURI": "https://assets.coingecko.com/coins/images/39504/large/logo_oil_200%D1%85200.png?1722581566"
     },
     {
       "chainId": 42161,
-      "address": "0xafccb724e3aec1657fc9514e3e53a0e71e80622d",
-      "name": "Vaultka",
-      "symbol": "VKA",
+      "address": "0x0002bcdaf53f4889bf2f43a3252d7c03fe1b80bc",
+      "name": "GorplesCoin",
+      "symbol": "GORPLES",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32408/thumb/VKA_logo_PNG.png?1698057073"
+      "logoURI": "https://assets.coingecko.com/coins/images/38681/large/Round_Avatar.png?1720520435"
     },
     {
       "chainId": 42161,
-      "address": "0x8347dff20de05b11c0781aaea90d5bee46c30252",
-      "name": "Playahh App",
-      "symbol": "PLAH",
+      "address": "0x949185d3be66775ea648f4a306740ea9eff9c567",
+      "name": "Yel Finance",
+      "symbol": "YEL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40098/thumb/logoPlayahh10.png?1725632328"
+      "logoURI": "https://assets.coingecko.com/coins/images/17429/large/Logo200.png?1696516976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
+      "name": "Pickle Finance",
+      "symbol": "PICKLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12435/large/0M4W6Yr6_400x400.jpg?1696512255"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x965d00aa7abc62ca10132e641d08593435ac811d",
+      "name": "KAP Games",
+      "symbol": "KAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27682/large/KAP_Logo.png?1696526710"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x54bdbf3ce36f451ec61493236b8e6213ac87c0f6",
+      "name": "Radpie",
+      "symbol": "RDP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34052/large/Radpie_token_3_2.png?1704672743"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x80dd74145b8bb10cef01bf914f796bd8b54d7809",
+      "name": "Hepton",
+      "symbol": "HTE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30274/large/HTECoingecko.png?1696529180"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6dbf2155b0636cb3fd5359fccefb8a2c02b6cb51",
+      "name": "Plutus RDNT",
+      "symbol": "PLSRDNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30635/large/plsRDNT.png?1696529508"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51fc0f6660482ea73330e414efd7808811a57fa2",
+      "name": "Premia",
+      "symbol": "PREMIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13962/large/apple-touch-icon.png?1696513698"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x249c48e22e95514ca975de31f473f30c2f3c0916",
+      "name": "USDFI",
+      "symbol": "USDFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31149/large/USDFI_200.png?1696529977"
     },
     {
       "chainId": 42161,
@@ -3160,7 +3032,119 @@
       "name": "ArbiDoge",
       "symbol": "ADOGE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18333/thumb/Screen-Shot-2021-09-04-at-11-59-16-AM.png?1696517824"
+      "logoURI": "https://assets.coingecko.com/coins/images/18333/large/Screen-Shot-2021-09-04-at-11-59-16-AM.png?1696517824"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa334884bf6b0a066d553d19e507315e839409e62",
+      "name": "Ethos Reserve Note",
+      "symbol": "ERN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29744/large/ERN200x200.png?1696528676"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x64343594ab9b56e99087bfa6f2335db24c2d1f17",
+      "name": "Vesta Stable",
+      "symbol": "VST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23621/large/vesta.png?1696522826"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9cce9ae579142e372a8959285e3a5a2e211904f7",
+      "name": "DGWToken",
+      "symbol": "DGW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39642/large/1000146817.jpg?1723410321"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa9011ee5796be43123651181dc75c0e72bb1191c",
+      "name": "NeuroPulse AI",
+      "symbol": "NPAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31848/large/NPAI.png?1700257725"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9cfb13e6c11054ac9fcb92ba89644f30775436e4",
+      "name": "Bridged Wrapped stETH  Axelar ",
+      "symbol": "AXL-WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32223/large/steth-wei_D_3x.png?1696926841"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xecc68d0451e20292406967fe7c04280e5238ac7d",
+      "name": "Axelar Bridged Frax Ether",
+      "symbol": "AXLFRXETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38976/large/Screen_Shot_2024-06-18_at_12.55.54_PM_2.png?1719714886"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x221a0f68770658c15b525d0f89f5da2baab5f321",
+      "name": "Open Dollar",
+      "symbol": "OD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38630/large/OD_Token_200_x_200.png?1718170821"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd4848211b699503c772aa1bc7d33b433c4242ac3",
+      "name": "Equilibria Finance ePENDLE",
+      "symbol": "EPENDLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33379/large/photo_2023-12-02_19-45-14.jpg?1701665986"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x07e49d5de43dda6162fa28d24d5935c151875283",
+      "name": "CVI",
+      "symbol": "GOVI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13875/large/GOVI.png?1696513619"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe4421566a501045ae4285996577a36f6cf074190",
+      "name": "Ice",
+      "symbol": "ICE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35093/large/ICE_LOGO.jpg?1707363813"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x31c91d8fb96bff40955dd2dbc909b36e8b104dde",
+      "name": "Poison Finance",
+      "symbol": "POION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28630/large/poisonlogo160x160.png?1696527614"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd978f8489e1245568704407a479a71fcce2afe8f",
+      "name": "ApeSwap",
+      "symbol": "BANANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14870/large/banana.png?1696514534"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8347dff20de05b11c0781aaea90d5bee46c30252",
+      "name": "Playahh App",
+      "symbol": "PLAH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40098/large/logoPlayahh10.png?1725632328"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x079504b86d38119f859c4194765029f692b7b7aa",
+      "name": "Lyra Finance",
+      "symbol": "LYRA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21490/large/Add-a-heading-26.png?1696520850"
     },
     {
       "chainId": 42161,
@@ -3168,7 +3152,7 @@
       "name": "VEE",
       "symbol": "VEE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52199/thumb/1000002075.png?1732732974"
+      "logoURI": "https://assets.coingecko.com/coins/images/52199/large/1000002075.png?1732732974"
     },
     {
       "chainId": 42161,
@@ -3176,7 +3160,15 @@
       "name": "Pingu Exchange",
       "symbol": "PINGU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34790/thumb/icon_primary.png?1706030846"
+      "logoURI": "https://assets.coingecko.com/coins/images/34790/large/icon_primary.png?1706030846"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xafccb724e3aec1657fc9514e3e53a0e71e80622d",
+      "name": "Vaultka",
+      "symbol": "VKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32408/large/VKA_logo_PNG.png?1698057073"
     },
     {
       "chainId": 42161,
@@ -3184,7 +3176,7 @@
       "name": "Bitci DOGE",
       "symbol": "BOGE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38048/thumb/DOGE_TOKEN_200.png?1716401036"
+      "logoURI": "https://assets.coingecko.com/coins/images/38048/large/DOGE_TOKEN_200.png?1716401036"
     },
     {
       "chainId": 42161,
@@ -3192,7 +3184,7 @@
       "name": "handle fi",
       "symbol": "FOREX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18533/thumb/handle.fiFOREXLogoDark200x200.png?1696518013"
+      "logoURI": "https://assets.coingecko.com/coins/images/18533/large/handle.fiFOREXLogoDark200x200.png?1696518013"
     },
     {
       "chainId": 42161,
@@ -3200,7 +3192,15 @@
       "name": "Curve fi USDC USDT",
       "symbol": "2CRV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28365/thumb/curve2.png?1696527368"
+      "logoURI": "https://assets.coingecko.com/coins/images/28365/large/curve2.png?1696527368"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x498c620c7c91c6eba2e3cd5485383f41613b7eb6",
+      "name": "Alongside Crypto Market Index",
+      "symbol": "AMKT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28496/large/22999.png?1696527488"
     },
     {
       "chainId": 42161,
@@ -3208,7 +3208,7 @@
       "name": "KEWL EXCHANGE",
       "symbol": "KWL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36883/thumb/yamuk.png?1712649510"
+      "logoURI": "https://assets.coingecko.com/coins/images/36883/large/yamuk.png?1712649510"
     },
     {
       "chainId": 42161,
@@ -3216,7 +3216,7 @@
       "name": "ANIMA",
       "symbol": "ANIMA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30377/thumb/anima_logo_yellow.png?1696529271"
+      "logoURI": "https://assets.coingecko.com/coins/images/30377/large/anima_logo_yellow.png?1696529271"
     },
     {
       "chainId": 42161,
@@ -3224,7 +3224,7 @@
       "name": "Superpower Squad",
       "symbol": "SQUAD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28466/thumb/SQUAD200X200.png?1696527460"
+      "logoURI": "https://assets.coingecko.com/coins/images/28466/large/SQUAD200X200.png?1696527460"
     },
     {
       "chainId": 42161,
@@ -3232,23 +3232,7 @@
       "name": "Hermes Protocol",
       "symbol": "HERMES",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24251/thumb/Transparent-13_%281%29_%281%29.png?1725188033"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6f5401c53e2769c858665621d22ddbf53d8d27c5",
-      "name": "Connect Financial",
-      "symbol": "CNFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13592/thumb/cf-logo-iconic-black.png?1696513344"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x16a500aec6c37f84447ef04e66c57cfc6254cf92",
-      "name": "Umoja",
-      "symbol": "UMJA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38328/thumb/Umoja_Logo.png?1717639928"
+      "logoURI": "https://assets.coingecko.com/coins/images/24251/large/Transparent-13_%281%29_%281%29.png?1725188033"
     },
     {
       "chainId": 42161,
@@ -3256,23 +3240,15 @@
       "name": "Maia",
       "symbol": "MAIA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22502/thumb/Transparent-04_%281%29_%281%29.png?1725187885"
+      "logoURI": "https://assets.coingecko.com/coins/images/22502/large/Transparent-04_%281%29_%281%29.png?1725187885"
     },
     {
       "chainId": 42161,
-      "address": "0x65c936f008bc34fe819bce9fa5afd9dc2d49977f",
-      "name": "Y2K",
-      "symbol": "Y2K",
+      "address": "0x6f5401c53e2769c858665621d22ddbf53d8d27c5",
+      "name": "Connect Financial",
+      "symbol": "CNFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28542/thumb/l7jRo-5-_400x400.jpg?1696527534"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2fac624899a844e0628bfdcc70efcd25f6e90b95",
-      "name": "Youwho",
-      "symbol": "YOU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25353/thumb/youwho_200.png?1696524487"
+      "logoURI": "https://assets.coingecko.com/coins/images/13592/large/cf-logo-iconic-black.png?1696513344"
     },
     {
       "chainId": 42161,
@@ -3280,7 +3256,23 @@
       "name": "Verified USD",
       "symbol": "USDV",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/32948/thumb/usdv_%281%29.png?1699933314"
+      "logoURI": "https://assets.coingecko.com/coins/images/32948/large/usdv_%281%29.png?1699933314"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x16a500aec6c37f84447ef04e66c57cfc6254cf92",
+      "name": "Umoja",
+      "symbol": "UMJA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38328/large/Umoja_Logo.png?1717639928"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x65c936f008bc34fe819bce9fa5afd9dc2d49977f",
+      "name": "Y2K",
+      "symbol": "Y2K",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28542/large/l7jRo-5-_400x400.jpg?1696527534"
     },
     {
       "chainId": 42161,
@@ -3288,23 +3280,7 @@
       "name": "Dorado Finance",
       "symbol": "DORAB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38347/thumb/Dorado_Logo.png?1717143752"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb9af4762c039d63e30039f1712dfab77026408c7",
-      "name": "BullBear AI",
-      "symbol": "AIBB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30096/thumb/ICON_200.png?1696529020"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x643b34980e635719c15a2d4ce69571a258f940e9",
-      "name": "The Standard EURO",
-      "symbol": "EUROS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32231/thumb/EUROs-coingecko.png?1696936278"
+      "logoURI": "https://assets.coingecko.com/coins/images/38347/large/Dorado_Logo.png?1717143752"
     },
     {
       "chainId": 42161,
@@ -3312,7 +3288,31 @@
       "name": "Zyberswap",
       "symbol": "ZYB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28943/thumb/logo_with_bg.png?1696527917"
+      "logoURI": "https://assets.coingecko.com/coins/images/28943/large/logo_with_bg.png?1696527917"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb9af4762c039d63e30039f1712dfab77026408c7",
+      "name": "BullBear AI",
+      "symbol": "AIBB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30096/large/ICON_200.png?1696529020"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2fac624899a844e0628bfdcc70efcd25f6e90b95",
+      "name": "Youwho",
+      "symbol": "YOU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25353/large/youwho_200.png?1696524487"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x643b34980e635719c15a2d4ce69571a258f940e9",
+      "name": "The Standard EURO",
+      "symbol": "EUROS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32231/large/EUROs-coingecko.png?1696936278"
     },
     {
       "chainId": 42161,
@@ -3320,7 +3320,7 @@
       "name": "dHEDGE DAO",
       "symbol": "DHT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12508/thumb/dht.png?1696512323"
+      "logoURI": "https://assets.coingecko.com/coins/images/12508/large/dht.png?1696512323"
     },
     {
       "chainId": 42161,
@@ -3328,7 +3328,7 @@
       "name": "usdx money Staked USDX",
       "symbol": "SUSDX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50836/thumb/sUSDX200px.png?1731906119"
+      "logoURI": "https://assets.coingecko.com/coins/images/50836/large/sUSDX200px.png?1731906119"
     },
     {
       "chainId": 42161,
@@ -3336,7 +3336,7 @@
       "name": "The Knowers",
       "symbol": "KNOW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36964/thumb/63_%281%29.png?1712907583"
+      "logoURI": "https://assets.coingecko.com/coins/images/36964/large/63_%281%29.png?1712907583"
     },
     {
       "chainId": 42161,
@@ -3344,7 +3344,7 @@
       "name": "Space Token",
       "symbol": "SPACE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20676/thumb/jYw3kgsY_400x400.png?1696520076"
+      "logoURI": "https://assets.coingecko.com/coins/images/20676/large/jYw3kgsY_400x400.png?1696520076"
     },
     {
       "chainId": 42161,
@@ -3352,7 +3352,7 @@
       "name": "Quack Token",
       "symbol": "QUACK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31436/thumb/0x639C0D019C257966C4907bD4E68E3F349bB58109.png?1696530251"
+      "logoURI": "https://assets.coingecko.com/coins/images/31436/large/0x639C0D019C257966C4907bD4E68E3F349bB58109.png?1696530251"
     },
     {
       "chainId": 42161,
@@ -3360,7 +3360,7 @@
       "name": "Gemach",
       "symbol": "GMAC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32334/thumb/gmac-200x200.png?1697452788"
+      "logoURI": "https://assets.coingecko.com/coins/images/32334/large/gmac-200x200.png?1697452788"
     },
     {
       "chainId": 42161,
@@ -3368,263 +3368,7 @@
       "name": "KNOX Dollar",
       "symbol": "KNOX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38074/thumb/knox%28200_x_200_px%29.png?1716449113"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x641441c631e2f909700d2f41fd87f0aa6a6b4edb",
-      "name": "dForce USD",
-      "symbol": "USX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17422/thumb/usx_32.png?1696516969"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x36295e7de7024362ad95bb8be93d6d6d21d7f6c1",
-      "name": "XGPU AI",
-      "symbol": "XGPU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37453/thumb/xgpu.png?1714448873"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7f5373ae26c3e8ffc4c77b7255df7ec1a9af52a6",
-      "name": "Bridged Tether  Axelar ",
-      "symbol": "AXLUSDT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/31002/thumb/uusdt_D_3x.png?1696529840"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9b06f3c5de42d4623d7a2bd940ec735103c68a76",
-      "name": "Volta Club",
-      "symbol": "VOLTA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31602/thumb/volta-200x200.png?1696530418"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7a5d193fe4ed9098f7eadc99797087c96b002907",
-      "name": "Plutus ARB",
-      "symbol": "PLSARB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30636/thumb/plsARB.png?1696529509"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbbea044f9e7c0520195e49ad1e561572e7e1b948",
-      "name": "Mizar",
-      "symbol": "MZR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23272/thumb/V1DTptkT_400x400.jpg?1696522492"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf42e2b8bc2af8b110b65be98db1321b1ab8d44f5",
-      "name": "Donut",
-      "symbol": "DONUT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7538/thumb/Donut.png?1696507804"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe20b9e246db5a0d21bf9209e4858bc9a3ff7a034",
-      "name": "Wrapped Banano",
-      "symbol": "WBAN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32617/thumb/WBAN.jpg?1698749253"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd1e094cabc5acb9d3b0599c3f76f2d01ff8d3563",
-      "name": "VirtuSwap",
-      "symbol": "VRSW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30629/thumb/VirtuSwap_Logo_Red_200x200.png?1696529502"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9d0c0675a995d5f12b03e880763f639d0628b5c6",
-      "name": "SuperWalk WALK",
-      "symbol": "WALK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37379/thumb/superwalk.jpeg?1714213441"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4e0da40b9063dc48364c1c0ffb4ae9d091fc2270",
-      "name": "Edgeware",
-      "symbol": "EDG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8452/thumb/logo-edgeware.png?1696508638"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa3210cd727fe6daf8386af5623ba51a367e46263",
-      "name": "Basket",
-      "symbol": "BSKT",
-      "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/34661/thumb/BSKT_Logo.png?1705636891"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9500ba777560daf9d3ab148ea1cf1ed39df9ebdb",
-      "name": "STYLE Token",
-      "symbol": "STYLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37507/thumb/Token_Logo__STYLE.png?1729579902"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3ed03e95dd894235090b3d4a49e0c3239edce59e",
-      "name": "Blox MYRC",
-      "symbol": "MYRC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38632/thumb/myrc-token-trans-200x200.png?1718172187"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x666966ef3925b1c92fa355fda9722899f3e73451",
-      "name": "Stable",
-      "symbol": "STABLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31148/thumb/stable_200.png?1696529976"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb01cf1be9568f09449382a47cd5bf58e2a9d5922",
-      "name": "Lightspeed",
-      "symbol": "SPEED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51401/thumb/lightspeed-round-200.png?1731085512"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x180f7cf38805d1be95c7632f653e26b0838e2969",
-      "name": "XDEFI",
-      "symbol": "XDEFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19524/thumb/xdefi.jpg?1723436519"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd26b0c6ef8581e921ae41c66e508c62a581b709d",
-      "name": "Sexone",
-      "symbol": "SEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32135/thumb/IMG_20231004_163306_491.jpg?1696589011"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4727a7d2022e99ee5c298513b730307f458f9b40",
-      "name": "Guberto",
-      "symbol": "GUBERTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50787/thumb/guberto_%281%29.jpg?1729210166"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x284592a004d945f98de5b040808578c61a4bb39a",
-      "name": "AIR",
-      "symbol": "AIR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36113/thumb/Air_%28AIR%29_1.png?1710487829"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7f850b0ab1988dd17b69ac564c1e2857949e4dee",
-      "name": "Lift Dollar",
-      "symbol": "USDL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38484/thumb/USDL-Token-200px.png?1725022887"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4d15a3a2286d883af0aa1b3f21367843fac63e07",
-      "name": "Bridged TrueUSD",
-      "symbol": "TUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30837/thumb/tusd.jpeg?1696529695"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4cfa50b7ce747e2d61724fcac57f24b748ff2b2a",
-      "name": "Fluid USDC",
-      "symbol": "FUSDC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/28471/thumb/fUSDC-200x200.png?1696527465"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd44257dde89ca53f1471582f718632e690e46dc2",
-      "name": "S",
-      "symbol": "S",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50350/thumb/s.jpg?1727249471"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0a3bb08b3a15a19b4de82f8acfc862606fb69a2d",
-      "name": "iZUMi Bond USD",
-      "symbol": "IUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25388/thumb/iusd-logo-symbol-10k%E5%A4%A7%E5%B0%8F.png?1696524521"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfb930d1a28990820c98144201637c99bea8cb91c",
-      "name": "Bumper",
-      "symbol": "BUMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17822/thumb/Bumper_-__Icon_-_256x256.png?1715280092"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x123389c2f0e9194d9ba98c21e63c375b67614108",
-      "name": "EthereumMax",
-      "symbol": "EMAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15540/thumb/EMAX-Coin-Final2000x.png?1696515181"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x30dcba0405004cf124045793e1933c798af9e66a",
-      "name": "Yieldification",
-      "symbol": "YDF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26699/thumb/logo.png?1696525772"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee",
-      "name": "Aave v3 DAI",
-      "symbol": "ADAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32886/thumb/dai.png?1699769446"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x17a8541b82bf67e10b0874284b4ae66858cb1fd5",
-      "name": "Possum",
-      "symbol": "PSM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33596/thumb/PSM.png?1702521046"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf80d589b3dbe130c270a69f1a69d050f268786df",
-      "name": "Datamine FLUX",
-      "symbol": "FLUX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11756/thumb/fluxres.png?1696511637"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf7693c6fd9a7172d537fa75d133d309501cbd657",
-      "name": "Web3 No Value",
-      "symbol": "W3N",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32083/thumb/WechatIMG718.jpg?1710596218"
+      "logoURI": "https://assets.coingecko.com/coins/images/38074/large/knox%28200_x_200_px%29.png?1716449113"
     },
     {
       "chainId": 42161,
@@ -3632,7 +3376,263 @@
       "name": "DizzyHavoc",
       "symbol": "DZHV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35575/thumb/dizzyhavoc_circle_3_200_200_transparentBg.png?1709194317"
+      "logoURI": "https://assets.coingecko.com/coins/images/35575/large/dizzyhavoc_circle_3_200_200_transparentBg.png?1709194317"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x641441c631e2f909700d2f41fd87f0aa6a6b4edb",
+      "name": "dForce USD",
+      "symbol": "USX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17422/large/usx_32.png?1696516969"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x36295e7de7024362ad95bb8be93d6d6d21d7f6c1",
+      "name": "XGPU AI",
+      "symbol": "XGPU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37453/large/xgpu.png?1714448873"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f5373ae26c3e8ffc4c77b7255df7ec1a9af52a6",
+      "name": "Bridged Tether  Axelar ",
+      "symbol": "AXLUSDT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31002/large/uusdt_D_3x.png?1696529840"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9b06f3c5de42d4623d7a2bd940ec735103c68a76",
+      "name": "Volta Club",
+      "symbol": "VOLTA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31602/large/volta-200x200.png?1696530418"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7a5d193fe4ed9098f7eadc99797087c96b002907",
+      "name": "Plutus ARB",
+      "symbol": "PLSARB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30636/large/plsARB.png?1696529509"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbbea044f9e7c0520195e49ad1e561572e7e1b948",
+      "name": "Mizar",
+      "symbol": "MZR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23272/large/V1DTptkT_400x400.jpg?1696522492"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf42e2b8bc2af8b110b65be98db1321b1ab8d44f5",
+      "name": "Donut",
+      "symbol": "DONUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7538/large/Donut.png?1696507804"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe20b9e246db5a0d21bf9209e4858bc9a3ff7a034",
+      "name": "Wrapped Banano",
+      "symbol": "WBAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32617/large/WBAN.jpg?1698749253"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd1e094cabc5acb9d3b0599c3f76f2d01ff8d3563",
+      "name": "VirtuSwap",
+      "symbol": "VRSW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30629/large/VirtuSwap_Logo_Red_200x200.png?1696529502"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9d0c0675a995d5f12b03e880763f639d0628b5c6",
+      "name": "SuperWalk WALK",
+      "symbol": "WALK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37379/large/superwalk.jpeg?1714213441"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e0da40b9063dc48364c1c0ffb4ae9d091fc2270",
+      "name": "Edgeware",
+      "symbol": "EDG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8452/large/logo-edgeware.png?1696508638"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa3210cd727fe6daf8386af5623ba51a367e46263",
+      "name": "Basket",
+      "symbol": "BSKT",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/34661/large/BSKT_Logo.png?1705636891"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9500ba777560daf9d3ab148ea1cf1ed39df9ebdb",
+      "name": "STYLE Token",
+      "symbol": "STYLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37507/large/Token_Logo__STYLE.png?1729579902"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3ed03e95dd894235090b3d4a49e0c3239edce59e",
+      "name": "Blox MYRC",
+      "symbol": "MYRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38632/large/myrc-token-trans-200x200.png?1718172187"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x666966ef3925b1c92fa355fda9722899f3e73451",
+      "name": "Stable",
+      "symbol": "STABLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31148/large/stable_200.png?1696529976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb01cf1be9568f09449382a47cd5bf58e2a9d5922",
+      "name": "Lightspeed",
+      "symbol": "SPEED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51401/large/lightspeed-round-200.png?1731085512"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x180f7cf38805d1be95c7632f653e26b0838e2969",
+      "name": "XDEFI",
+      "symbol": "XDEFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19524/large/xdefi.jpg?1723436519"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd26b0c6ef8581e921ae41c66e508c62a581b709d",
+      "name": "Sexone",
+      "symbol": "SEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32135/large/IMG_20231004_163306_491.jpg?1696589011"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4727a7d2022e99ee5c298513b730307f458f9b40",
+      "name": "Guberto",
+      "symbol": "GUBERTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50787/large/guberto_%281%29.jpg?1729210166"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x284592a004d945f98de5b040808578c61a4bb39a",
+      "name": "AIR",
+      "symbol": "AIR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36113/large/Air_%28AIR%29_1.png?1710487829"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f850b0ab1988dd17b69ac564c1e2857949e4dee",
+      "name": "Lift Dollar",
+      "symbol": "USDL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38484/large/USDL-Token-200px.png?1725022887"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4d15a3a2286d883af0aa1b3f21367843fac63e07",
+      "name": "Bridged TrueUSD",
+      "symbol": "TUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30837/large/tusd.jpeg?1696529695"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4cfa50b7ce747e2d61724fcac57f24b748ff2b2a",
+      "name": "Fluid USDC",
+      "symbol": "FUSDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28471/large/fUSDC-200x200.png?1696527465"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd44257dde89ca53f1471582f718632e690e46dc2",
+      "name": "S",
+      "symbol": "S",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50350/large/s.jpg?1727249471"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0a3bb08b3a15a19b4de82f8acfc862606fb69a2d",
+      "name": "iZUMi Bond USD",
+      "symbol": "IUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25388/large/iusd-logo-symbol-10k%E5%A4%A7%E5%B0%8F.png?1696524521"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfb930d1a28990820c98144201637c99bea8cb91c",
+      "name": "Bumper",
+      "symbol": "BUMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17822/large/Bumper_-__Icon_-_256x256.png?1715280092"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x123389c2f0e9194d9ba98c21e63c375b67614108",
+      "name": "EthereumMax",
+      "symbol": "EMAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15540/large/EMAX-Coin-Final2000x.png?1696515181"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x30dcba0405004cf124045793e1933c798af9e66a",
+      "name": "Yieldification",
+      "symbol": "YDF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26699/large/logo.png?1696525772"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee",
+      "name": "Aave v3 DAI",
+      "symbol": "ADAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32886/large/dai.png?1699769446"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x17a8541b82bf67e10b0874284b4ae66858cb1fd5",
+      "name": "Possum",
+      "symbol": "PSM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33596/large/PSM.png?1702521046"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf80d589b3dbe130c270a69f1a69d050f268786df",
+      "name": "Datamine FLUX",
+      "symbol": "FLUX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11756/large/fluxres.png?1696511637"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf7693c6fd9a7172d537fa75d133d309501cbd657",
+      "name": "Web3 No Value",
+      "symbol": "W3N",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32083/large/WechatIMG718.jpg?1710596218"
     },
     {
       "chainId": 42161,
@@ -3640,7 +3640,7 @@
       "name": "ArbiPad",
       "symbol": "ARBI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30275/thumb/ARBI_Logo.png?1696529181"
+      "logoURI": "https://assets.coingecko.com/coins/images/30275/large/ARBI_Logo.png?1696529181"
     },
     {
       "chainId": 42161,
@@ -3648,7 +3648,7 @@
       "name": "TridentDAO",
       "symbol": "PSI",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/28955/thumb/trident.jpg?1696527928"
+      "logoURI": "https://assets.coingecko.com/coins/images/28955/large/trident.jpg?1696527928"
     },
     {
       "chainId": 42161,
@@ -3656,7 +3656,7 @@
       "name": "Ojamu",
       "symbol": "OJA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18947/thumb/ojamu-icon-PNK.png?1696518402"
+      "logoURI": "https://assets.coingecko.com/coins/images/18947/large/ojamu-icon-PNK.png?1696518402"
     },
     {
       "chainId": 42161,
@@ -3664,7 +3664,7 @@
       "name": "Sundae the Dog",
       "symbol": "SUNDAE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32010/thumb/sundae.jpg?1696530808"
+      "logoURI": "https://assets.coingecko.com/coins/images/32010/large/sundae.jpg?1696530808"
     },
     {
       "chainId": 42161,
@@ -3672,15 +3672,7 @@
       "name": "Inception Restaked ETH",
       "symbol": "INETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34127/thumb/inETH.png?1715036464"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x96a993f06951b01430523d0d5590192d650ebf3e",
-      "name": "Revenue Generating USD",
-      "symbol": "RGUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38146/thumb/rgusd%28200_x_200_px%29.png?1716654569"
+      "logoURI": "https://assets.coingecko.com/coins/images/34127/large/inETH.png?1715036464"
     },
     {
       "chainId": 42161,
@@ -3688,7 +3680,15 @@
       "name": "Arbidex",
       "symbol": "ARX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29506/thumb/tokenlogo.png?1696528451"
+      "logoURI": "https://assets.coingecko.com/coins/images/29506/large/tokenlogo.png?1696528451"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x96a993f06951b01430523d0d5590192d650ebf3e",
+      "name": "Revenue Generating USD",
+      "symbol": "RGUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38146/large/rgusd%28200_x_200_px%29.png?1716654569"
     },
     {
       "chainId": 42161,
@@ -3696,7 +3696,7 @@
       "name": "Agave",
       "symbol": "AGVE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14146/thumb/agve.png?1696513865"
+      "logoURI": "https://assets.coingecko.com/coins/images/14146/large/agve.png?1696513865"
     },
     {
       "chainId": 42161,
@@ -3704,7 +3704,7 @@
       "name": "Brightpool Finance BRIX",
       "symbol": "BRIX",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37446/thumb/IMAGE_2024-04-29_13_55_38.jpg?1714446963"
+      "logoURI": "https://assets.coingecko.com/coins/images/37446/large/IMAGE_2024-04-29_13_55_38.jpg?1714446963"
     },
     {
       "chainId": 42161,
@@ -3712,7 +3712,7 @@
       "name": "Reunit Wallet",
       "symbol": "REUNI",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29492/thumb/reunit_200.png?1696528436"
+      "logoURI": "https://assets.coingecko.com/coins/images/29492/large/reunit_200.png?1696528436"
     },
     {
       "chainId": 42161,
@@ -3720,7 +3720,7 @@
       "name": "Yum",
       "symbol": "YUM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39116/thumb/yum.png?1720590184"
+      "logoURI": "https://assets.coingecko.com/coins/images/39116/large/yum.png?1720590184"
     },
     {
       "chainId": 42161,
@@ -3728,7 +3728,7 @@
       "name": "Hold VIP",
       "symbol": "HOLD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30129/thumb/RteOSWQ__400x400.jpg?1696529050"
+      "logoURI": "https://assets.coingecko.com/coins/images/30129/large/RteOSWQ__400x400.jpg?1696529050"
     },
     {
       "chainId": 42161,
@@ -3736,15 +3736,7 @@
       "name": "Omnisea",
       "symbol": "OSEA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26475/thumb/logo-06_%281%29.png?1728502928"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x76bc2e765414e6c8b596c0f52c4240f80268f41d",
-      "name": "Unibit",
-      "symbol": "UIBT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36911/thumb/Unibit.png?1712764033"
+      "logoURI": "https://assets.coingecko.com/coins/images/26475/large/logo-06_%281%29.png?1728502928"
     },
     {
       "chainId": 42161,
@@ -3752,7 +3744,15 @@
       "name": "Wrapped USDM",
       "symbol": "WUSDM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33785/thumb/wUSDM_PNG_240px.png?1702981552"
+      "logoURI": "https://assets.coingecko.com/coins/images/33785/large/wUSDM_PNG_240px.png?1702981552"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x76bc2e765414e6c8b596c0f52c4240f80268f41d",
+      "name": "Unibit",
+      "symbol": "UIBT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36911/large/Unibit.png?1712764033"
     },
     {
       "chainId": 42161,
@@ -3760,7 +3760,7 @@
       "name": "Wrapped Staked LINK",
       "symbol": "WSTLINK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35678/thumb/wstlink_logo.png?1709525182"
+      "logoURI": "https://assets.coingecko.com/coins/images/35678/large/wstlink_logo.png?1709525182"
     },
     {
       "chainId": 42161,
@@ -3768,7 +3768,7 @@
       "name": "Angle Staked EURA",
       "symbol": "STEUR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32036/thumb/stEUR-x4.png?1696530832"
+      "logoURI": "https://assets.coingecko.com/coins/images/32036/large/stEUR-x4.png?1696530832"
     },
     {
       "chainId": 42161,
@@ -3776,15 +3776,7 @@
       "name": "D2 Finance",
       "symbol": "D2",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34914/thumb/D2_Token_Logo.png?1706610408"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x5429706887fcb58a595677b73e9b0441c25d993d",
-      "name": "UniDex",
-      "symbol": "UNIDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13178/thumb/unidx.png?1696512961"
+      "logoURI": "https://assets.coingecko.com/coins/images/34914/large/D2_Token_Logo.png?1706610408"
     },
     {
       "chainId": 42161,
@@ -3792,7 +3784,15 @@
       "name": "PlutusDAO",
       "symbol": "PLS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25326/thumb/M6nUndNU_400x400.jpg?1696524461"
+      "logoURI": "https://assets.coingecko.com/coins/images/25326/large/M6nUndNU_400x400.jpg?1696524461"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5429706887fcb58a595677b73e9b0441c25d993d",
+      "name": "UniDex",
+      "symbol": "UNIDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13178/large/unidx.png?1696512961"
     },
     {
       "chainId": 42161,
@@ -3800,7 +3800,7 @@
       "name": "Tapioca DAO Token",
       "symbol": "TAP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38756/thumb/TAPP.png?1718729124"
+      "logoURI": "https://assets.coingecko.com/coins/images/38756/large/TAPP.png?1718729124"
     },
     {
       "chainId": 42161,
@@ -3808,7 +3808,7 @@
       "name": "GODDOG",
       "symbol": "OOOOOO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38157/thumb/Goddog_logo_for_Coingecko_200x200.png?1716669510"
+      "logoURI": "https://assets.coingecko.com/coins/images/38157/large/Goddog_logo_for_Coingecko_200x200.png?1716669510"
     },
     {
       "chainId": 42161,
@@ -3816,7 +3816,7 @@
       "name": "GoldenBoys",
       "symbol": "GOLD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31353/thumb/goldenboys.png?1696530170"
+      "logoURI": "https://assets.coingecko.com/coins/images/31353/large/goldenboys.png?1696530170"
     },
     {
       "chainId": 42161,
@@ -3824,7 +3824,7 @@
       "name": "Hat",
       "symbol": "HAT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39394/thumb/Black_circle_%281%29.png?1721976884"
+      "logoURI": "https://assets.coingecko.com/coins/images/39394/large/Black_circle_%281%29.png?1721976884"
     },
     {
       "chainId": 42161,
@@ -3832,7 +3832,7 @@
       "name": "Tarot V1",
       "symbol": "TAROT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17881/thumb/tarot-200px.png?1696517403"
+      "logoURI": "https://assets.coingecko.com/coins/images/17881/large/tarot-200px.png?1696517403"
     },
     {
       "chainId": 42161,
@@ -3840,7 +3840,7 @@
       "name": "ZAI Stablecoin",
       "symbol": "USDZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39733/thumb/Group_4.png?1723771588"
+      "logoURI": "https://assets.coingecko.com/coins/images/39733/large/Group_4.png?1723771588"
     },
     {
       "chainId": 42161,
@@ -3848,7 +3848,7 @@
       "name": "Mchain Network",
       "symbol": "MARK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37447/thumb/mchain.png?1714447037"
+      "logoURI": "https://assets.coingecko.com/coins/images/37447/large/mchain.png?1714447037"
     },
     {
       "chainId": 42161,
@@ -3856,7 +3856,7 @@
       "name": "Army of Fortune Metaverse",
       "symbol": "AFC",
       "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/32577/thumb/UI_Icon_Coin_Token_AFC_200x200.png?1698558434"
+      "logoURI": "https://assets.coingecko.com/coins/images/32577/large/UI_Icon_Coin_Token_AFC_200x200.png?1698558434"
     },
     {
       "chainId": 42161,
@@ -3864,7 +3864,7 @@
       "name": "Crypto Index Pool",
       "symbol": "CIP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32504/thumb/photo_6176746894382970935_y_%281%29.jpg?1698313185"
+      "logoURI": "https://assets.coingecko.com/coins/images/32504/large/photo_6176746894382970935_y_%281%29.jpg?1698313185"
     },
     {
       "chainId": 42161,
@@ -3872,7 +3872,7 @@
       "name": "0xBitcoin",
       "symbol": "0XBTC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/4454/thumb/0xbtc.png?1696505045"
+      "logoURI": "https://assets.coingecko.com/coins/images/4454/large/0xbtc.png?1696505045"
     },
     {
       "chainId": 42161,
@@ -3880,15 +3880,7 @@
       "name": "AlphaScan AI",
       "symbol": "ASCN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31180/thumb/AlphaScan_logo.jpg?1696530008"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf29fdf6b7bdffb025d7e6dfdf344992d2d16e249",
-      "name": "Genius X",
-      "symbol": "GENSX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/30904/thumb/GX_short_logo.png?1696529749"
+      "logoURI": "https://assets.coingecko.com/coins/images/31180/large/AlphaScan_logo.jpg?1696530008"
     },
     {
       "chainId": 42161,
@@ -3896,87 +3888,7 @@
       "name": "Nola",
       "symbol": "NOLA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33708/thumb/nola.jpg?1702854587"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe934ab7e98d81e39477b1e47b961876c2d902598",
-      "name": "Nola",
-      "symbol": "NOLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37420/thumb/NOLA.png?1714377065"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x66e535e8d2ebf13f49f3d49e5c50395a97c137b1",
-      "name": "Molten",
-      "symbol": "MOLTEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36726/thumb/moltenmesh.png?1712147407"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x59a729658e9245b0cf1f8cb9fb37945d2b06ea27",
-      "name": "GenomesDAO GENE",
-      "symbol": "GENE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20807/thumb/1637683704200x200.png?1696520200"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x21ccbc5e7f353ec43b2f5b1fb12c3e9d89d30dca",
-      "name": "BlackDragon",
-      "symbol": "BDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13426/thumb/Black-Dragon-Black.png?1696513186"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1824a51c106efc27d35a74efb56d9bf54ddb22d4",
-      "name": "Perpy Finance",
-      "symbol": "PRY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29525/thumb/perpy-icon-dark.png?1696528468"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9b3fa2a7c3eb36d048a5d38d81e7fafc6bc47b25",
-      "name": "Aluna",
-      "symbol": "ALN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14379/thumb/uaLoLU8c_400x400_%281%29.png?1696514071"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd3ac016b1b8c80eeadde4d186a9138c9324e4189",
-      "name": "Okcash",
-      "symbol": "OK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/274/thumb/ok-logo-200px.png?1696501624"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd08c3f25862077056cb1b710937576af899a4959",
-      "name": "Inception stETH",
-      "symbol": "INSTETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34954/thumb/Group_14.png?1706773546"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6aa395f06986ea4efe0a4630c7865c1eb08d5e7e",
-      "name": "Jarvis Reward",
-      "symbol": "JRT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10390/thumb/cfeii0y.png?1696510389"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8ec1877698acf262fe8ad8a295ad94d6ea258988",
-      "name": "Davos xyz USD",
-      "symbol": "DUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28775/thumb/dusd_logo_200x200.png?1696527754"
+      "logoURI": "https://assets.coingecko.com/coins/images/33708/large/nola.jpg?1702854587"
     },
     {
       "chainId": 42161,
@@ -3984,7 +3896,95 @@
       "name": "Rari Governance",
       "symbol": "RGT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1696512688"
+      "logoURI": "https://assets.coingecko.com/coins/images/12900/large/Rari_Logo_Transparent.png?1696512688"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf29fdf6b7bdffb025d7e6dfdf344992d2d16e249",
+      "name": "Genius X",
+      "symbol": "GENSX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/30904/large/GX_short_logo.png?1696529749"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe934ab7e98d81e39477b1e47b961876c2d902598",
+      "name": "Nola",
+      "symbol": "NOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37420/large/NOLA.png?1714377065"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x66e535e8d2ebf13f49f3d49e5c50395a97c137b1",
+      "name": "Molten",
+      "symbol": "MOLTEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36726/large/moltenmesh.png?1712147407"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x59a729658e9245b0cf1f8cb9fb37945d2b06ea27",
+      "name": "GenomesDAO GENE",
+      "symbol": "GENE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20807/large/1637683704200x200.png?1696520200"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x21ccbc5e7f353ec43b2f5b1fb12c3e9d89d30dca",
+      "name": "BlackDragon",
+      "symbol": "BDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13426/large/Black-Dragon-Black.png?1696513186"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1824a51c106efc27d35a74efb56d9bf54ddb22d4",
+      "name": "Perpy Finance",
+      "symbol": "PRY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29525/large/perpy-icon-dark.png?1696528468"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9b3fa2a7c3eb36d048a5d38d81e7fafc6bc47b25",
+      "name": "Aluna",
+      "symbol": "ALN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14379/large/uaLoLU8c_400x400_%281%29.png?1696514071"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd08c3f25862077056cb1b710937576af899a4959",
+      "name": "Inception stETH",
+      "symbol": "INSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34954/large/Group_14.png?1706773546"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd3ac016b1b8c80eeadde4d186a9138c9324e4189",
+      "name": "Okcash",
+      "symbol": "OK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/274/large/ok-logo-200px.png?1696501624"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8ec1877698acf262fe8ad8a295ad94d6ea258988",
+      "name": "Davos xyz USD",
+      "symbol": "DUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28775/large/dusd_logo_200x200.png?1696527754"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6aa395f06986ea4efe0a4630c7865c1eb08d5e7e",
+      "name": "Jarvis Reward",
+      "symbol": "JRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10390/large/cfeii0y.png?1696510389"
     },
     {
       "chainId": 42161,
@@ -3992,7 +3992,7 @@
       "name": "BOO",
       "symbol": "BOO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34234/thumb/boo_coin_%28200%29.png?1704306085"
+      "logoURI": "https://assets.coingecko.com/coins/images/34234/large/boo_coin_%28200%29.png?1704306085"
     },
     {
       "chainId": 42161,
@@ -4000,7 +4000,7 @@
       "name": "Strips Finance",
       "symbol": "STRP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18327/thumb/Logo-Strips-200-x-200px---without-words.png?1696517818"
+      "logoURI": "https://assets.coingecko.com/coins/images/18327/large/Logo-Strips-200-x-200px---without-words.png?1696517818"
     },
     {
       "chainId": 42161,
@@ -4008,8 +4008,8 @@
       "name": "Goons of Balatroon",
       "symbol": "GOB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27104/thumb/TokenLogo200x200.png?1702250134"
+      "logoURI": "https://assets.coingecko.com/coins/images/27104/large/TokenLogo200x200.png?1702250134"
     }
   ],
-  "timestamp": "2024-12-06T16:10:22.485Z"
+  "timestamp": "2024-12-06T16:15:00.121Z"
 }

--- a/src/public/CoinGecko.8453.json
+++ b/src/public/CoinGecko.8453.json
@@ -16,7 +16,7 @@
       "name": "USDC",
       "symbol": "USDC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/6319/thumb/usdc.png?1696506694"
+      "logoURI": "https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696506694"
     },
     {
       "chainId": 8453,
@@ -24,7 +24,7 @@
       "name": "L2 Standard Bridged WETH  Base ",
       "symbol": "WETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39810/thumb/weth.png?1724139790"
+      "logoURI": "https://assets.coingecko.com/coins/images/39810/large/weth.png?1724139790"
     },
     {
       "chainId": 8453,
@@ -32,7 +32,7 @@
       "name": "LayerZero",
       "symbol": "ZRO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28206/thumb/ftxG9_TJ_400x400.jpeg?1696527208"
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
     },
     {
       "chainId": 8453,
@@ -40,7 +40,7 @@
       "name": "Coinbase Wrapped BTC",
       "symbol": "CBBTC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/40143/thumb/cbbtc.webp?1726136727"
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
     },
     {
       "chainId": 8453,
@@ -48,7 +48,7 @@
       "name": "Reserve Rights",
       "symbol": "RSR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8365/thumb/RSR_Blue_Circle_1000.png?1721777856"
+      "logoURI": "https://assets.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
     },
     {
       "chainId": 8453,
@@ -56,7 +56,7 @@
       "name": "Mog Coin",
       "symbol": "MOG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31059/thumb/MOG_LOGO_200x200.png?1696529893"
+      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png?1696529893"
     },
     {
       "chainId": 8453,
@@ -64,7 +64,7 @@
       "name": "Morpho",
       "symbol": "MORPHO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29837/thumb/Morpho-token-icon.png?1726771230"
+      "logoURI": "https://assets.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
     },
     {
       "chainId": 8453,
@@ -72,7 +72,7 @@
       "name": "Wormhole",
       "symbol": "W",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35087/thumb/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
+      "logoURI": "https://assets.coingecko.com/coins/images/35087/large/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
     },
     {
       "chainId": 8453,
@@ -80,7 +80,7 @@
       "name": "PancakeSwap",
       "symbol": "CAKE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12632/thumb/pancakeswap-cake-logo_%281%29.png?1696512440"
+      "logoURI": "https://assets.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
     },
     {
       "chainId": 8453,
@@ -88,7 +88,7 @@
       "name": "Compound",
       "symbol": "COMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10775/thumb/COMP.png?1696510737"
+      "logoURI": "https://assets.coingecko.com/coins/images/10775/large/COMP.png?1696510737"
     },
     {
       "chainId": 8453,
@@ -96,7 +96,7 @@
       "name": "Virtuals Protocol",
       "symbol": "VIRTUAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34057/thumb/LOGOMARK.png?1708356054"
+      "logoURI": "https://assets.coingecko.com/coins/images/34057/large/LOGOMARK.png?1708356054"
     },
     {
       "chainId": 8453,
@@ -104,7 +104,7 @@
       "name": "Sushi",
       "symbol": "SUSHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1696512101"
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/large/512x512_Logo_no_chop.png?1696512101"
     },
     {
       "chainId": 8453,
@@ -112,7 +112,7 @@
       "name": "yearn finance",
       "symbol": "YFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yearn.jpg?1696511720"
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/large/yearn.jpg?1696511720"
     },
     {
       "chainId": 8453,
@@ -120,7 +120,7 @@
       "name": "Yield Guild Games",
       "symbol": "YGG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
+      "logoURI": "https://assets.coingecko.com/coins/images/17358/large/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
     },
     {
       "chainId": 8453,
@@ -128,55 +128,7 @@
       "name": "Aerodrome Finance",
       "symbol": "AERO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31745/thumb/token.png?1696530564"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x22e6966b799c4d5b13be962e1d117b56327fda66",
-      "name": "Synthetix Network",
-      "symbol": "SNX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3406/thumb/SNX.png?1696504103"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3992b27da26848c2b19cea6fd25ad5568b68ab98",
-      "name": "MANTRA",
-      "symbol": "OM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12151/thumb/OM_Token.png?1696511991"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x532f27101965dd16442e59d40670faf5ebb142e4",
-      "name": "Brett",
-      "symbol": "BRETT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35529/thumb/1000050750.png?1709031995"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",
-      "name": "Wrapped stETH",
-      "symbol": "WSTETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18834/thumb/wstETH.png?1696518295"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
-      "name": "Degen  Base ",
-      "symbol": "DEGEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34515/thumb/android-chrome-512x512.png?1706198225"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbcbaf311cec8a4eac0430193a528d9ff27ae38c1",
-      "name": "IoTeX",
-      "symbol": "IOTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3334/thumb/Token_Icon_Token_Icon.png?1727899869"
+      "logoURI": "https://assets.coingecko.com/coins/images/31745/large/token.png?1696530564"
     },
     {
       "chainId": 8453,
@@ -184,7 +136,55 @@
       "name": "Gravity",
       "symbol": "G",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39200/thumb/gravity.jpg?1721020647"
+      "logoURI": "https://assets.coingecko.com/coins/images/39200/large/gravity.jpg?1721020647"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x22e6966b799c4d5b13be962e1d117b56327fda66",
+      "name": "Synthetix Network",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3406/large/SNX.png?1696504103"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3992b27da26848c2b19cea6fd25ad5568b68ab98",
+      "name": "MANTRA",
+      "symbol": "OM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12151/large/OM_Token.png?1696511991"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x532f27101965dd16442e59d40670faf5ebb142e4",
+      "name": "Brett",
+      "symbol": "BRETT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35529/large/1000050750.png?1709031995"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",
+      "name": "Wrapped stETH",
+      "symbol": "WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
+      "name": "Degen  Base ",
+      "symbol": "DEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbcbaf311cec8a4eac0430193a528d9ff27ae38c1",
+      "name": "IoTeX",
+      "symbol": "IOTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3334/large/Token_Icon_Token_Icon.png?1727899869"
     },
     {
       "chainId": 8453,
@@ -192,7 +192,7 @@
       "name": "Stargate Finance",
       "symbol": "STG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1696523595"
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
     },
     {
       "chainId": 8453,
@@ -200,15 +200,7 @@
       "name": "CARV",
       "symbol": "CARV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37689/thumb/CARV_%281%29.png?1728418485"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x23ee2343b892b1bb63503a4fabc840e0e2c6810f",
-      "name": "Axelar",
-      "symbol": "AXL",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/27277/thumb/V-65_xQ1_400x400.jpeg?1696526329"
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
     },
     {
       "chainId": 8453,
@@ -216,7 +208,15 @@
       "name": "Echelon Prime",
       "symbol": "PRIME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29053/thumb/prime-logo-small-border_%282%29.png?1696528020"
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/prime-logo-small-border_%282%29.png?1696528020"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x23ee2343b892b1bb63503a4fabc840e0e2c6810f",
+      "name": "Axelar",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg?1696526329"
     },
     {
       "chainId": 8453,
@@ -224,7 +224,7 @@
       "name": "EURC",
       "symbol": "EURC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro.png?1696525125"
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/large/euro.png?1696525125"
     },
     {
       "chainId": 8453,
@@ -232,7 +232,7 @@
       "name": "Radiant Capital",
       "symbol": "RDNT",
       "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/26536/thumb/Radiant-Logo-200x200.png?1696525610"
+      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
     },
     {
       "chainId": 8453,
@@ -240,7 +240,7 @@
       "name": "Spectral",
       "symbol": "SPEC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36138/thumb/ls7wS7vf_400x400.jpg?1724975224"
+      "logoURI": "https://assets.coingecko.com/coins/images/36138/large/ls7wS7vf_400x400.jpg?1724975224"
     },
     {
       "chainId": 8453,
@@ -248,7 +248,7 @@
       "name": "Bridged USDC  Base ",
       "symbol": "USDBC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/31164/thumb/baseusdc.jpg?1696529993"
+      "logoURI": "https://assets.coingecko.com/coins/images/31164/large/baseusdc.jpg?1696529993"
     },
     {
       "chainId": 8453,
@@ -256,7 +256,7 @@
       "name": "Savings Dai",
       "symbol": "SDAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32254/thumb/sdai.png?1697015278"
+      "logoURI": "https://assets.coingecko.com/coins/images/32254/large/sdai.png?1697015278"
     },
     {
       "chainId": 8453,
@@ -264,7 +264,7 @@
       "name": "Heroes of Mavia",
       "symbol": "MAVIA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33895/thumb/2023-12-20_21.21.41_%281%29.jpg?1703230771"
+      "logoURI": "https://assets.coingecko.com/coins/images/33895/large/2023-12-20_21.21.41_%281%29.jpg?1703230771"
     },
     {
       "chainId": 8453,
@@ -272,7 +272,7 @@
       "name": "Origin Token",
       "symbol": "OGN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1696504006"
+      "logoURI": "https://assets.coingecko.com/coins/images/3296/large/op.jpg?1696504006"
     },
     {
       "chainId": 8453,
@@ -280,7 +280,7 @@
       "name": "Cartesi",
       "symbol": "CTSI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/Cartesi_Logo.png?1696510982"
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
     },
     {
       "chainId": 8453,
@@ -288,7 +288,7 @@
       "name": "Orderly Network",
       "symbol": "ORDER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38501/thumb/Orderly_Network_Coingecko_200*200.png?1717751359"
+      "logoURI": "https://assets.coingecko.com/coins/images/38501/large/Orderly_Network_Coingecko_200*200.png?1717751359"
     },
     {
       "chainId": 8453,
@@ -296,7 +296,7 @@
       "name": "aixbt by Virtuals",
       "symbol": "AIXBT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51784/thumb/3.png?1731981138"
+      "logoURI": "https://assets.coingecko.com/coins/images/51784/large/3.png?1731981138"
     },
     {
       "chainId": 8453,
@@ -304,7 +304,7 @@
       "name": "Toshi",
       "symbol": "TOSHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31126/thumb/Toshi_Logo_-_Circular.png?1721677476"
+      "logoURI": "https://assets.coingecko.com/coins/images/31126/large/Toshi_Logo_-_Circular.png?1721677476"
     },
     {
       "chainId": 8453,
@@ -312,7 +312,7 @@
       "name": "AI Agent Layer",
       "symbol": "AIFUN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51634/thumb/logo_400x400.png?1731686436"
+      "logoURI": "https://assets.coingecko.com/coins/images/51634/large/logo_400x400.png?1731686436"
     },
     {
       "chainId": 8453,
@@ -320,7 +320,7 @@
       "name": "Aavegotchi",
       "symbol": "GHST",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/GHST.png?1696512286"
+      "logoURI": "https://assets.coingecko.com/coins/images/12467/large/GHST.png?1696512286"
     },
     {
       "chainId": 8453,
@@ -328,7 +328,7 @@
       "name": "tBTC",
       "symbol": "TBTC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
     },
     {
       "chainId": 8453,
@@ -336,7 +336,7 @@
       "name": "Balancer",
       "symbol": "BAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1696511572"
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
     },
     {
       "chainId": 8453,
@@ -344,15 +344,7 @@
       "name": "Overnight fi USD   Base ",
       "symbol": "USD+",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39624/thumb/USD_.png?1723179227"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x50da645f148798f68ef2d7db7c1cb22a6819bb2c",
-      "name": "SPX6900",
-      "symbol": "SPX",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/31401/thumb/sticker_%281%29.jpg?1702371083"
+      "logoURI": "https://assets.coingecko.com/coins/images/39624/large/USD_.png?1723179227"
     },
     {
       "chainId": 8453,
@@ -360,15 +352,7 @@
       "name": "Maverick Protocol",
       "symbol": "MAV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30850/thumb/MAV_Logo.png?1696529701"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x768be13e1680b5ebe0024c42c896e3db59ec0149",
-      "name": "Ski Mask Dog",
-      "symbol": "SKI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37195/thumb/32992128-F52F-4346-84CA-8E0C48F43606.jpeg?1713676521"
+      "logoURI": "https://assets.coingecko.com/coins/images/30850/large/MAV_Logo.png?1696529701"
     },
     {
       "chainId": 8453,
@@ -376,7 +360,15 @@
       "name": "L2 Standard Bridged USDT  Base ",
       "symbol": "USDT",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39963/thumb/usdt.png?1724952731"
+      "logoURI": "https://assets.coingecko.com/coins/images/39963/large/usdt.png?1724952731"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x50da645f148798f68ef2d7db7c1cb22a6819bb2c",
+      "name": "SPX6900",
+      "symbol": "SPX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/31401/large/sticker_%281%29.jpg?1702371083"
     },
     {
       "chainId": 8453,
@@ -384,7 +376,15 @@
       "name": "Anon",
       "symbol": "ANON",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51871/thumb/_.png?1732095727"
+      "logoURI": "https://assets.coingecko.com/coins/images/51871/large/_.png?1732095727"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x768be13e1680b5ebe0024c42c896e3db59ec0149",
+      "name": "Ski Mask Dog",
+      "symbol": "SKI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37195/large/32992128-F52F-4346-84CA-8E0C48F43606.jpeg?1713676521"
     },
     {
       "chainId": 8453,
@@ -392,15 +392,7 @@
       "name": "Mister Miggles",
       "symbol": "MIGGLES",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39251/thumb/photo_2024-11-14_16-50-08_%282%29.jpg?1731814015"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
-      "name": "Axelar Bridged USDC",
-      "symbol": "AXLUSDC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/26476/thumb/uausdc_D_3x.png?1696525548"
+      "logoURI": "https://assets.coingecko.com/coins/images/39251/large/photo_2024-11-14_16-50-08_%282%29.jpg?1731814015"
     },
     {
       "chainId": 8453,
@@ -408,7 +400,7 @@
       "name": "crvUSD",
       "symbol": "CRVUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30118/thumb/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/large/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
     },
     {
       "chainId": 8453,
@@ -416,7 +408,15 @@
       "name": "Department Of Government Efficiency",
       "symbol": "DOGE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39841/thumb/IMG_9775.PNG?1729771739"
+      "logoURI": "https://assets.coingecko.com/coins/images/39841/large/IMG_9775.PNG?1729771739"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
+      "name": "Axelar Bridged USDC",
+      "symbol": "AXLUSDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26476/large/uausdc_D_3x.png?1696525548"
     },
     {
       "chainId": 8453,
@@ -424,7 +424,7 @@
       "name": "Coinbase Wrapped Staked ETH",
       "symbol": "CBETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27008/thumb/cbeth.png?1709186989"
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1709186989"
     },
     {
       "chainId": 8453,
@@ -432,15 +432,7 @@
       "name": "tokenbot",
       "symbol": "CLANKER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51440/thumb/CLANKER.png?1731232869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
-      "name": "Renzo Restaked ETH",
-      "symbol": "EZETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34753/thumb/Ezeth_logo_circle.png?1713496404"
+      "logoURI": "https://assets.coingecko.com/coins/images/51440/large/CLANKER.png?1731232869"
     },
     {
       "chainId": 8453,
@@ -448,7 +440,7 @@
       "name": "Moonwell",
       "symbol": "WELL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26133/thumb/WELL.png?1696525221"
+      "logoURI": "https://assets.coingecko.com/coins/images/26133/large/WELL.png?1696525221"
     },
     {
       "chainId": 8453,
@@ -456,7 +448,7 @@
       "name": "Non Playable Coin",
       "symbol": "NPC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31193/thumb/NPC_200x200.png?1696530021"
+      "logoURI": "https://assets.coingecko.com/coins/images/31193/large/NPC_200x200.png?1696530021"
     },
     {
       "chainId": 8453,
@@ -464,7 +456,15 @@
       "name": "Onyxcoin",
       "symbol": "XCN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/onyxlogo.jpg?1696523397"
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/large/onyxlogo.jpg?1696523397"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
     },
     {
       "chainId": 8453,
@@ -472,7 +472,7 @@
       "name": "Altura",
       "symbol": "ALU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15127/thumb/logo-dark.png?1696514784"
+      "logoURI": "https://assets.coingecko.com/coins/images/15127/large/logo-dark.png?1696514784"
     },
     {
       "chainId": 8453,
@@ -480,7 +480,7 @@
       "name": "Gains Network",
       "symbol": "GNS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19737/thumb/logo.png?1696519161"
+      "logoURI": "https://assets.coingecko.com/coins/images/19737/large/logo.png?1696519161"
     },
     {
       "chainId": 8453,
@@ -488,111 +488,7 @@
       "name": "Avail",
       "symbol": "AVAIL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37372/thumb/avail-logo.png?1714145201"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xecac9c5f704e954931349da37f60e39f515c11c1",
-      "name": "Lombard Staked BTC",
-      "symbol": "LBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39969/thumb/LBTC_Logo.png?1724959872"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe997017e0cb0ceb503565f181e9ea922cd979c35",
-      "name": "LimeWire",
-      "symbol": "LMWR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30356/thumb/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2a06a17cbc6d0032cac2c6696da90f29d39a1a29",
-      "name": "HarryPotterObamaSonic10Inu  ETH ",
-      "symbol": "BITCOIN",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/30323/thumb/hpos10i_logo_casino_night-dexview.png?1696529224"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3792dbdd07e87413247df995e692806aa13d3299",
-      "name": "ECOMI",
-      "symbol": "OMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4428/thumb/ECOMI.png?1696505023"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c",
-      "name": "Rocket Pool ETH",
-      "symbol": "RETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20764/thumb/reth.png?1696520159"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb0505e5a99abd03d94a1169e638b78edfed26ea4",
-      "name": "Wrapped SUI  Universal ",
-      "symbol": "USUI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50482/thumb/UA-SUI-PAD.png?1727888681"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
-      "name": "Pocket Network",
-      "symbol": "POKT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/22506/thumb/POKT.jpg?1703257310"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf5bc3439f53a45607ccad667abc7daf5a583633f",
-      "name": "AgentLayer",
-      "symbol": "AGENT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50213/thumb/Logo-Mark-White_256.png?1726433757"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x619c4bbbd65f836b78b36cbe781513861d57f39d",
-      "name": "Bitget Wallet Token",
-      "symbol": "BWB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37767/thumb/bwb.png?1715480561"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x161e113b8e9bbaefb846f73f31624f6f9607bd44",
-      "name": "Simmi Token",
-      "symbol": "SIMMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52349/thumb/simmi.png?1733160996"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x04c0599ae5a44757c0af6f9ec3b93da8976c150a",
-      "name": "ether fi Bridged weETH  Base ",
-      "symbol": "WEETHBASE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39950/thumb/WETH.PNG?1724902237"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9a26f5433671751c3276a065f57e5a02d2817973",
-      "name": "Keyboard Cat  Base ",
-      "symbol": "KEYCAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36608/thumb/keyboard_cat.jpeg?1711965348"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x20d704099b62ada091028bcfc44445041ed16f09",
-      "name": "Chaos",
-      "symbol": "CHAOS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52444/thumb/chaos-2.jpg?1733365634"
+      "logoURI": "https://assets.coingecko.com/coins/images/37372/large/avail-logo.png?1714145201"
     },
     {
       "chainId": 8453,
@@ -600,7 +496,103 @@
       "name": "Solv Protocol SolvBTC",
       "symbol": "SOLVBTC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36800/thumb/solvBTC.png?1719810684"
+      "logoURI": "https://assets.coingecko.com/coins/images/36800/large/solvBTC.png?1719810684"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe997017e0cb0ceb503565f181e9ea922cd979c35",
+      "name": "LimeWire",
+      "symbol": "LMWR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30356/large/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xecac9c5f704e954931349da37f60e39f515c11c1",
+      "name": "Lombard Staked BTC",
+      "symbol": "LBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39969/large/LBTC_Logo.png?1724959872"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2a06a17cbc6d0032cac2c6696da90f29d39a1a29",
+      "name": "HarryPotterObamaSonic10Inu  ETH ",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3792dbdd07e87413247df995e692806aa13d3299",
+      "name": "ECOMI",
+      "symbol": "OMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4428/large/ECOMI.png?1696505023"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb0505e5a99abd03d94a1169e638b78edfed26ea4",
+      "name": "Wrapped SUI  Universal ",
+      "symbol": "USUI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50482/large/UA-SUI-PAD.png?1727888681"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
+      "name": "Pocket Network",
+      "symbol": "POKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf5bc3439f53a45607ccad667abc7daf5a583633f",
+      "name": "AgentLayer",
+      "symbol": "AGENT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50213/large/Logo-Mark-White_256.png?1726433757"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x619c4bbbd65f836b78b36cbe781513861d57f39d",
+      "name": "Bitget Wallet Token",
+      "symbol": "BWB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37767/large/bwb.png?1715480561"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x161e113b8e9bbaefb846f73f31624f6f9607bd44",
+      "name": "Simmi Token",
+      "symbol": "SIMMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52349/large/simmi.png?1733160996"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x04c0599ae5a44757c0af6f9ec3b93da8976c150a",
+      "name": "ether fi Bridged weETH  Base ",
+      "symbol": "WEETHBASE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39950/large/WETH.PNG?1724902237"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9a26f5433671751c3276a065f57e5a02d2817973",
+      "name": "Keyboard Cat  Base ",
+      "symbol": "KEYCAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36608/large/keyboard_cat.jpeg?1711965348"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x20d704099b62ada091028bcfc44445041ed16f09",
+      "name": "Chaos",
+      "symbol": "CHAOS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52444/large/chaos-2.jpg?1733365634"
     },
     {
       "chainId": 8453,
@@ -608,7 +600,7 @@
       "name": "World Mobile Token",
       "symbol": "WMTX",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17333/thumb/1000097112.png?1727698144"
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
     },
     {
       "chainId": 8453,
@@ -616,7 +608,7 @@
       "name": "MAGA",
       "symbol": "TRUMP",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/31498/thumb/Maga-Trump-Logo-200px.png?1696530309"
+      "logoURI": "https://assets.coingecko.com/coins/images/31498/large/Maga-Trump-Logo-200px.png?1696530309"
     },
     {
       "chainId": 8453,
@@ -624,7 +616,7 @@
       "name": "Metacade",
       "symbol": "MCADE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29764/thumb/Square_Profile_Photo_1080_x_1080px.png?1699396445"
+      "logoURI": "https://assets.coingecko.com/coins/images/29764/large/Square_Profile_Photo_1080_x_1080px.png?1699396445"
     },
     {
       "chainId": 8453,
@@ -632,23 +624,7 @@
       "name": "Aleph im",
       "symbol": "ALEPH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Aleph-Logo-BW.png?1696511566"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x50c5725949a6f0c72e6c4a641f24049a917db0cb",
-      "name": "L2 Standard Bridged DAI  Base ",
-      "symbol": "DAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39807/thumb/dai.png?1724126571"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc43f3ae305a92043bd9b62ebd2fe14f7547ee485",
-      "name": "CHEX Token",
-      "symbol": "CHEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10349/thumb/logo-white-bg-dark.png?1733475849"
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/large/Aleph-Logo-BW.png?1696511566"
     },
     {
       "chainId": 8453,
@@ -656,31 +632,23 @@
       "name": "Artificial Liquid Intelligence",
       "symbol": "ALI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/ALI-v2.webp?1728501978"
+      "logoURI": "https://assets.coingecko.com/coins/images/22062/large/ALI-v2.webp?1728501978"
     },
     {
       "chainId": 8453,
-      "address": "0x23a96680ccde03bd4bdd9a3e9a0cb56a5d27f7c9",
-      "name": "Henlo",
-      "symbol": "HENLO",
+      "address": "0x50c5725949a6f0c72e6c4a641f24049a917db0cb",
+      "name": "L2 Standard Bridged DAI  Base ",
+      "symbol": "DAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52083/thumb/henlo.webp?1732532244"
+      "logoURI": "https://assets.coingecko.com/coins/images/39807/large/dai.png?1724126571"
     },
     {
       "chainId": 8453,
-      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
-      "name": "OX Coin",
-      "symbol": "OX",
+      "address": "0xc43f3ae305a92043bd9b62ebd2fe14f7547ee485",
+      "name": "CHEX Token",
+      "symbol": "CHEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35365/thumb/9.png?1727331352"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe2b1dc2d4a3b4e59fdf0c47b71a7a86391a8b35a",
-      "name": "RWA Inc ",
-      "symbol": "RWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50975/thumb/logo_%281%29.png?1732594737"
+      "logoURI": "https://assets.coingecko.com/coins/images/10349/large/logo-white-bg-dark.png?1733475849"
     },
     {
       "chainId": 8453,
@@ -688,7 +656,31 @@
       "name": "Propy",
       "symbol": "PRO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1696502002"
+      "logoURI": "https://assets.coingecko.com/coins/images/869/large/propy.png?1696502002"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x23a96680ccde03bd4bdd9a3e9a0cb56a5d27f7c9",
+      "name": "Henlo",
+      "symbol": "HENLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52083/large/henlo.webp?1732532244"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c",
+      "name": "Rocket Pool ETH",
+      "symbol": "RETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20764/large/reth.png?1696520159"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
     },
     {
       "chainId": 8453,
@@ -696,7 +688,15 @@
       "name": "SKI MASK CAT",
       "symbol": "SKICAT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52355/thumb/logo200x.png?1733168346"
+      "logoURI": "https://assets.coingecko.com/coins/images/52355/large/logo200x.png?1733168346"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe2b1dc2d4a3b4e59fdf0c47b71a7a86391a8b35a",
+      "name": "RWA Inc ",
+      "symbol": "RWA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50975/large/logo_%281%29.png?1732594737"
     },
     {
       "chainId": 8453,
@@ -704,7 +704,7 @@
       "name": "DOLA",
       "symbol": "DOLA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14287/thumb/dola.png?1696513984"
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
     },
     {
       "chainId": 8453,
@@ -712,7 +712,7 @@
       "name": "TYBENG",
       "symbol": "TYBENG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31022/thumb/NVoa_mZ6_400x400.jpg?1721805735"
+      "logoURI": "https://assets.coingecko.com/coins/images/31022/large/NVoa_mZ6_400x400.jpg?1721805735"
     },
     {
       "chainId": 8453,
@@ -720,15 +720,7 @@
       "name": "DOSE",
       "symbol": "DOSE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18847/thumb/dose.PNG?1696518308"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb676f87a6e701f0de8de5ab91b56b66109766db1",
-      "name": "BLOCKLORDS",
-      "symbol": "LRDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34775/thumb/LRDS_PNG.png?1706001771"
+      "logoURI": "https://assets.coingecko.com/coins/images/18847/large/dose.PNG?1696518308"
     },
     {
       "chainId": 8453,
@@ -736,7 +728,15 @@
       "name": "AEROBUD",
       "symbol": "AEROBUD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38210/thumb/Logo_Coingecko.png?1716798924"
+      "logoURI": "https://assets.coingecko.com/coins/images/38210/large/Logo_Coingecko.png?1716798924"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb676f87a6e701f0de8de5ab91b56b66109766db1",
+      "name": "BLOCKLORDS",
+      "symbol": "LRDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34775/large/LRDS_PNG.png?1706001771"
     },
     {
       "chainId": 8453,
@@ -744,15 +744,7 @@
       "name": "Chinese Doge Wow",
       "symbol": "CHIDO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52054/thumb/1.png?1732449299"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe3086852a4b125803c815a158249ae468a3254ca",
-      "name": "mfercoin",
-      "symbol": "MFER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36550/thumb/mfercoin-logo.png?1711876821"
+      "logoURI": "https://assets.coingecko.com/coins/images/52054/large/1.png?1732449299"
     },
     {
       "chainId": 8453,
@@ -760,7 +752,7 @@
       "name": "Worldwide USD",
       "symbol": "WUSD",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35358/thumb/WUSD%282%29.png?1715042139"
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
     },
     {
       "chainId": 8453,
@@ -768,7 +760,7 @@
       "name": "Anzen USDz",
       "symbol": "USDZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38039/thumb/usdz-image-200x200.png?1716334412"
+      "logoURI": "https://assets.coingecko.com/coins/images/38039/large/usdz-image-200x200.png?1716334412"
     },
     {
       "chainId": 8453,
@@ -776,7 +768,15 @@
       "name": "Basenji",
       "symbol": "BENJI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36416/thumb/ben200x200.jpg?1711420807"
+      "logoURI": "https://assets.coingecko.com/coins/images/36416/large/ben200x200.jpg?1711420807"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe3086852a4b125803c815a158249ae468a3254ca",
+      "name": "mfercoin",
+      "symbol": "MFER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36550/large/mfercoin-logo.png?1711876821"
     },
     {
       "chainId": 8453,
@@ -784,7 +784,7 @@
       "name": "Freysa AI",
       "symbol": "FAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52315/thumb/FAI.png?1733076295"
+      "logoURI": "https://assets.coingecko.com/coins/images/52315/large/FAI.png?1733076295"
     },
     {
       "chainId": 8453,
@@ -792,7 +792,7 @@
       "name": "Wrapped MistCoin",
       "symbol": "WMC",
       "decimals": 2,
-      "logoURI": "https://assets.coingecko.com/coins/images/32490/thumb/355966EE-F4AD-4023-A38E-59B9DEF1C6C3.jpeg?1732678326"
+      "logoURI": "https://assets.coingecko.com/coins/images/32490/large/355966EE-F4AD-4023-A38E-59B9DEF1C6C3.jpeg?1732678326"
     },
     {
       "chainId": 8453,
@@ -800,7 +800,7 @@
       "name": "Propbase",
       "symbol": "PROPS",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/32932/thumb/PROP_BASE_%286%29.png?1699870054"
+      "logoURI": "https://assets.coingecko.com/coins/images/32932/large/PROP_BASE_%286%29.png?1699870054"
     },
     {
       "chainId": 8453,
@@ -808,7 +808,7 @@
       "name": "MOEW",
       "symbol": "MOEW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36737/thumb/img_v3_02h9_c36546da-c4b6-4636-bc50-5239ab5d78hu.png?1733472868"
+      "logoURI": "https://assets.coingecko.com/coins/images/36737/large/img_v3_02h9_c36546da-c4b6-4636-bc50-5239ab5d78hu.png?1733472868"
     },
     {
       "chainId": 8453,
@@ -816,7 +816,7 @@
       "name": "Wrapped Solana  Universal ",
       "symbol": "USOL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39987/thumb/UA-SOL_1.png?1725027946"
+      "logoURI": "https://assets.coingecko.com/coins/images/39987/large/UA-SOL_1.png?1725027946"
     },
     {
       "chainId": 8453,
@@ -824,7 +824,7 @@
       "name": "Luminous",
       "symbol": "LUM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51439/thumb/LUM.jpg?1731232511"
+      "logoURI": "https://assets.coingecko.com/coins/images/51439/large/LUM.jpg?1731232511"
     },
     {
       "chainId": 8453,
@@ -832,7 +832,7 @@
       "name": "Alien Base",
       "symbol": "ALB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31301/thumb/ALB.png?1720133373"
+      "logoURI": "https://assets.coingecko.com/coins/images/31301/large/ALB.png?1720133373"
     },
     {
       "chainId": 8453,
@@ -840,23 +840,7 @@
       "name": "sekoia by Virtuals",
       "symbol": "SEKOIA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51785/thumb/sekoia.jpg?1731982234"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xea651c035f52b644856cab1f59775369c36ecadd",
-      "name": "La ka",
-      "symbol": "LAIKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39364/thumb/logo_laika.jpg?1721895773"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfb0c734fc3008683c5eff45bcf8128836c4d97d0",
-      "name": "Vertex",
-      "symbol": "VRTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27927/thumb/vrtx.png?1696526947"
+      "logoURI": "https://assets.coingecko.com/coins/images/51785/large/sekoia.jpg?1731982234"
     },
     {
       "chainId": 8453,
@@ -864,7 +848,15 @@
       "name": "Braintrust",
       "symbol": "BTRST",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1696517605"
+      "logoURI": "https://assets.coingecko.com/coins/images/18100/large/braintrust.PNG?1696517605"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfb0c734fc3008683c5eff45bcf8128836c4d97d0",
+      "name": "Vertex",
+      "symbol": "VRTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27927/large/vrtx.png?1696526947"
     },
     {
       "chainId": 8453,
@@ -872,7 +864,7 @@
       "name": "Cornucopias",
       "symbol": "COPI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21452/thumb/g56WwJDA_400x400.jpg?1696520814"
+      "logoURI": "https://assets.coingecko.com/coins/images/21452/large/g56WwJDA_400x400.jpg?1696520814"
     },
     {
       "chainId": 8453,
@@ -880,7 +872,15 @@
       "name": "MATH",
       "symbol": "MATH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1696511257"
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/large/2020-05-19-token-200.png?1696511257"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xea651c035f52b644856cab1f59775369c36ecadd",
+      "name": "La ka",
+      "symbol": "LAIKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39364/large/logo_laika.jpg?1721895773"
     },
     {
       "chainId": 8453,
@@ -888,15 +888,7 @@
       "name": "SmarDex",
       "symbol": "SDEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29470/thumb/SDEX_logo_transparent_outside_240x240.png?1696930070"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x750cf88d9e0c2bcedeec31d5faad6ed6e3f1abc6",
-      "name": "XCAD Network",
-      "symbol": "XCAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15857/thumb/xcad_logo.jpg?1707832192"
+      "logoURI": "https://assets.coingecko.com/coins/images/29470/large/SDEX_logo_transparent_outside_240x240.png?1696930070"
     },
     {
       "chainId": 8453,
@@ -904,7 +896,15 @@
       "name": "LogX Network",
       "symbol": "LOGX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50226/thumb/Token_200px.png?1726556358"
+      "logoURI": "https://assets.coingecko.com/coins/images/50226/large/Token_200px.png?1726556358"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x750cf88d9e0c2bcedeec31d5faad6ed6e3f1abc6",
+      "name": "XCAD Network",
+      "symbol": "XCAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15857/large/xcad_logo.jpg?1707832192"
     },
     {
       "chainId": 8453,
@@ -912,7 +912,7 @@
       "name": "Luna by Virtuals",
       "symbol": "LUNA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50880/thumb/luna.png?1729478763"
+      "logoURI": "https://assets.coingecko.com/coins/images/50880/large/luna.png?1729478763"
     },
     {
       "chainId": 8453,
@@ -920,7 +920,7 @@
       "name": "Zeebu",
       "symbol": "ZBU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31145/thumb/200x200_Front_token.png?1696529974"
+      "logoURI": "https://assets.coingecko.com/coins/images/31145/large/200x200_Front_token.png?1696529974"
     },
     {
       "chainId": 8453,
@@ -928,7 +928,7 @@
       "name": "Ambire Wallet",
       "symbol": "WALLET",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23154/thumb/wallet.PNG?1696522445"
+      "logoURI": "https://assets.coingecko.com/coins/images/23154/large/wallet.PNG?1696522445"
     },
     {
       "chainId": 8453,
@@ -936,7 +936,7 @@
       "name": "Own The Doge",
       "symbol": "DOG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18111/thumb/Doge.png?1696517615"
+      "logoURI": "https://assets.coingecko.com/coins/images/18111/large/Doge.png?1696517615"
     },
     {
       "chainId": 8453,
@@ -944,7 +944,7 @@
       "name": "nftxbt by Virtuals",
       "symbol": "NFTXBT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52332/thumb/nftxbt_logo.jpg?1733087152"
+      "logoURI": "https://assets.coingecko.com/coins/images/52332/large/nftxbt_logo.jpg?1733087152"
     },
     {
       "chainId": 8453,
@@ -952,71 +952,7 @@
       "name": "Liquity USD",
       "symbol": "LUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1696514341"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd2012fc1b913ce50732ebcaa7e601fe37ac728c6",
-      "name": "StakeStone ETH",
-      "symbol": "STONE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33103/thumb/200_200.png?1702602672"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
-      "name": "Mountain Protocol USD",
-      "symbol": "USDM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31719/thumb/usdm.png?1696530540"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
-      "name": "Cookie DAO",
-      "symbol": "COOKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38450/thumb/cookie_token_logo_200x200.png?1733194528"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x27e3bc3a66e24cad043ac3d93a12a8070e3897ba",
-      "name": "Ovr",
-      "symbol": "OVR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13429/thumb/LOGO-OVER-ICON-200X200PX.png?1699396496"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6921b130d297cc43754afba22e5eac0fbf8db75b",
-      "name": "doginme",
-      "symbol": "DOGINME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35123/thumb/doginme-logo1-transparent200.png?1710856784"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xedfa23602d0ec14714057867a78d01e94176bea0",
-      "name": "Wrapped rsETH",
-      "symbol": "WRSETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37919/thumb/rseth.png?1715936438"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1c7a460413dd4e964f96d8dfc56e7223ce88cd85",
-      "name": "Seamless Protocol",
-      "symbol": "SEAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33480/thumb/Seamless_Logo_Black_Transparent.png?1702019657"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc7dcca0a3e69bd762c8db257f868f76be36c8514",
-      "name": "KiboShib",
-      "symbol": "KIBSHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29335/thumb/foto_no_exif_%2811%29%282%29_%281%29.png?1696528285"
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1696514341"
     },
     {
       "chainId": 8453,
@@ -1024,23 +960,7 @@
       "name": "Electronic USD",
       "symbol": "EUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28445/thumb/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x50ce4129ca261ccde4eb100c170843c2936bc11b",
-      "name": "KOLZ",
-      "symbol": "KOLZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51235/thumb/KOLZ.png?1730447667"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc26c9099bd3789107888c35bb41178079b282561",
-      "name": "Solv Protocol SolvBTC BBN",
-      "symbol": "SOLVBTCBBN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39384/thumb/unnamed.png?1721961640"
+      "logoURI": "https://assets.coingecko.com/coins/images/28445/large/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
     },
     {
       "chainId": 8453,
@@ -1048,7 +968,87 @@
       "name": "pSTAKE Finance",
       "symbol": "PSTAKE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23931/thumb/512_x_512_Dark.png?1721243699"
+      "logoURI": "https://assets.coingecko.com/coins/images/23931/large/512_x_512_Dark.png?1721243699"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd2012fc1b913ce50732ebcaa7e601fe37ac728c6",
+      "name": "StakeStone ETH",
+      "symbol": "STONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33103/large/200_200.png?1702602672"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x27e3bc3a66e24cad043ac3d93a12a8070e3897ba",
+      "name": "Ovr",
+      "symbol": "OVR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13429/large/LOGO-OVER-ICON-200X200PX.png?1699396496"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6921b130d297cc43754afba22e5eac0fbf8db75b",
+      "name": "doginme",
+      "symbol": "DOGINME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35123/large/doginme-logo1-transparent200.png?1710856784"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+      "name": "Mountain Protocol USD",
+      "symbol": "USDM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31719/large/usdm.png?1696530540"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
+      "name": "Cookie DAO",
+      "symbol": "COOKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38450/large/cookie_token_logo_200x200.png?1733194528"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xedfa23602d0ec14714057867a78d01e94176bea0",
+      "name": "Wrapped rsETH",
+      "symbol": "WRSETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37919/large/rseth.png?1715936438"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1c7a460413dd4e964f96d8dfc56e7223ce88cd85",
+      "name": "Seamless Protocol",
+      "symbol": "SEAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33480/large/Seamless_Logo_Black_Transparent.png?1702019657"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc7dcca0a3e69bd762c8db257f868f76be36c8514",
+      "name": "KiboShib",
+      "symbol": "KIBSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29335/large/foto_no_exif_%2811%29%282%29_%281%29.png?1696528285"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x50ce4129ca261ccde4eb100c170843c2936bc11b",
+      "name": "KOLZ",
+      "symbol": "KOLZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51235/large/KOLZ.png?1730447667"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc26c9099bd3789107888c35bb41178079b282561",
+      "name": "Solv Protocol SolvBTC BBN",
+      "symbol": "SOLVBTCBBN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39384/large/unnamed.png?1721961640"
     },
     {
       "chainId": 8453,
@@ -1056,7 +1056,7 @@
       "name": "PAW",
       "symbol": "PAW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28946/thumb/PawLogo.png?1699394612"
+      "logoURI": "https://assets.coingecko.com/coins/images/28946/large/PawLogo.png?1699394612"
     },
     {
       "chainId": 8453,
@@ -1064,7 +1064,7 @@
       "name": "BASED",
       "symbol": "BASED",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39669/thumb/BASED.jpg?1723603780"
+      "logoURI": "https://assets.coingecko.com/coins/images/39669/large/BASED.jpg?1723603780"
     },
     {
       "chainId": 8453,
@@ -1072,7 +1072,7 @@
       "name": "Wrapped Ampleforth",
       "symbol": "WAMPL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1696520218"
+      "logoURI": "https://assets.coingecko.com/coins/images/20825/large/photo_2021-11-25_02-05-11.jpg?1696520218"
     },
     {
       "chainId": 8453,
@@ -1080,7 +1080,7 @@
       "name": "Phavercoin",
       "symbol": "SOCIAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50304/thumb/Phavercoin-_Social-MAIN-purple-logo-square.png?1727024458"
+      "logoURI": "https://assets.coingecko.com/coins/images/50304/large/Phavercoin-_Social-MAIN-purple-logo-square.png?1727024458"
     },
     {
       "chainId": 8453,
@@ -1088,7 +1088,7 @@
       "name": "Sensay",
       "symbol": "SNSY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36121/thumb/sensay.jpeg?1710495398"
+      "logoURI": "https://assets.coingecko.com/coins/images/36121/large/sensay.jpeg?1710495398"
     },
     {
       "chainId": 8453,
@@ -1096,7 +1096,7 @@
       "name": "Fuse",
       "symbol": "FUSE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10347/thumb/fuse.png?1696510348"
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
     },
     {
       "chainId": 8453,
@@ -1104,7 +1104,7 @@
       "name": "GAME by Virtuals",
       "symbol": "GAME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51063/thumb/Gaming_Agent_1fe70d54ba.jpg?1729925539"
+      "logoURI": "https://assets.coingecko.com/coins/images/51063/large/Gaming_Agent_1fe70d54ba.jpg?1729925539"
     },
     {
       "chainId": 8453,
@@ -1112,7 +1112,7 @@
       "name": "SKI MASK PUP",
       "symbol": "SKIPUP",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/38093/thumb/SkiPup_Logo.png?1716486539"
+      "logoURI": "https://assets.coingecko.com/coins/images/38093/large/SkiPup_Logo.png?1716486539"
     },
     {
       "chainId": 8453,
@@ -1120,7 +1120,7 @@
       "name": "VaderAI by Virtuals",
       "symbol": "VADER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51910/thumb/kare_pepe.png?1733345833"
+      "logoURI": "https://assets.coingecko.com/coins/images/51910/large/kare_pepe.png?1733345833"
     },
     {
       "chainId": 8453,
@@ -1128,7 +1128,7 @@
       "name": "Boomer",
       "symbol": "BOOMER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36477/thumb/Token_Image_200x200.png?1714757172"
+      "logoURI": "https://assets.coingecko.com/coins/images/36477/large/Token_Image_200x200.png?1714757172"
     },
     {
       "chainId": 8453,
@@ -1136,7 +1136,7 @@
       "name": "higher",
       "symbol": "HIGHER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36084/thumb/200x200logo.png?1710427814"
+      "logoURI": "https://assets.coingecko.com/coins/images/36084/large/200x200logo.png?1710427814"
     },
     {
       "chainId": 8453,
@@ -1144,7 +1144,7 @@
       "name": "Apetardio",
       "symbol": "APETARDIO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38155/thumb/apetardio200x200.png?1716669062"
+      "logoURI": "https://assets.coingecko.com/coins/images/38155/large/apetardio200x200.png?1716669062"
     },
     {
       "chainId": 8453,
@@ -1152,15 +1152,7 @@
       "name": "Seraph by Virtuals",
       "symbol": "SERAPH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52442/thumb/fire_guy.png?1733351187"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x858c50c3af1913b0e849afdb74617388a1a5340d",
-      "name": "SubQuery Network",
-      "symbol": "SQT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23359/thumb/LinkedIn_Avatar_Op1.png?1724379155"
+      "logoURI": "https://assets.coingecko.com/coins/images/52442/large/fire_guy.png?1733351187"
     },
     {
       "chainId": 8453,
@@ -1168,7 +1160,15 @@
       "name": "Cryptex Finance",
       "symbol": "CTX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/CTX_Logo_200px.png?1723514786"
+      "logoURI": "https://assets.coingecko.com/coins/images/14932/large/CTX_Logo_200px.png?1723514786"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x858c50c3af1913b0e849afdb74617388a1a5340d",
+      "name": "SubQuery Network",
+      "symbol": "SQT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23359/large/LinkedIn_Avatar_Op1.png?1724379155"
     },
     {
       "chainId": 8453,
@@ -1176,7 +1176,7 @@
       "name": "Lovely Inu Finance",
       "symbol": "LOVELY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19053/thumb/lovely-inu-logo-new.png?1696518503"
+      "logoURI": "https://assets.coingecko.com/coins/images/19053/large/lovely-inu-logo-new.png?1696518503"
     },
     {
       "chainId": 8453,
@@ -1184,7 +1184,7 @@
       "name": "Okayeg",
       "symbol": "OKAYEG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37748/thumb/Okayeg_200.png?1715442444"
+      "logoURI": "https://assets.coingecko.com/coins/images/37748/large/Okayeg_200.png?1715442444"
     },
     {
       "chainId": 8453,
@@ -1192,23 +1192,7 @@
       "name": "Wrapped BMX Liquidity Token",
       "symbol": "WBLT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31532/thumb/wBLT_200x200.png?1696530341"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2676e4e0e2eb58d9bdb5078358ff8a3a964cedf5",
-      "name": "Polytrader by Virtuals",
-      "symbol": "POLY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52168/thumb/poly.jpg?1732682921"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x18e692c03de43972fe81058f322fa542ae1a5e2c",
-      "name": "imgnAI",
-      "symbol": "IMGNAI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/28666/thumb/imgnai-200x200.png?1698476572"
+      "logoURI": "https://assets.coingecko.com/coins/images/31532/large/wBLT_200x200.png?1696530341"
     },
     {
       "chainId": 8453,
@@ -1216,7 +1200,15 @@
       "name": "Katana Inu",
       "symbol": "KATA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21872/thumb/Katana_Inu512.png?1696521226"
+      "logoURI": "https://assets.coingecko.com/coins/images/21872/large/Katana_Inu512.png?1696521226"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x18e692c03de43972fe81058f322fa542ae1a5e2c",
+      "name": "imgnAI",
+      "symbol": "IMGNAI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28666/large/imgnai-200x200.png?1698476572"
     },
     {
       "chainId": 8453,
@@ -1224,7 +1216,7 @@
       "name": "Base God",
       "symbol": "TYBG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34563/thumb/tybg.png?1705400778"
+      "logoURI": "https://assets.coingecko.com/coins/images/34563/large/tybg.png?1705400778"
     },
     {
       "chainId": 8453,
@@ -1232,7 +1224,7 @@
       "name": "Talent Protocol",
       "symbol": "TALENT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51120/thumb/Ticker-logo-200.png?1730128751"
+      "logoURI": "https://assets.coingecko.com/coins/images/51120/large/Ticker-logo-200.png?1730128751"
     },
     {
       "chainId": 8453,
@@ -1240,7 +1232,7 @@
       "name": "Super Champs",
       "symbol": "CHAMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51900/thumb/CHAMP_Token_256x256.png?1732131989"
+      "logoURI": "https://assets.coingecko.com/coins/images/51900/large/CHAMP_Token_256x256.png?1732131989"
     },
     {
       "chainId": 8453,
@@ -1248,15 +1240,15 @@
       "name": "Wrapped XRP  Universal ",
       "symbol": "UXRP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51658/thumb/UA-XRP_1.png?1731703523"
+      "logoURI": "https://assets.coingecko.com/coins/images/51658/large/UA-XRP_1.png?1731703523"
     },
     {
       "chainId": 8453,
-      "address": "0x52b492a33e447cdb854c7fc19f1e57e8bfa1777d",
-      "name": "Based Pepe",
-      "symbol": "PEPE",
+      "address": "0x2676e4e0e2eb58d9bdb5078358ff8a3a964cedf5",
+      "name": "Polytrader by Virtuals",
+      "symbol": "POLY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39763/thumb/based_pepe_transparent.png?1724010222"
+      "logoURI": "https://assets.coingecko.com/coins/images/52168/large/poly.jpg?1732682921"
     },
     {
       "chainId": 8453,
@@ -1264,7 +1256,15 @@
       "name": "Media Network",
       "symbol": "MEDIA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15142/thumb/media50x50.png?1696514798"
+      "logoURI": "https://assets.coingecko.com/coins/images/15142/large/media50x50.png?1696514798"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x52b492a33e447cdb854c7fc19f1e57e8bfa1777d",
+      "name": "Based Pepe",
+      "symbol": "PEPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39763/large/based_pepe_transparent.png?1724010222"
     },
     {
       "chainId": 8453,
@@ -1272,7 +1272,7 @@
       "name": "GALAXIS Token",
       "symbol": "GALAXIS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36221/thumb/500x500.png?1714755244"
+      "logoURI": "https://assets.coingecko.com/coins/images/36221/large/500x500.png?1714755244"
     },
     {
       "chainId": 8453,
@@ -1280,55 +1280,7 @@
       "name": "ResearchCoin",
       "symbol": "RSC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28146/thumb/RH_BOTTLE_CLEAN_Aug_2024_1.png?1732742001"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfe550bffb51eb645ea3b324d772a19ac449e92c5",
-      "name": "IX Swap",
-      "symbol": "IXS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18069/thumb/ixswap.PNG?1696517577"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa3a2cdd230f9b3ff6e01a01534a3ed3cbf049815",
-      "name": "zkRace",
-      "symbol": "ZERC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17438/thumb/zkRace-logomark-border.png?1716518566"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x703d57164ca270b0b330a87fd159cfef1490c0a5",
-      "name": "RAI Finance",
-      "symbol": "SOFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14686/thumb/sofi.png?1696514359"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x64cb1bafc59bf93aeb90676885c63540cf4f4106",
-      "name": "Coin6900",
-      "symbol": "COIN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51425/thumb/logo.jpg?1731186114"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7588880d9c78e81fade7b7e8dc0781e95995a792",
-      "name": "Satoshi AI agent by Virtuals",
-      "symbol": "SAINT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52336/thumb/saint.jpg?1733121865"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5ed25e305e08f58afd7995eac72563e6be65a617",
-      "name": "Wrapped NEAR  Universal ",
-      "symbol": "UNEAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50645/thumb/UA-NEAR_1.png?1728579564"
+      "logoURI": "https://assets.coingecko.com/coins/images/28146/large/RH_BOTTLE_CLEAN_Aug_2024_1.png?1732742001"
     },
     {
       "chainId": 8453,
@@ -1336,7 +1288,55 @@
       "name": "GammaSwap",
       "symbol": "GS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29222/thumb/newLogo2.png?1731702645"
+      "logoURI": "https://assets.coingecko.com/coins/images/29222/large/newLogo2.png?1731702645"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa3a2cdd230f9b3ff6e01a01534a3ed3cbf049815",
+      "name": "zkRace",
+      "symbol": "ZERC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17438/large/zkRace-logomark-border.png?1716518566"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfe550bffb51eb645ea3b324d772a19ac449e92c5",
+      "name": "IX Swap",
+      "symbol": "IXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18069/large/ixswap.PNG?1696517577"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x703d57164ca270b0b330a87fd159cfef1490c0a5",
+      "name": "RAI Finance",
+      "symbol": "SOFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14686/large/sofi.png?1696514359"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5ed25e305e08f58afd7995eac72563e6be65a617",
+      "name": "Wrapped NEAR  Universal ",
+      "symbol": "UNEAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50645/large/UA-NEAR_1.png?1728579564"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7588880d9c78e81fade7b7e8dc0781e95995a792",
+      "name": "Satoshi AI agent by Virtuals",
+      "symbol": "SAINT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52336/large/saint.jpg?1733121865"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x64cb1bafc59bf93aeb90676885c63540cf4f4106",
+      "name": "Coin6900",
+      "symbol": "COIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51425/large/logo.jpg?1731186114"
     },
     {
       "chainId": 8453,
@@ -1344,7 +1344,7 @@
       "name": "Unagi Token",
       "symbol": "UNA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34733/thumb/unagi.png?1705922276"
+      "logoURI": "https://assets.coingecko.com/coins/images/34733/large/unagi.png?1705922276"
     },
     {
       "chainId": 8453,
@@ -1352,7 +1352,7 @@
       "name": "Base",
       "symbol": "BASE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31199/thumb/59302ba8-022e-45a4-8d00-e29fe2ee768c-removebg-preview.png?1696530026"
+      "logoURI": "https://assets.coingecko.com/coins/images/31199/large/59302ba8-022e-45a4-8d00-e29fe2ee768c-removebg-preview.png?1696530026"
     },
     {
       "chainId": 8453,
@@ -1360,7 +1360,7 @@
       "name": "Hacken",
       "symbol": "HAI",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/11081/thumb/hacken-symbol-with-bg.png?1696511022"
+      "logoURI": "https://assets.coingecko.com/coins/images/11081/large/hacken-symbol-with-bg.png?1696511022"
     },
     {
       "chainId": 8453,
@@ -1368,7 +1368,7 @@
       "name": "Overnight fi USDC ",
       "symbol": "USDC+",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/34763/thumb/USDC_.png?1705990720"
+      "logoURI": "https://assets.coingecko.com/coins/images/34763/large/USDC_.png?1705990720"
     },
     {
       "chainId": 8453,
@@ -1376,7 +1376,7 @@
       "name": "Gochujangcoin",
       "symbol": "GOCHU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39318/thumb/GochujangLogo_200_3x.png?1721709656"
+      "logoURI": "https://assets.coingecko.com/coins/images/39318/large/GochujangLogo_200_3x.png?1721709656"
     },
     {
       "chainId": 8453,
@@ -1384,7 +1384,7 @@
       "name": "GAM3S GG",
       "symbol": "G3",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35662/thumb/G3_logo.jpg?1709454143"
+      "logoURI": "https://assets.coingecko.com/coins/images/35662/large/G3_logo.jpg?1709454143"
     },
     {
       "chainId": 8453,
@@ -1392,15 +1392,7 @@
       "name": "ChompCoin",
       "symbol": "CHOMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36942/thumb/chomplogo200.png?1712864472"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe2dca969624795985f2f083bcd0b674337ba130a",
-      "name": "Saakuru",
-      "symbol": "SKR",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/37058/thumb/saakuru.jpeg?1713172376"
+      "logoURI": "https://assets.coingecko.com/coins/images/36942/large/chomplogo200.png?1712864472"
     },
     {
       "chainId": 8453,
@@ -1408,7 +1400,15 @@
       "name": "Bonkey",
       "symbol": "BONKEY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51629/thumb/nWKo5DZvrtkwwjtT7YXyYQeDstBhvwrqxdOmGmWvUNN6d_GSurf_TR1InJS8oLo2WYIJG2ZsX2Lffmr8z1bjqjygtVNcAKuMIX3TJPg65wPZepTpTQnXCXZrbA_oXuiIkzN2PU1vd1i6scKtGgJa4ffeecm1R7WzR7NX65j6JVu_ys42VMrpvNuNJ2ovRGM8sh9V-MovD8Mbs9NkaYQ_%281%29.jpg?1731664154"
+      "logoURI": "https://assets.coingecko.com/coins/images/51629/large/nWKo5DZvrtkwwjtT7YXyYQeDstBhvwrqxdOmGmWvUNN6d_GSurf_TR1InJS8oLo2WYIJG2ZsX2Lffmr8z1bjqjygtVNcAKuMIX3TJPg65wPZepTpTQnXCXZrbA_oXuiIkzN2PU1vd1i6scKtGgJa4ffeecm1R7WzR7NX65j6JVu_ys42VMrpvNuNJ2ovRGM8sh9V-MovD8Mbs9NkaYQ_%281%29.jpg?1731664154"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe2dca969624795985f2f083bcd0b674337ba130a",
+      "name": "Saakuru",
+      "symbol": "SKR",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/37058/large/saakuru.jpeg?1713172376"
     },
     {
       "chainId": 8453,
@@ -1416,15 +1416,7 @@
       "name": "Shaka",
       "symbol": "SHAKA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36850/thumb/sharetheshaka.png?1712585688"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8319767a7b602f88e376368dca1b92d38869b9b4",
-      "name": "Based Peaches",
-      "symbol": "PEACH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36762/thumb/Peaches-New-Logo-200x200.png?1719742607"
+      "logoURI": "https://assets.coingecko.com/coins/images/36850/large/sharetheshaka.png?1712585688"
     },
     {
       "chainId": 8453,
@@ -1432,7 +1424,15 @@
       "name": "Build",
       "symbol": "BUILD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37836/thumb/buildlogo.png?1715741487"
+      "logoURI": "https://assets.coingecko.com/coins/images/37836/large/buildlogo.png?1715741487"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8319767a7b602f88e376368dca1b92d38869b9b4",
+      "name": "Based Peaches",
+      "symbol": "PEACH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36762/large/Peaches-New-Logo-200x200.png?1719742607"
     },
     {
       "chainId": 8453,
@@ -1440,15 +1440,7 @@
       "name": "Brian",
       "symbol": "BRIAN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51099/thumb/Brian_Arm_Strong.png?1730083824"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf6e932ca12afa26665dc4dde7e27be02a7c02e50",
-      "name": "Mochi",
-      "symbol": "MOCHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33083/thumb/CIRCLE-200x200.png?1713297273"
+      "logoURI": "https://assets.coingecko.com/coins/images/51099/large/Brian_Arm_Strong.png?1730083824"
     },
     {
       "chainId": 8453,
@@ -1456,15 +1448,7 @@
       "name": "MISATO",
       "symbol": "MISATO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52231/thumb/misatocleanboost.png?1732802425"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6d3b8c76c5396642960243febf736c6be8b60562",
-      "name": "Skull of Pepe Token",
-      "symbol": "SKOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38342/thumb/skop.jpeg?1717141011"
+      "logoURI": "https://assets.coingecko.com/coins/images/52231/large/misatocleanboost.png?1732802425"
     },
     {
       "chainId": 8453,
@@ -1472,23 +1456,15 @@
       "name": "Token Metrics AI",
       "symbol": "TMAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37707/thumb/Mascot_200x200.png?1733173189"
+      "logoURI": "https://assets.coingecko.com/coins/images/37707/large/Mascot_200x200.png?1733173189"
     },
     {
       "chainId": 8453,
-      "address": "0x85e90a5430af45776548adb82ee4cd9e33b08077",
-      "name": "Coding Dino",
-      "symbol": "DINO",
+      "address": "0x6d3b8c76c5396642960243febf736c6be8b60562",
+      "name": "Skull of Pepe Token",
+      "symbol": "SKOP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36637/thumb/dino_icon_copy.png?1712029544"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3d1d651761d535df881740ab50ba4bd8a2ec2c00",
-      "name": "Synthesizer Dog",
-      "symbol": "SYNDOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51577/thumb/SYNDOG_LOGO.png?1731534533"
+      "logoURI": "https://assets.coingecko.com/coins/images/38342/large/skop.jpeg?1717141011"
     },
     {
       "chainId": 8453,
@@ -1496,15 +1472,23 @@
       "name": "KlimaDAO",
       "symbol": "KLIMA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19169/thumb/Klima-Token.png?1696518618"
+      "logoURI": "https://assets.coingecko.com/coins/images/19169/large/Klima-Token.png?1696518618"
     },
     {
       "chainId": 8453,
-      "address": "0x47b464edb8dc9bc67b5cd4c9310bb87b773845bd",
-      "name": "NORMIE",
-      "symbol": "NORMIE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/35880/thumb/NORMIEsite.png?1709983341"
+      "address": "0x85e90a5430af45776548adb82ee4cd9e33b08077",
+      "name": "Coding Dino",
+      "symbol": "DINO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36637/large/dino_icon_copy.png?1712029544"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3d1d651761d535df881740ab50ba4bd8a2ec2c00",
+      "name": "Synthesizer Dog",
+      "symbol": "SYNDOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51577/large/SYNDOG_LOGO.png?1731534533"
     },
     {
       "chainId": 8453,
@@ -1512,31 +1496,15 @@
       "name": "EMAIL Token",
       "symbol": "EMT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38631/thumb/EMT_square_LG%282%29.png?1718171885"
+      "logoURI": "https://assets.coingecko.com/coins/images/38631/large/EMT_square_LG%282%29.png?1718171885"
     },
     {
       "chainId": 8453,
-      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
-      "name": "Osaka Protocol",
-      "symbol": "OSAK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30911/thumb/OSAK_LOGO_200x200.png?1723662197"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2974dc646e375e83bd1c0342625b49f288987fa4",
-      "name": "Swarm Markets",
-      "symbol": "SMT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17488/thumb/swarm-SMT-token-symbol_200x200.png?1696517029"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6b2504a03ca4d43d0d73776f6ad46dab2f2a4cfd",
-      "name": "Unit 00   Rei",
-      "symbol": "REI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52005/thumb/Unit_00_-_Rei.jpg?1732592775"
+      "address": "0x47b464edb8dc9bc67b5cd4c9310bb87b773845bd",
+      "name": "NORMIE",
+      "symbol": "NORMIE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/35880/large/NORMIEsite.png?1709983341"
     },
     {
       "chainId": 8453,
@@ -1544,15 +1512,31 @@
       "name": "Catamoto",
       "symbol": "CATA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37218/thumb/200x200.png?1713774219"
+      "logoURI": "https://assets.coingecko.com/coins/images/37218/large/200x200.png?1713774219"
     },
     {
       "chainId": 8453,
-      "address": "0x10f434b3d1cc13a4a79b062dcc25706f64d10d47",
-      "name": "BEPE",
-      "symbol": "BEPE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/35989/thumb/NEW_LOGO200x200.png?1721595288"
+      "address": "0x6b2504a03ca4d43d0d73776f6ad46dab2f2a4cfd",
+      "name": "Unit 00   Rei",
+      "symbol": "REI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52005/large/Unit_00_-_Rei.jpg?1732592775"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2974dc646e375e83bd1c0342625b49f288987fa4",
+      "name": "Swarm Markets",
+      "symbol": "SMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17488/large/swarm-SMT-token-symbol_200x200.png?1696517029"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
+      "name": "Osaka Protocol",
+      "symbol": "OSAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30911/large/OSAK_LOGO_200x200.png?1723662197"
     },
     {
       "chainId": 8453,
@@ -1560,7 +1544,15 @@
       "name": "Miracle Play",
       "symbol": "MPT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32653/thumb/MPT.png?1698895300"
+      "logoURI": "https://assets.coingecko.com/coins/images/32653/large/MPT.png?1698895300"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x10f434b3d1cc13a4a79b062dcc25706f64d10d47",
+      "name": "BEPE",
+      "symbol": "BEPE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/35989/large/NEW_LOGO200x200.png?1721595288"
     },
     {
       "chainId": 8453,
@@ -1568,7 +1560,7 @@
       "name": "AxonDAO Governance Token",
       "symbol": "AXGT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35290/thumb/AXGT-logo-7.png?1708076161"
+      "logoURI": "https://assets.coingecko.com/coins/images/35290/large/AXGT-logo-7.png?1708076161"
     },
     {
       "chainId": 8453,
@@ -1576,7 +1568,7 @@
       "name": "Insane Labz  Base ",
       "symbol": "LABZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51886/thumb/Photo_May_18_2024__6_11_22_PM.jpg?1732120518"
+      "logoURI": "https://assets.coingecko.com/coins/images/51886/large/Photo_May_18_2024__6_11_22_PM.jpg?1732120518"
     },
     {
       "chainId": 8453,
@@ -1584,7 +1576,7 @@
       "name": "Persistence One",
       "symbol": "XPRT",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/14582/thumb/Download%28black_Dark%29.png?1723470571"
+      "logoURI": "https://assets.coingecko.com/coins/images/14582/large/Download%28black_Dark%29.png?1723470571"
     },
     {
       "chainId": 8453,
@@ -1592,7 +1584,7 @@
       "name": "Dypius",
       "symbol": "DYP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33016/thumb/RS-zDhFE_400x400.jpg?1700157370"
+      "logoURI": "https://assets.coingecko.com/coins/images/33016/large/RS-zDhFE_400x400.jpg?1700157370"
     },
     {
       "chainId": 8453,
@@ -1600,7 +1592,7 @@
       "name": "Gyroscope GYD",
       "symbol": "GYD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33428/thumb/GYD-gradient_resized_transparent.png?1702316822"
+      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
     },
     {
       "chainId": 8453,
@@ -1608,63 +1600,7 @@
       "name": "Gibape",
       "symbol": "GIB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37691/thumb/gib_ape_logo.jpeg?1715650189"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9c0e042d65a2e1ff31ac83f404e5cb79f452c337",
-      "name": "Wrapped Aptos  Universal ",
-      "symbol": "UAPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50646/thumb/UA-APTOS-PAD_1.png?1728579627"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdfbea88c4842d30c26669602888d746d30f9d60d",
-      "name": "crow with knife",
-      "symbol": "CAW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36067/thumb/200px.png?1710405601"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5a7a2bf9ffae199f088b25837dcd7e115cf8e1bb",
-      "name": "IMO",
-      "symbol": "IMO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14831/thumb/IMO_logo_rond_200.png?1729798616"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5a76a56ad937335168b30df3aa1327277421c6ae",
-      "name": "Vela Token",
-      "symbol": "VELA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28739/thumb/VELA_logo_-_no_background.png?1696527719"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2c002ffec41568d138acc36f5894d6156398d539",
-      "name": "Lucky Dog",
-      "symbol": "LUCKY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51334/thumb/LUCKYTokenSymbol.png?1730797716"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c5142bc58f9a61ab8c3d2085dd2f4e550c5ce0b",
-      "name": "RUSSELL",
-      "symbol": "RUSSELL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50690/thumb/russelllogo.png?1730010143"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc1ffaef4e7d553bbaf13926e258a1a555a363a07",
-      "name": "Human Intelligence Machin",
-      "symbol": "HIM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37898/thumb/Human_Intelligence_Machine.png?1715848133"
+      "logoURI": "https://assets.coingecko.com/coins/images/37691/large/gib_ape_logo.jpeg?1715650189"
     },
     {
       "chainId": 8453,
@@ -1672,95 +1608,15 @@
       "name": "Based ETH",
       "symbol": "BSDETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35774/thumb/Icon_White_on_Blue.png?1709793654"
+      "logoURI": "https://assets.coingecko.com/coins/images/35774/large/Icon_White_on_Blue.png?1709793654"
     },
     {
       "chainId": 8453,
-      "address": "0xf0268c5f9aa95baf5c25d646aabb900ac12f0800",
-      "name": "RealGoat",
-      "symbol": "RGOAT",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/38923/thumb/IMG_20240625_033037_003.jpg?1719521003"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
-      "name": "Wagmi",
-      "symbol": "WAGMI",
+      "address": "0x9c0e042d65a2e1ff31ac83f404e5cb79f452c337",
+      "name": "Wrapped Aptos  Universal ",
+      "symbol": "UAPT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31887/thumb/wagmi_token_logo.png?1696530698"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x051fb509e4a775fabd257611eea1efaed8f91359",
-      "name": "CateCoin",
-      "symbol": "CATE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/15364/thumb/logo.png?1696515013"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x12e96c2bfea6e835cf8dd38a5834fa61cf723736",
-      "name": "Wrapped DOGE  Universal ",
-      "symbol": "UDOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40099/thumb/UA-DOGE_1.png?1725632510"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x776aaef8d8760129a0398cf8674ee28cefc0eab9",
-      "name": "Floppa Cat",
-      "symbol": "FLOPPA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36969/thumb/floppa.jpg?1722771377"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x71a67215a2025f501f386a49858a9ced2fc0249d",
-      "name": "Wrapped SEI  Universal ",
-      "symbol": "USEI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51023/thumb/UA-SEI_1.png?1729770680"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf544251d25f3d243a36b07e7e7962a678f952691",
-      "name": "Tarot",
-      "symbol": "TAROT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31800/thumb/TAROT.jpg?1696530615"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd98832e8a59156acbee4744b9a94a9989a728f36",
-      "name": "AgentAIgo",
-      "symbol": "AGENT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52294/thumb/agent_logo.jpg?1732966712"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
-      "name": "Truflation",
-      "symbol": "TRUF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36642/thumb/truflation.jpg?1733315818"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf8a99f2bf2ce5bb6ce4aafcf070d8723bc904aa2",
-      "name": "Chinese Brett",
-      "symbol": "CHRETT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38541/thumb/GNQP9A7WwAIcolJ_%282%29.png?1717926712"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xed2d13a70acbd61074fc56bd0d0845e35f793e5e",
-      "name": "Planet Mojo",
-      "symbol": "MOJO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36670/thumb/MOJOIcon.jpg?1712061269"
+      "logoURI": "https://assets.coingecko.com/coins/images/50646/large/UA-APTOS-PAD_1.png?1728579627"
     },
     {
       "chainId": 8453,
@@ -1768,7 +1624,143 @@
       "name": "Guru Network",
       "symbol": "GURU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38583/thumb/tGURU_token_circle.png?1718087986"
+      "logoURI": "https://assets.coingecko.com/coins/images/38583/large/tGURU_token_circle.png?1718087986"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdfbea88c4842d30c26669602888d746d30f9d60d",
+      "name": "crow with knife",
+      "symbol": "CAW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36067/large/200px.png?1710405601"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5a76a56ad937335168b30df3aa1327277421c6ae",
+      "name": "Vela Token",
+      "symbol": "VELA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28739/large/VELA_logo_-_no_background.png?1696527719"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2c002ffec41568d138acc36f5894d6156398d539",
+      "name": "Lucky Dog",
+      "symbol": "LUCKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51334/large/LUCKYTokenSymbol.png?1730797716"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5a7a2bf9ffae199f088b25837dcd7e115cf8e1bb",
+      "name": "IMO",
+      "symbol": "IMO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14831/large/IMO_logo_rond_200.png?1729798616"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0c5142bc58f9a61ab8c3d2085dd2f4e550c5ce0b",
+      "name": "RUSSELL",
+      "symbol": "RUSSELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50690/large/russelllogo.png?1730010143"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc1ffaef4e7d553bbaf13926e258a1a555a363a07",
+      "name": "Human Intelligence Machin",
+      "symbol": "HIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37898/large/Human_Intelligence_Machine.png?1715848133"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf0268c5f9aa95baf5c25d646aabb900ac12f0800",
+      "name": "RealGoat",
+      "symbol": "RGOAT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/38923/large/IMG_20240625_033037_003.jpg?1719521003"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
+      "name": "Wagmi",
+      "symbol": "WAGMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31887/large/wagmi_token_logo.png?1696530698"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x051fb509e4a775fabd257611eea1efaed8f91359",
+      "name": "CateCoin",
+      "symbol": "CATE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/15364/large/logo.png?1696515013"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x12e96c2bfea6e835cf8dd38a5834fa61cf723736",
+      "name": "Wrapped DOGE  Universal ",
+      "symbol": "UDOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40099/large/UA-DOGE_1.png?1725632510"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x776aaef8d8760129a0398cf8674ee28cefc0eab9",
+      "name": "Floppa Cat",
+      "symbol": "FLOPPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36969/large/floppa.jpg?1722771377"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x71a67215a2025f501f386a49858a9ced2fc0249d",
+      "name": "Wrapped SEI  Universal ",
+      "symbol": "USEI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51023/large/UA-SEI_1.png?1729770680"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
+      "name": "Truflation",
+      "symbol": "TRUF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36642/large/truflation.jpg?1733315818"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd98832e8a59156acbee4744b9a94a9989a728f36",
+      "name": "AgentAIgo",
+      "symbol": "AGENT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52294/large/agent_logo.jpg?1732966712"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xed2d13a70acbd61074fc56bd0d0845e35f793e5e",
+      "name": "Planet Mojo",
+      "symbol": "MOJO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36670/large/MOJOIcon.jpg?1712061269"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf8a99f2bf2ce5bb6ce4aafcf070d8723bc904aa2",
+      "name": "Chinese Brett",
+      "symbol": "CHRETT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38541/large/GNQP9A7WwAIcolJ_%282%29.png?1717926712"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf6e932ca12afa26665dc4dde7e27be02a7c02e50",
+      "name": "Mochi",
+      "symbol": "MOCHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33083/large/CIRCLE-200x200.png?1713297273"
     },
     {
       "chainId": 8453,
@@ -1776,7 +1768,7 @@
       "name": "ghffb47yii2rteeyy10op",
       "symbol": "GHFFB47YII2RTEEYY10",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52104/thumb/0x354d6890caa31a5e28b6059d46781f40880786a6.png?1732591949"
+      "logoURI": "https://assets.coingecko.com/coins/images/52104/large/0x354d6890caa31a5e28b6059d46781f40880786a6.png?1732591949"
     },
     {
       "chainId": 8453,
@@ -1784,47 +1776,7 @@
       "name": "Andy",
       "symbol": "ANDY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36552/thumb/ANDY.jpg?1711896298"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf5e89006cbeff2dabcfda0def5bf45ebe7f8429f",
-      "name": "Ragdoll",
-      "symbol": "RAGDOLL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51848/thumb/O0_Ds5Ad_400x400.jpg?1732060576"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x314d7f9e2f55b430ef656fbb98a7635d43a2261e",
-      "name": "Naym",
-      "symbol": "NAYM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50981/thumb/naym.jpg?1729651162"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
-      "name": "Any Inu",
-      "symbol": "AI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34126/thumb/anyinulogo200.png?1704174269"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0808bf94d57c905f1236212654268ef82e1e594e",
-      "name": "ritestream",
-      "symbol": "RITE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24130/thumb/rite.png?1696523321"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3ee5e23eee121094f1cfc0ccc79d6c809ebd22e5",
-      "name": "Ionic Protocol",
-      "symbol": "ION",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36713/thumb/Ionic-icon-green.png?1712127547"
+      "logoURI": "https://assets.coingecko.com/coins/images/36552/large/ANDY.jpg?1711896298"
     },
     {
       "chainId": 8453,
@@ -1832,7 +1784,39 @@
       "name": "Based Bario",
       "symbol": "BARIO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50719/thumb/bario.jpg?1728803763"
+      "logoURI": "https://assets.coingecko.com/coins/images/50719/large/bario.jpg?1728803763"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf5e89006cbeff2dabcfda0def5bf45ebe7f8429f",
+      "name": "Ragdoll",
+      "symbol": "RAGDOLL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51848/large/O0_Ds5Ad_400x400.jpg?1732060576"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
+      "name": "Any Inu",
+      "symbol": "AI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34126/large/anyinulogo200.png?1704174269"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x314d7f9e2f55b430ef656fbb98a7635d43a2261e",
+      "name": "Naym",
+      "symbol": "NAYM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50981/large/naym.jpg?1729651162"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0808bf94d57c905f1236212654268ef82e1e594e",
+      "name": "ritestream",
+      "symbol": "RITE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24130/large/rite.png?1696523321"
     },
     {
       "chainId": 8453,
@@ -1840,7 +1824,23 @@
       "name": "Tyler",
       "symbol": "TYLER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50734/thumb/photo_2024-09-23_09-14-08.jpg?1728916087"
+      "logoURI": "https://assets.coingecko.com/coins/images/50734/large/photo_2024-09-23_09-14-08.jpg?1728916087"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf544251d25f3d243a36b07e7e7962a678f952691",
+      "name": "Tarot",
+      "symbol": "TAROT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31800/large/TAROT.jpg?1696530615"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3ee5e23eee121094f1cfc0ccc79d6c809ebd22e5",
+      "name": "Ionic Protocol",
+      "symbol": "ION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36713/large/Ionic-icon-green.png?1712127547"
     },
     {
       "chainId": 8453,
@@ -1848,7 +1848,7 @@
       "name": "Assimilate",
       "symbol": "SIM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52377/thumb/SIM_LOGO.jpeg?1733253732"
+      "logoURI": "https://assets.coingecko.com/coins/images/52377/large/SIM_LOGO.jpeg?1733253732"
     },
     {
       "chainId": 8453,
@@ -1856,7 +1856,7 @@
       "name": "GenomesDAO GENOME",
       "symbol": "GENOME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36763/thumb/images.jpg?1712282056"
+      "logoURI": "https://assets.coingecko.com/coins/images/36763/large/images.jpg?1712282056"
     },
     {
       "chainId": 8453,
@@ -1864,7 +1864,7 @@
       "name": "iZUMi Finance",
       "symbol": "IZI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21791/thumb/izumi-logo-symbol.png?1696521144"
+      "logoURI": "https://assets.coingecko.com/coins/images/21791/large/izumi-logo-symbol.png?1696521144"
     },
     {
       "chainId": 8453,
@@ -1872,7 +1872,7 @@
       "name": "Prefrontal Cortex Convo Agent by Virtua",
       "symbol": "CONVO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51064/thumb/Convo_Agent_89ef084f87.jpg?1729926154"
+      "logoURI": "https://assets.coingecko.com/coins/images/51064/large/Convo_Agent_89ef084f87.jpg?1729926154"
     },
     {
       "chainId": 8453,
@@ -1880,15 +1880,7 @@
       "name": "Tower",
       "symbol": "TOWER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14134/thumb/tower-circular-1000.png?1696513854"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf3c7cecf8cbc3066f9a87b310cebe198d00479ac",
-      "name": "FEED EVERY GORILLA",
-      "symbol": "FEG",
-      "decimals": 11,
-      "logoURI": "https://assets.coingecko.com/coins/images/29643/thumb/IMG_3919.jpeg?1721352213"
+      "logoURI": "https://assets.coingecko.com/coins/images/14134/large/tower-circular-1000.png?1696513854"
     },
     {
       "chainId": 8453,
@@ -1896,15 +1888,7 @@
       "name": "GENIUS AI",
       "symbol": "GNUS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36914/thumb/IMG_5346.png?1712769235"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa3a34a0d9a08ccddb6ed422ac0a28a06731335aa",
-      "name": "Wrapped ADA  Universal ",
-      "symbol": "UADA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51868/thumb/UA-ADA.png?1732095196"
+      "logoURI": "https://assets.coingecko.com/coins/images/36914/large/IMG_5346.png?1712769235"
     },
     {
       "chainId": 8453,
@@ -1912,15 +1896,23 @@
       "name": "Burning Circle",
       "symbol": "CIRCLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35274/thumb/circle.png?1708048159"
+      "logoURI": "https://assets.coingecko.com/coins/images/35274/large/circle.png?1708048159"
     },
     {
       "chainId": 8453,
-      "address": "0xf04d220b8136e2d3d4be08081dbb565c3c302ffd",
-      "name": "Freya by Virtuals",
-      "symbol": "FREYA",
+      "address": "0xf3c7cecf8cbc3066f9a87b310cebe198d00479ac",
+      "name": "FEED EVERY GORILLA",
+      "symbol": "FEG",
+      "decimals": 11,
+      "logoURI": "https://assets.coingecko.com/coins/images/29643/large/IMG_3919.jpeg?1721352213"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa3a34a0d9a08ccddb6ed422ac0a28a06731335aa",
+      "name": "Wrapped ADA  Universal ",
+      "symbol": "UADA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52325/thumb/FREYA_%281%29.png?1733079799"
+      "logoURI": "https://assets.coingecko.com/coins/images/51868/large/UA-ADA.png?1732095196"
     },
     {
       "chainId": 8453,
@@ -1928,23 +1920,15 @@
       "name": "LaunchTokenBot",
       "symbol": "CAPO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52234/thumb/f22a0bcbbfa4da6930bf8c1d37c2e0a0.jpeg?1732804814"
+      "logoURI": "https://assets.coingecko.com/coins/images/52234/large/f22a0bcbbfa4da6930bf8c1d37c2e0a0.jpeg?1732804814"
     },
     {
       "chainId": 8453,
-      "address": "0xdfd579dd6aeb232e95a15d964a135a61925b5c93",
-      "name": "Marso Tech",
-      "symbol": "MARSO",
+      "address": "0xf04d220b8136e2d3d4be08081dbb565c3c302ffd",
+      "name": "Freya by Virtuals",
+      "symbol": "FREYA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50292/thumb/QKbwAja.png?1726905588"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9f95e17b2668afe01f8fbd157068b0a4405cc08d",
-      "name": "Bullieverse",
-      "symbol": "BULL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24174/thumb/KR3qVAQe_400x400.jpg?1696523362"
+      "logoURI": "https://assets.coingecko.com/coins/images/52325/large/FREYA_%281%29.png?1733079799"
     },
     {
       "chainId": 8453,
@@ -1952,7 +1936,23 @@
       "name": "Fantom Bomb",
       "symbol": "BOMB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24109/thumb/logo-blue.png?1696523301"
+      "logoURI": "https://assets.coingecko.com/coins/images/24109/large/logo-blue.png?1696523301"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdfd579dd6aeb232e95a15d964a135a61925b5c93",
+      "name": "Marso Tech",
+      "symbol": "MARSO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50292/large/QKbwAja.png?1726905588"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9f95e17b2668afe01f8fbd157068b0a4405cc08d",
+      "name": "Bullieverse",
+      "symbol": "BULL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24174/large/KR3qVAQe_400x400.jpg?1696523362"
     },
     {
       "chainId": 8453,
@@ -1960,15 +1960,7 @@
       "name": "GME  Base ",
       "symbol": "GME",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37229/thumb/gamestop.jpeg?1713780481"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x06a63c498ef95ad1fa4fff841955e512b4b2198a",
-      "name": "Gluteus Maximus by Virtuals",
-      "symbol": "GLUTEU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52177/thumb/gluteu.jpg?1732685854"
+      "logoURI": "https://assets.coingecko.com/coins/images/37229/large/gamestop.jpeg?1713780481"
     },
     {
       "chainId": 8453,
@@ -1976,7 +1968,15 @@
       "name": "OnlyCalls by Virtuals",
       "symbol": "CALLS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52481/thumb/onlyCalls_%281%29.jpg?1733425816"
+      "logoURI": "https://assets.coingecko.com/coins/images/52481/large/onlyCalls_%281%29.jpg?1733425816"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x06a63c498ef95ad1fa4fff841955e512b4b2198a",
+      "name": "Gluteus Maximus by Virtuals",
+      "symbol": "GLUTEU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52177/large/gluteu.jpg?1732685854"
     },
     {
       "chainId": 8453,
@@ -1984,7 +1984,7 @@
       "name": "PAID",
       "symbol": "PAID",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13761/thumb/PAID_Logo_new.png?1730798431"
+      "logoURI": "https://assets.coingecko.com/coins/images/13761/large/PAID_Logo_new.png?1730798431"
     },
     {
       "chainId": 8453,
@@ -1992,7 +1992,7 @@
       "name": "Guanciale by Virtuals",
       "symbol": "GUAN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51865/thumb/guanciale.jpeg?1732173396"
+      "logoURI": "https://assets.coingecko.com/coins/images/51865/large/guanciale.jpeg?1732173396"
     },
     {
       "chainId": 8453,
@@ -2000,7 +2000,7 @@
       "name": "BMX",
       "symbol": "BMX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31699/thumb/bmx_white.png?1696530517"
+      "logoURI": "https://assets.coingecko.com/coins/images/31699/large/bmx_white.png?1696530517"
     },
     {
       "chainId": 8453,
@@ -2008,7 +2008,7 @@
       "name": "Dexalot",
       "symbol": "ALOT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24188/thumb/logo_200x200.png?1696523376"
+      "logoURI": "https://assets.coingecko.com/coins/images/24188/large/logo_200x200.png?1696523376"
     },
     {
       "chainId": 8453,
@@ -2016,7 +2016,7 @@
       "name": "This Is My Iguana",
       "symbol": "TIMI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39361/thumb/200x200.png?1722464115"
+      "logoURI": "https://assets.coingecko.com/coins/images/39361/large/200x200.png?1722464115"
     },
     {
       "chainId": 8453,
@@ -2024,7 +2024,7 @@
       "name": "DEFLI",
       "symbol": "FLI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50582/thumb/defli_lgo_2_%28200_x_200_px%29.png?1728415750"
+      "logoURI": "https://assets.coingecko.com/coins/images/50582/large/defli_lgo_2_%28200_x_200_px%29.png?1728415750"
     },
     {
       "chainId": 8453,
@@ -2032,7 +2032,7 @@
       "name": "Wokie Plumpkin by Virtuals",
       "symbol": "WOKIE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52176/thumb/wokie.jpg?1732685106"
+      "logoURI": "https://assets.coingecko.com/coins/images/52176/large/wokie.jpg?1732685106"
     },
     {
       "chainId": 8453,
@@ -2040,7 +2040,7 @@
       "name": "Libertum",
       "symbol": "LBM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37147/thumb/wmGmpgSW_400x400.jpg?1713469301"
+      "logoURI": "https://assets.coingecko.com/coins/images/37147/large/wmGmpgSW_400x400.jpg?1713469301"
     },
     {
       "chainId": 8453,
@@ -2048,7 +2048,7 @@
       "name": "Dtravel",
       "symbol": "TRVL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20911/thumb/trvl.jpeg?1696520301"
+      "logoURI": "https://assets.coingecko.com/coins/images/20911/large/trvl.jpeg?1696520301"
     },
     {
       "chainId": 8453,
@@ -2056,7 +2056,7 @@
       "name": "Lyvely",
       "symbol": "LVLY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50215/thumb/symbol_color.png?1726436150"
+      "logoURI": "https://assets.coingecko.com/coins/images/50215/large/symbol_color.png?1726436150"
     },
     {
       "chainId": 8453,
@@ -2064,23 +2064,7 @@
       "name": "Normilio",
       "symbol": "NORMILIO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36915/thumb/vm2byD93.jpg?1733436102"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa9f5031b54c44c3603b4300fde9b8f5cd18ad06f",
-      "name": "Mars Battle",
-      "symbol": "SHOOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36553/thumb/icon.png?1711896644"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcacf1ca03983ce6c7e235fb20c70acc70ed13509",
-      "name": "AstroPepeX",
-      "symbol": "APX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31839/thumb/astropepexcoingecko.png?1731814766"
+      "logoURI": "https://assets.coingecko.com/coins/images/36915/large/vm2byD93.jpg?1733436102"
     },
     {
       "chainId": 8453,
@@ -2088,7 +2072,15 @@
       "name": "AUKI",
       "symbol": "AUKI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39811/thumb/COINGECKO-200-x-200_%281%29.png?1724166209"
+      "logoURI": "https://assets.coingecko.com/coins/images/39811/large/COINGECKO-200-x-200_%281%29.png?1724166209"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa9f5031b54c44c3603b4300fde9b8f5cd18ad06f",
+      "name": "Mars Battle",
+      "symbol": "SHOOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36553/large/icon.png?1711896644"
     },
     {
       "chainId": 8453,
@@ -2096,7 +2088,7 @@
       "name": "Newton On Base",
       "symbol": "NEWB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38475/thumb/IMG_1092.JPG?1724476844"
+      "logoURI": "https://assets.coingecko.com/coins/images/38475/large/IMG_1092.JPG?1724476844"
     },
     {
       "chainId": 8453,
@@ -2104,47 +2096,15 @@
       "name": "Based USA",
       "symbol": "USA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37981/thumb/BASE_USA_200px.png?1716203776"
+      "logoURI": "https://assets.coingecko.com/coins/images/37981/large/BASE_USA_200px.png?1716203776"
     },
     {
       "chainId": 8453,
-      "address": "0x30d19fb77c3ee5cfa97f73d72c6a1e509fa06aef",
-      "name": "CONDO",
-      "symbol": "CONDO",
+      "address": "0xcacf1ca03983ce6c7e235fb20c70acc70ed13509",
+      "name": "AstroPepeX",
+      "symbol": "APX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37174/thumb/1000012387.jpg?1724589415"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8761155c814c807cd3ccd15b256d69d3c10f198c",
-      "name": "Joystream",
-      "symbol": "JOY",
-      "decimals": 10,
-      "logoURI": "https://assets.coingecko.com/coins/images/24785/thumb/joy.png?1696523945"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2f20cf3466f80a5f7f532fca553c8cbc9727fef6",
-      "name": "Akuma Inu",
-      "symbol": "AKUMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52182/thumb/IMG_7527.PNG?1732690402"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c03ce270b4826ec62e7dd007f0b716068639f7b",
-      "name": "The Innovation Game",
-      "symbol": "TIG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50669/thumb/TIG_Logo_200x200.png?1729604604"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6797b6244fa75f2e78cdffc3a4eb169332b730cc",
-      "name": "Eagle AI",
-      "symbol": "EAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38650/thumb/Eagle_AI.png?1718215736"
+      "logoURI": "https://assets.coingecko.com/coins/images/31839/large/astropepexcoingecko.png?1731814766"
     },
     {
       "chainId": 8453,
@@ -2152,15 +2112,39 @@
       "name": "ElonRWA",
       "symbol": "ELONRWA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36970/thumb/elonrwa.png?1712910039"
+      "logoURI": "https://assets.coingecko.com/coins/images/36970/large/elonrwa.png?1712910039"
     },
     {
       "chainId": 8453,
-      "address": "0x99b2b1a2adb02b38222adcd057783d7e5d1fcc7d",
-      "name": "Common Wealth",
-      "symbol": "WLTH",
+      "address": "0x30d19fb77c3ee5cfa97f73d72c6a1e509fa06aef",
+      "name": "CONDO",
+      "symbol": "CONDO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37858/thumb/WLTH_TICKER_200x200.png?1730241264"
+      "logoURI": "https://assets.coingecko.com/coins/images/37174/large/1000012387.jpg?1724589415"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2f20cf3466f80a5f7f532fca553c8cbc9727fef6",
+      "name": "Akuma Inu",
+      "symbol": "AKUMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52182/large/IMG_7527.PNG?1732690402"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0c03ce270b4826ec62e7dd007f0b716068639f7b",
+      "name": "The Innovation Game",
+      "symbol": "TIG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50669/large/TIG_Logo_200x200.png?1729604604"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6797b6244fa75f2e78cdffc3a4eb169332b730cc",
+      "name": "Eagle AI",
+      "symbol": "EAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38650/large/Eagle_AI.png?1718215736"
     },
     {
       "chainId": 8453,
@@ -2168,63 +2152,15 @@
       "name": "DREAM",
       "symbol": "DREAM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52029/thumb/dream-logo.png?1732358413"
+      "logoURI": "https://assets.coingecko.com/coins/images/52029/large/dream-logo.png?1732358413"
     },
     {
       "chainId": 8453,
-      "address": "0xac12f930318be4f9d37f602cbf89cd33e99aa9d4",
-      "name": "Wexo",
-      "symbol": "WEXO",
+      "address": "0x99b2b1a2adb02b38222adcd057783d7e5d1fcc7d",
+      "name": "Common Wealth",
+      "symbol": "WLTH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33801/thumb/wexo_token_200x200.png?1702991908"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
-      "name": "Aura Finance",
-      "symbol": "AURA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25942/thumb/logo.png?1696525021"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x36912b5cf63e509f18e53ac98b3012fa79e77bf5",
-      "name": "FUEGO",
-      "symbol": "FUEGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51345/thumb/FUEGO_200x200.jpg?1730825086"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x554bba833518793056cf105e66abea330672c0de",
-      "name": "Maha",
-      "symbol": "MAHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13404/thumb/black.png?1724679606"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xae2bddbcc932c2d2cf286bad0028c6f5074c77b5",
-      "name": "Falcons",
-      "symbol": "FAH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50297/thumb/Falcons.png?1726935509"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7d27187eb33a7b1d99258ff222633670f84fa342",
-      "name": "IntentX",
-      "symbol": "INTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38241/thumb/PFP_IX_2.png?1716881240"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xda761a290e01c69325d12d82ac402e5a73d62e81",
-      "name": "Base Pro Shops",
-      "symbol": "BPS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36855/thumb/BPS_2.png?1712634757"
+      "logoURI": "https://assets.coingecko.com/coins/images/37858/large/WLTH_TICKER_200x200.png?1730241264"
     },
     {
       "chainId": 8453,
@@ -2232,7 +2168,55 @@
       "name": "Everyworld",
       "symbol": "EVERY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36799/thumb/coin_gecko.png?1714459237"
+      "logoURI": "https://assets.coingecko.com/coins/images/36799/large/coin_gecko.png?1714459237"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8761155c814c807cd3ccd15b256d69d3c10f198c",
+      "name": "Joystream",
+      "symbol": "JOY",
+      "decimals": 10,
+      "logoURI": "https://assets.coingecko.com/coins/images/24785/large/joy.png?1696523945"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
+      "name": "Aura Finance",
+      "symbol": "AURA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25942/large/logo.png?1696525021"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac12f930318be4f9d37f602cbf89cd33e99aa9d4",
+      "name": "Wexo",
+      "symbol": "WEXO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33801/large/wexo_token_200x200.png?1702991908"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x36912b5cf63e509f18e53ac98b3012fa79e77bf5",
+      "name": "FUEGO",
+      "symbol": "FUEGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51345/large/FUEGO_200x200.jpg?1730825086"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x554bba833518793056cf105e66abea330672c0de",
+      "name": "Maha",
+      "symbol": "MAHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13404/large/black.png?1724679606"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xae2bddbcc932c2d2cf286bad0028c6f5074c77b5",
+      "name": "Falcons",
+      "symbol": "FAH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50297/large/Falcons.png?1726935509"
     },
     {
       "chainId": 8453,
@@ -2240,15 +2224,23 @@
       "name": "ViciCoin",
       "symbol": "VCNT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31305/thumb/ViciCoin_-_small.png?1696530124"
+      "logoURI": "https://assets.coingecko.com/coins/images/31305/large/ViciCoin_-_small.png?1696530124"
     },
     {
       "chainId": 8453,
-      "address": "0x82b0e1a2374ea0198f62a48b14ffab53db6c1e36",
-      "name": "PokPok Golden Egg",
-      "symbol": "PEGG",
+      "address": "0x7d27187eb33a7b1d99258ff222633670f84fa342",
+      "name": "IntentX",
+      "symbol": "INTX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40102/thumb/golden_eggs_%281%29.png?1725694597"
+      "logoURI": "https://assets.coingecko.com/coins/images/38241/large/PFP_IX_2.png?1716881240"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xda761a290e01c69325d12d82ac402e5a73d62e81",
+      "name": "Base Pro Shops",
+      "symbol": "BPS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36855/large/BPS_2.png?1712634757"
     },
     {
       "chainId": 8453,
@@ -2256,7 +2248,7 @@
       "name": "Bitcoin on Base",
       "symbol": "BTCB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38868/thumb/BTCB_Official_Logo_July_2024.png?1721753012"
+      "logoURI": "https://assets.coingecko.com/coins/images/38868/large/BTCB_Official_Logo_July_2024.png?1721753012"
     },
     {
       "chainId": 8453,
@@ -2264,63 +2256,7 @@
       "name": "Based Chad",
       "symbol": "CHAD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36285/thumb/logo_200_200_square.jpg?1712167823"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
-      "name": "Seedworld",
-      "symbol": "SWORLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51000/thumb/IMG_2798.PNG?1729685531"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x25e1c298f100d7c600e9e44d46788c1ebbd4f69b",
-      "name": "Pike Finance",
-      "symbol": "P",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50771/thumb/image.png?1729132574"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf56b3b3972f2f154555a0b62ff5a22b7b2a3c90b",
-      "name": "ZAP",
-      "symbol": "ZAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50515/thumb/zap.jpg?1728033535"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd652c5425aea2afd5fb142e120fecf79e18fafc3",
-      "name": "PoolTogether",
-      "symbol": "POOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14003/thumb/PoolTogether.png?1696513732"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfd1013c72cbb0ffb920d347c5836bf88965d0d5e",
-      "name": "STIX",
-      "symbol": "STIX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52015/thumb/STIX_Logo_Transparent_200x200.png?1732346967"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x52e0d3c27cc9e3607c1ca7914b9049be3d5e9c41",
-      "name": "Blu",
-      "symbol": "BLU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51922/thumb/Blu.jpg?1732190348"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe8aae6251c6cf39927b0ff31399030c60bec798f",
-      "name": "SUMI",
-      "symbol": "SUMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51253/thumb/SUMI.jpg?1730477794"
+      "logoURI": "https://assets.coingecko.com/coins/images/36285/large/logo_200_200_square.jpg?1712167823"
     },
     {
       "chainId": 8453,
@@ -2328,55 +2264,39 @@
       "name": "Florence Finance Medici",
       "symbol": "FFM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34382/thumb/M_PNG_200x200_copy.png?1704779326"
+      "logoURI": "https://assets.coingecko.com/coins/images/34382/large/M_PNG_200x200_copy.png?1704779326"
     },
     {
       "chainId": 8453,
-      "address": "0xb4e017223fd3d639d0264de4da1b9e080325cb5e",
-      "name": "SyncVault",
-      "symbol": "SVTS",
+      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
+      "name": "Seedworld",
+      "symbol": "SWORLD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50447/thumb/White_SV_logo_200x200.png?1727771615"
+      "logoURI": "https://assets.coingecko.com/coins/images/51000/large/IMG_2798.PNG?1729685531"
     },
     {
       "chainId": 8453,
-      "address": "0xb38266e0e9d9681b77aeb0a280e98131b953f865",
-      "name": "DOVU",
-      "symbol": "DOVU",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/31930/thumb/Dovu_Icon_Black_%281%29.png?1696530738"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x99298c6be0e8ec9e56b7a2be5850abe1fc109d94",
-      "name": "Degen Capital by Virtuals",
-      "symbol": "DEGENC",
+      "address": "0x25e1c298f100d7c600e9e44d46788c1ebbd4f69b",
+      "name": "Pike Finance",
+      "symbol": "P",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52246/thumb/Degen_Capital_DEGENC.png?1732824263"
+      "logoURI": "https://assets.coingecko.com/coins/images/50771/large/image.png?1729132574"
     },
     {
       "chainId": 8453,
-      "address": "0x3c4b6cd7874edc945797123fce2d9a871818524b",
-      "name": "PARADOX",
-      "symbol": "PARADOX",
+      "address": "0xf56b3b3972f2f154555a0b62ff5a22b7b2a3c90b",
+      "name": "ZAP",
+      "symbol": "ZAP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51590/thumb/IMG_1408.jpeg?1731570502"
+      "logoURI": "https://assets.coingecko.com/coins/images/50515/large/zap.jpg?1728033535"
     },
     {
       "chainId": 8453,
-      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-      "name": "Hop Protocol",
-      "symbol": "HOP",
+      "address": "0xfd1013c72cbb0ffb920d347c5836bf88965d0d5e",
+      "name": "STIX",
+      "symbol": "STIX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25445/thumb/hop.png?1696524577"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2dad3a13ef0c6366220f989157009e501e7938f8",
-      "name": "Extra Finance",
-      "symbol": "EXTRA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30973/thumb/Ex_logo-white-blue_ring_288x.png?1696529812"
+      "logoURI": "https://assets.coingecko.com/coins/images/52015/large/STIX_Logo_Transparent_200x200.png?1732346967"
     },
     {
       "chainId": 8453,
@@ -2384,39 +2304,71 @@
       "name": "Fren Pet",
       "symbol": "FP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33022/thumb/token.png?1700274697"
+      "logoURI": "https://assets.coingecko.com/coins/images/33022/large/token.png?1700274697"
     },
     {
       "chainId": 8453,
-      "address": "0x78a087d713be963bf307b18f2ff8122ef9a63ae9",
-      "name": "BaseSwap",
-      "symbol": "BSWAP",
+      "address": "0xd652c5425aea2afd5fb142e120fecf79e18fafc3",
+      "name": "PoolTogether",
+      "symbol": "POOL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31245/thumb/Baseswap_LogoNew.jpg?1696530070"
+      "logoURI": "https://assets.coingecko.com/coins/images/14003/large/PoolTogether.png?1696513732"
     },
     {
       "chainId": 8453,
-      "address": "0x6009e7cd237087e6d7570990e8bdac09c3e182b0",
-      "name": "TaskBunny",
-      "symbol": "BNY",
+      "address": "0x52e0d3c27cc9e3607c1ca7914b9049be3d5e9c41",
+      "name": "Blu",
+      "symbol": "BLU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51478/thumb/Bunny_coin_200x200.png?1731404290"
+      "logoURI": "https://assets.coingecko.com/coins/images/51922/large/Blu.jpg?1732190348"
     },
     {
       "chainId": 8453,
-      "address": "0x3816dd4bd44c8830c2fa020a5605bac72fa3de7a",
-      "name": "Presearch",
-      "symbol": "PRE",
+      "address": "0xe8aae6251c6cf39927b0ff31399030c60bec798f",
+      "name": "SUMI",
+      "symbol": "SUMI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1299/thumb/presearch.png?1696502369"
+      "logoURI": "https://assets.coingecko.com/coins/images/51253/large/SUMI.jpg?1730477794"
     },
     {
       "chainId": 8453,
-      "address": "0x262a9f4e84efa2816d87a68606bb4c1ea3874bf1",
-      "name": "Bangkit",
-      "symbol": "BKIT",
+      "address": "0xb4e017223fd3d639d0264de4da1b9e080325cb5e",
+      "name": "SyncVault",
+      "symbol": "SVTS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52416/thumb/logo.png?1733309160"
+      "logoURI": "https://assets.coingecko.com/coins/images/50447/large/White_SV_logo_200x200.png?1727771615"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb38266e0e9d9681b77aeb0a280e98131b953f865",
+      "name": "DOVU",
+      "symbol": "DOVU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/31930/large/Dovu_Icon_Black_%281%29.png?1696530738"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c4b6cd7874edc945797123fce2d9a871818524b",
+      "name": "PARADOX",
+      "symbol": "PARADOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51590/large/IMG_1408.jpeg?1731570502"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2dad3a13ef0c6366220f989157009e501e7938f8",
+      "name": "Extra Finance",
+      "symbol": "EXTRA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30973/large/Ex_logo-white-blue_ring_288x.png?1696529812"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x99298c6be0e8ec9e56b7a2be5850abe1fc109d94",
+      "name": "Degen Capital by Virtuals",
+      "symbol": "DEGENC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52246/large/Degen_Capital_DEGENC.png?1732824263"
     },
     {
       "chainId": 8453,
@@ -2424,23 +2376,39 @@
       "name": "MorpheusAI",
       "symbol": "MOR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37969/thumb/MOR200X200.png?1716327119"
+      "logoURI": "https://assets.coingecko.com/coins/images/37969/large/MOR200X200.png?1716327119"
     },
     {
       "chainId": 8453,
-      "address": "0x7a8a5012022bccbf3ea4b03cd2bb5583d915fb1a",
-      "name": "Chuck",
-      "symbol": "CHUCK",
+      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "name": "Hop Protocol",
+      "symbol": "HOP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37468/thumb/1000030138.jpg?1714457112"
+      "logoURI": "https://assets.coingecko.com/coins/images/25445/large/hop.png?1696524577"
     },
     {
       "chainId": 8453,
-      "address": "0x01aac2b594f7bdbec740f0f1aa22910ebb4b74ab",
-      "name": "Unio Coin",
-      "symbol": "UNIO",
+      "address": "0x78a087d713be963bf307b18f2ff8122ef9a63ae9",
+      "name": "BaseSwap",
+      "symbol": "BSWAP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50191/thumb/uniocoin-200x200.png?1726206790"
+      "logoURI": "https://assets.coingecko.com/coins/images/31245/large/Baseswap_LogoNew.jpg?1696530070"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6009e7cd237087e6d7570990e8bdac09c3e182b0",
+      "name": "TaskBunny",
+      "symbol": "BNY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51478/large/Bunny_coin_200x200.png?1731404290"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3816dd4bd44c8830c2fa020a5605bac72fa3de7a",
+      "name": "Presearch",
+      "symbol": "PRE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1299/large/presearch.png?1696502369"
     },
     {
       "chainId": 8453,
@@ -2448,7 +2416,31 @@
       "name": "Weirdo",
       "symbol": "WEIRDO",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/37847/thumb/New_Project_%2823%29.png?1726539603"
+      "logoURI": "https://assets.coingecko.com/coins/images/37847/large/New_Project_%2823%29.png?1726539603"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x01aac2b594f7bdbec740f0f1aa22910ebb4b74ab",
+      "name": "Unio Coin",
+      "symbol": "UNIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50191/large/uniocoin-200x200.png?1726206790"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x262a9f4e84efa2816d87a68606bb4c1ea3874bf1",
+      "name": "Bangkit",
+      "symbol": "BKIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52416/large/logo.png?1733309160"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7a8a5012022bccbf3ea4b03cd2bb5583d915fb1a",
+      "name": "Chuck",
+      "symbol": "CHUCK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37468/large/1000030138.jpg?1714457112"
     },
     {
       "chainId": 8453,
@@ -2456,7 +2448,7 @@
       "name": "Virtu by Virtuals",
       "symbol": "VIRTU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51827/thumb/_removal.ai__24fd4161-77b5-412f-b553-a99e9012f575_photo_2024-11-07_08-05-59.png?1732042711"
+      "logoURI": "https://assets.coingecko.com/coins/images/51827/large/_removal.ai__24fd4161-77b5-412f-b553-a99e9012f575_photo_2024-11-07_08-05-59.png?1732042711"
     },
     {
       "chainId": 8453,
@@ -2464,7 +2456,7 @@
       "name": "Bento",
       "symbol": "BENTO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37138/thumb/logo-bento-200-200.png?1713419221"
+      "logoURI": "https://assets.coingecko.com/coins/images/37138/large/logo-bento-200-200.png?1713419221"
     },
     {
       "chainId": 8453,
@@ -2472,503 +2464,7 @@
       "name": "TN100x",
       "symbol": "TN100X",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35729/thumb/patch-transparent-blue.png?1729878068"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x42069de48741db40aef864f8764432bbccbd0b69",
-      "name": "All Street Bets",
-      "symbol": "BETS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36906/thumb/Screenshot_2024-03-17_034831_no_background.png?1712728634"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x252d223d0550bc6c137b003d90bc74f5341a2818",
-      "name": "Bitbot",
-      "symbol": "BITBOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52512/thumb/Bitbot_Logo.png?1733493165"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe095780ba2a64a4efa7a74830f0b71656f0b0ad4",
-      "name": "Byte",
-      "symbol": "BYTE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/33527/thumb/Byte200.jpeg?1702138460"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x70737489dfdf1a29b7584d40500d3561bd4fe196",
-      "name": "BORED",
-      "symbol": "BORED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37050/thumb/bored.jpeg?1713340233"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x689644b86075ed61c647596862c7403e1c474dbf",
-      "name": "Bamboo on Base",
-      "symbol": "BAMBOO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39126/thumb/Bamboo_Logo_800x800.png?1720656497"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4da78059d97f155e18b37765e2e042270f4e0fc4",
-      "name": "WUFFI",
-      "symbol": "WUF",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/36933/thumb/WUFFI.jpg?1720613603"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfaa4f3bcfc87d791e9305951275e0f62a98bcb10",
-      "name": "Super Best Friends",
-      "symbol": "SUBF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36368/thumb/1000017215.jpg?1711338058"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x120edc8e391ba4c94cb98bb65d8856ae6ec1525f",
-      "name": "LOUDER",
-      "symbol": "LOUDER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39495/thumb/louder_icon_200x200.png?1722539190"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x54b659832f59c24cec0e4a2cd193377f1bcefc3c",
-      "name": "Akashalife",
-      "symbol": "AK1111",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50533/thumb/Akasha-CoinIcon_%283%29.png?1728206155"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8a638ea79f71f3b91bdc96bbdf9fb27c93013d60",
-      "name": "Baby Tiger",
-      "symbol": "BBT",
-      "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/51933/thumb/BBT_%282%29_%281%29.png?1732205350"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc48e605c7b722a57277e087a6170b9e227e5ac0a",
-      "name": "OmniCat",
-      "symbol": "OMNI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33917/thumb/omnicatlogo.png?1717544778"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf5f2a79eeccf6e7f4c570c803f529930e29cc96b",
-      "name": "CertaiK by Virtuals",
-      "symbol": "CERTAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52488/thumb/download.jpeg?1733432223"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8fbd0648971d56f1f2c35fa075ff5bc75fb0e39d",
-      "name": "UNKJD",
-      "symbol": "MBS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20841/thumb/monkeyball.png?1696520233"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x60222751504796934bddee8218f9725f0c95d2c1",
-      "name": "Simps",
-      "symbol": "SIMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51994/thumb/200.png?1732296595"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9e53e88dcff56d3062510a745952dec4cefdff9e",
-      "name": "Basic Dog Meme",
-      "symbol": "DOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33749/thumb/Round_Logo.png?1703245893"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x52c2b317eb0bb61e650683d2f287f56c413e4cf6",
-      "name": "Tree",
-      "symbol": "TREE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33727/thumb/circle_green.png?1709894067"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x39fed555ff57cb1154bfa6b1a2492bb914ce2d9b",
-      "name": "EchoLeaks by Virtuals",
-      "symbol": "ECHO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52172/thumb/echoleaks.jpg?1732683705"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9f235d23354857efe6c541db92a9ef1877689bcb",
-      "name": "Goodle",
-      "symbol": "GOODLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39688/thumb/Screenshot_2024-07-26_at_5.38.55_PM-removebg-preview.png?1723660779"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1b6a569dd61edce3c383f6d565e2f79ec3a12980",
-      "name": "Young Peezy AKA Pepe",
-      "symbol": "PEEZY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36649/thumb/PFP_CG_200x200.jpeg?1719953176"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8853f0c059c27527d33d02378e5e4f6d5afb574a",
-      "name": "AI INU",
-      "symbol": "AIINU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36902/thumb/aiinu.png?1712699681"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3fbde9864362ce4abb244ebef2ef0482aba8ea39",
-      "name": "Baklava",
-      "symbol": "BAVA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23780/thumb/200x200_BAVA_LOGO_%282%29.png?1696522980"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd33c7b753ecaa85e5d5f5b5fd99dec59f26a087e",
-      "name": "Defactor",
-      "symbol": "FACTR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19201/thumb/jFLSu4U9_400x400.png?1696518648"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8c9037d1ef5c6d1f6816278c7aaf5491d24cd527",
-      "name": "Moxie",
-      "symbol": "MOXIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39451/thumb/favicon_-_200_x_200.png?1722311978"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7f05a7a9af2f5a07d1e64877c8dc37a64a22508e",
-      "name": "Ajna Protocol",
-      "symbol": "AJNA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30187/thumb/AJNA-Icon-200.png?1696529105"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x09579452bc3872727a5d105f342645792bb8a82b",
-      "name": "Aardvark",
-      "symbol": "VARK",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/32678/thumb/VARK.jpg?1698929830"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
-      "name": "Nya",
-      "symbol": "NYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40082/thumb/nya.jpg?1725523655"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1b5ce2a593a840e3ad3549a34d7b3dec697c114d",
-      "name": "Altcoinist Token",
-      "symbol": "ALTT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39455/thumb/Altcoinist_logo_png_%282%29.png?1733342642"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8c1851488f2daceae46d815dd204d5f6d946666a",
-      "name": "Besa Gaming Company",
-      "symbol": "BESA",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/33283/thumb/Besa_Gaming_Company_BESA_200.png?1701363231"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf3708859c178709d5319ad5405bc81511b72b9e9",
-      "name": "Aethernet",
-      "symbol": "AETHER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51065/thumb/Aether_Farcaster_frame.png?1729943869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd91d07e4949a858d29005d339610db2402ef5b73",
-      "name": "DataGold",
-      "symbol": "DGOLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52431/thumb/dGOLD-square-navy.png?1733436522"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8c81b4c816d66d36c4bf348bdec01dbcbc70e987",
-      "name": "Briun Armstrung",
-      "symbol": "BRIUN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36183/thumb/200x200.png?1710758416"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd1917629b3e6a72e6772aab5dbe58eb7fa3c2f33",
-      "name": "Settled EthXY Token",
-      "symbol": "SEXY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33032/thumb/logo-circle.png?1700348518"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x88faea256f789f8dd50de54f9c807eef24f71b16",
-      "name": "Landwolf",
-      "symbol": "WOLF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36803/thumb/IMG_8678.jpeg?1712469842"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xefb97aaf77993922ac4be4da8fbc9a2425322677",
-      "name": "Web 3 Dollar",
-      "symbol": "USD3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38073/thumb/usd3%28200_x_200_px%29.png?1716449060"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1ccb4b14a11e0f2994a7ecbbd4cc69632f4c7c76",
-      "name": "Cute Cat Candle",
-      "symbol": "CCC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36930/thumb/1000017879.jpg?1712803401"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8f2e6758c4d6570344bd5007dec6301cd57590a0",
-      "name": "Spot",
-      "symbol": "SPOT",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/28426/thumb/SPOT_Logo_200x200_sq_small_centered.png?1696527423"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe642657e4f43e6dcf0bd73ef24008394574dee28",
-      "name": "Music Protocol",
-      "symbol": "RECORD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39243/thumb/MP-mark-color.png?1724879503"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3203856eac03d343f9d5245ba2f39861838a7b36",
-      "name": "Aviator",
-      "symbol": "AVI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31024/thumb/avi-200x200png.png?1711119363"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8a9430e92153c026092544444cbb38077e6688d1",
-      "name": "KeptChain",
-      "symbol": "KEPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38406/thumb/Kept_200_200.png?1717463539"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe13e40e8fdb815fbc4a1e2133ab5588c33bac45d",
-      "name": "TRIBAL",
-      "symbol": "TRIBAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38531/thumb/7pc8ov67182ddpbqjnff20ik4oye.png?1733194448"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
-      "name": "Glo Dollar",
-      "symbol": "USDGLO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29319/thumb/GLO_logo_pine_on_cyan_1_3.png?1716971065"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8f019931375454fe4ee353427eb94e2e0c9e0a8c",
-      "name": "KOMPETE",
-      "symbol": "KOMPETE",
-      "decimals": 10,
-      "logoURI": "https://assets.coingecko.com/coins/images/24298/thumb/200x200.png?1732826917"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfea9dcdc9e23a9068bf557ad5b186675c61d33ea",
-      "name": "Based Shiba Inu",
-      "symbol": "BSHIB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36092/thumb/logocg.png?1710478223"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x511ef9ad5e645e533d15df605b4628e3d0d0ff53",
-      "name": "Velvet Unicorn by Virtuals",
-      "symbol": "VU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52175/thumb/velvet_unicorn.jpg?1732684869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x13741c5df9ab03e7aa9fb3bf1f714551dd5a5f8a",
-      "name": "Noggles",
-      "symbol": "NOGS",
-      "decimals": 15,
-      "logoURI": "https://assets.coingecko.com/coins/images/37238/thumb/nogs.jpeg?1713851209"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7d9ce55d54ff3feddb611fc63ff63ec01f26d15f",
-      "name": "Fungi",
-      "symbol": "FUNGI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/36690/thumb/image_2024-03-29_20-10-19_%282%29_%283%29.png?1712091884"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x681a09a902d9c7445b3b1ab282c38d60c72f1f09",
-      "name": "AlphaKEK AI",
-      "symbol": "AIKEK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35445/thumb/alphakek_-_Copy.png?1708620097"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8fe815417913a93ea99049fc0718ee1647a2a07c",
-      "name": "XSwap",
-      "symbol": "XSWAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36000/thumb/XSwap_Icon_%282%29.png?1710320467"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xaec9e50e3397f9ddc635c6c429c8c7eca418a143",
-      "name": "Arcana arcUSD",
-      "symbol": "ARCUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38490/thumb/USDa.png?1717688209"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb488fcb23333e7baa28d1dfd7b69a5d3a8bfeb3a",
-      "name": "Terminal",
-      "symbol": "TERMINAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51477/thumb/terminalLogo.png?1731403786"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8bfac1b375bf2894d6f12fb2eb48b1c1a7916789",
-      "name": "Mey Network",
-      "symbol": "MEY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52249/thumb/logo_mey_200.png?1732828172"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfafb7581a65a1f554616bf780fc8a8acd2ab8c9b",
-      "name": "Squid Game",
-      "symbol": "SQUID",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20506/thumb/squid.png?1696519912"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbf1aea8670d2528e08334083616dd9c5f3b087ae",
-      "name": "MAI  Base ",
-      "symbol": "MIMATIC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35466/thumb/mimatic-red.png?1708687857"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x29e39327b5b1e500b87fc0fcae3856cd8f96ed2a",
-      "name": "Bark Ruffalo by Virtuals",
-      "symbol": "PAWSY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52205/thumb/00_Avatar_200x200.png?1732736729"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x623cd3a3edf080057892aaf8d773bbb7a5c9b6e9",
-      "name": "Sekuya Multiverse",
-      "symbol": "SKYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38096/thumb/SKYA_Logo_200x200.png?1731909478"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf34e0cff046e154cafcae502c7541b9e5fd8c249",
-      "name": "Thales",
-      "symbol": "THALES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18388/thumb/CLVZJN_C_400x400.png?1696517879"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x37f24b26bcefbfac7f261b97f8036da98f81a299",
-      "name": "Brish",
-      "symbol": "BRISH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38700/thumb/brishlogoupdate.png?1718480842"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe0023e73aab4fe9a22f059a9d27e857e027ee3dc",
-      "name": "RWAX",
-      "symbol": "RWAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38266/thumb/Rwax_Token_Symbol_logo-200.png?1716949733"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x777b2839832982b35213063d850848369390ee16",
-      "name": "Jarvis",
-      "symbol": "JARVIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35812/thumb/jarvis.png?1709873633"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x59f680f431f5280e7662b96f2dfa195d1693852d",
-      "name": "Magnify Cash",
-      "symbol": "MAG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38992/thumb/magnifyt.jpg?1719808409"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1287a235474e0331c0975e373bdd066444d1bd35",
-      "name": "TAIKAI",
-      "symbol": "TKAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34827/thumb/TKAI.jpg?1706191900"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4dd9077269dd08899f2a9e73507125962b5bc87f",
-      "name": "Crash On Base",
-      "symbol": "CRASH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38817/thumb/_iNshlUA.png?1722185418"
+      "logoURI": "https://assets.coingecko.com/coins/images/35729/large/patch-transparent-blue.png?1729878068"
     },
     {
       "chainId": 8453,
@@ -2976,7 +2472,503 @@
       "name": "Moonsama",
       "symbol": "SAMA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28308/thumb/Small.png?1696527312"
+      "logoURI": "https://assets.coingecko.com/coins/images/28308/large/Small.png?1696527312"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x42069de48741db40aef864f8764432bbccbd0b69",
+      "name": "All Street Bets",
+      "symbol": "BETS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36906/large/Screenshot_2024-03-17_034831_no_background.png?1712728634"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x252d223d0550bc6c137b003d90bc74f5341a2818",
+      "name": "Bitbot",
+      "symbol": "BITBOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52512/large/Bitbot_Logo.png?1733493165"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x70737489dfdf1a29b7584d40500d3561bd4fe196",
+      "name": "BORED",
+      "symbol": "BORED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37050/large/bored.jpeg?1713340233"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe095780ba2a64a4efa7a74830f0b71656f0b0ad4",
+      "name": "Byte",
+      "symbol": "BYTE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/33527/large/Byte200.jpeg?1702138460"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x689644b86075ed61c647596862c7403e1c474dbf",
+      "name": "Bamboo on Base",
+      "symbol": "BAMBOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39126/large/Bamboo_Logo_800x800.png?1720656497"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
+      "name": "Nya",
+      "symbol": "NYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40082/large/nya.jpg?1725523655"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4da78059d97f155e18b37765e2e042270f4e0fc4",
+      "name": "WUFFI",
+      "symbol": "WUF",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/36933/large/WUFFI.jpg?1720613603"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfaa4f3bcfc87d791e9305951275e0f62a98bcb10",
+      "name": "Super Best Friends",
+      "symbol": "SUBF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36368/large/1000017215.jpg?1711338058"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x120edc8e391ba4c94cb98bb65d8856ae6ec1525f",
+      "name": "LOUDER",
+      "symbol": "LOUDER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39495/large/louder_icon_200x200.png?1722539190"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x54b659832f59c24cec0e4a2cd193377f1bcefc3c",
+      "name": "Akashalife",
+      "symbol": "AK1111",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50533/large/Akasha-CoinIcon_%283%29.png?1728206155"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8a638ea79f71f3b91bdc96bbdf9fb27c93013d60",
+      "name": "Baby Tiger",
+      "symbol": "BBT",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/51933/large/BBT_%282%29_%281%29.png?1732205350"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc48e605c7b722a57277e087a6170b9e227e5ac0a",
+      "name": "OmniCat",
+      "symbol": "OMNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33917/large/omnicatlogo.png?1717544778"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8fbd0648971d56f1f2c35fa075ff5bc75fb0e39d",
+      "name": "UNKJD",
+      "symbol": "MBS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20841/large/monkeyball.png?1696520233"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf5f2a79eeccf6e7f4c570c803f529930e29cc96b",
+      "name": "CertaiK by Virtuals",
+      "symbol": "CERTAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52488/large/download.jpeg?1733432223"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe13e40e8fdb815fbc4a1e2133ab5588c33bac45d",
+      "name": "TRIBAL",
+      "symbol": "TRIBAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38531/large/7pc8ov67182ddpbqjnff20ik4oye.png?1733194448"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x60222751504796934bddee8218f9725f0c95d2c1",
+      "name": "Simps",
+      "symbol": "SIMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51994/large/200.png?1732296595"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x52c2b317eb0bb61e650683d2f287f56c413e4cf6",
+      "name": "Tree",
+      "symbol": "TREE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33727/large/circle_green.png?1709894067"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x82b0e1a2374ea0198f62a48b14ffab53db6c1e36",
+      "name": "PokPok Golden Egg",
+      "symbol": "PEGG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40102/large/golden_eggs_%281%29.png?1725694597"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x39fed555ff57cb1154bfa6b1a2492bb914ce2d9b",
+      "name": "EchoLeaks by Virtuals",
+      "symbol": "ECHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52172/large/echoleaks.jpg?1732683705"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9f235d23354857efe6c541db92a9ef1877689bcb",
+      "name": "Goodle",
+      "symbol": "GOODLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39688/large/Screenshot_2024-07-26_at_5.38.55_PM-removebg-preview.png?1723660779"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9e53e88dcff56d3062510a745952dec4cefdff9e",
+      "name": "Basic Dog Meme",
+      "symbol": "DOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33749/large/Round_Logo.png?1703245893"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1b6a569dd61edce3c383f6d565e2f79ec3a12980",
+      "name": "Young Peezy AKA Pepe",
+      "symbol": "PEEZY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36649/large/PFP_CG_200x200.jpeg?1719953176"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3fbde9864362ce4abb244ebef2ef0482aba8ea39",
+      "name": "Baklava",
+      "symbol": "BAVA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23780/large/200x200_BAVA_LOGO_%282%29.png?1696522980"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd33c7b753ecaa85e5d5f5b5fd99dec59f26a087e",
+      "name": "Defactor",
+      "symbol": "FACTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19201/large/jFLSu4U9_400x400.png?1696518648"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7f05a7a9af2f5a07d1e64877c8dc37a64a22508e",
+      "name": "Ajna Protocol",
+      "symbol": "AJNA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30187/large/AJNA-Icon-200.png?1696529105"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8c9037d1ef5c6d1f6816278c7aaf5491d24cd527",
+      "name": "Moxie",
+      "symbol": "MOXIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39451/large/favicon_-_200_x_200.png?1722311978"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x09579452bc3872727a5d105f342645792bb8a82b",
+      "name": "Aardvark",
+      "symbol": "VARK",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32678/large/VARK.jpg?1698929830"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1b5ce2a593a840e3ad3549a34d7b3dec697c114d",
+      "name": "Altcoinist Token",
+      "symbol": "ALTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39455/large/Altcoinist_logo_png_%282%29.png?1733342642"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf3708859c178709d5319ad5405bc81511b72b9e9",
+      "name": "Aethernet",
+      "symbol": "AETHER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51065/large/Aether_Farcaster_frame.png?1729943869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8c1851488f2daceae46d815dd204d5f6d946666a",
+      "name": "Besa Gaming Company",
+      "symbol": "BESA",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/33283/large/Besa_Gaming_Company_BESA_200.png?1701363231"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd91d07e4949a858d29005d339610db2402ef5b73",
+      "name": "DataGold",
+      "symbol": "DGOLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52431/large/dGOLD-square-navy.png?1733436522"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8c81b4c816d66d36c4bf348bdec01dbcbc70e987",
+      "name": "Briun Armstrung",
+      "symbol": "BRIUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36183/large/200x200.png?1710758416"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd1917629b3e6a72e6772aab5dbe58eb7fa3c2f33",
+      "name": "Settled EthXY Token",
+      "symbol": "SEXY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33032/large/logo-circle.png?1700348518"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x88faea256f789f8dd50de54f9c807eef24f71b16",
+      "name": "Landwolf",
+      "symbol": "WOLF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36803/large/IMG_8678.jpeg?1712469842"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xefb97aaf77993922ac4be4da8fbc9a2425322677",
+      "name": "Web 3 Dollar",
+      "symbol": "USD3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38073/large/usd3%28200_x_200_px%29.png?1716449060"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1ccb4b14a11e0f2994a7ecbbd4cc69632f4c7c76",
+      "name": "Cute Cat Candle",
+      "symbol": "CCC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36930/large/1000017879.jpg?1712803401"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f2e6758c4d6570344bd5007dec6301cd57590a0",
+      "name": "Spot",
+      "symbol": "SPOT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28426/large/SPOT_Logo_200x200_sq_small_centered.png?1696527423"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfea9dcdc9e23a9068bf557ad5b186675c61d33ea",
+      "name": "Based Shiba Inu",
+      "symbol": "BSHIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36092/large/logocg.png?1710478223"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe642657e4f43e6dcf0bd73ef24008394574dee28",
+      "name": "Music Protocol",
+      "symbol": "RECORD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39243/large/MP-mark-color.png?1724879503"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3203856eac03d343f9d5245ba2f39861838a7b36",
+      "name": "Aviator",
+      "symbol": "AVI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31024/large/avi-200x200png.png?1711119363"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8a9430e92153c026092544444cbb38077e6688d1",
+      "name": "KeptChain",
+      "symbol": "KEPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38406/large/Kept_200_200.png?1717463539"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f019931375454fe4ee353427eb94e2e0c9e0a8c",
+      "name": "KOMPETE",
+      "symbol": "KOMPETE",
+      "decimals": 10,
+      "logoURI": "https://assets.coingecko.com/coins/images/24298/large/200x200.png?1732826917"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
+      "name": "Glo Dollar",
+      "symbol": "USDGLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29319/large/GLO_logo_pine_on_cyan_1_3.png?1716971065"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x511ef9ad5e645e533d15df605b4628e3d0d0ff53",
+      "name": "Velvet Unicorn by Virtuals",
+      "symbol": "VU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52175/large/velvet_unicorn.jpg?1732684869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x13741c5df9ab03e7aa9fb3bf1f714551dd5a5f8a",
+      "name": "Noggles",
+      "symbol": "NOGS",
+      "decimals": 15,
+      "logoURI": "https://assets.coingecko.com/coins/images/37238/large/nogs.jpeg?1713851209"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7d9ce55d54ff3feddb611fc63ff63ec01f26d15f",
+      "name": "Fungi",
+      "symbol": "FUNGI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/36690/large/image_2024-03-29_20-10-19_%282%29_%283%29.png?1712091884"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x681a09a902d9c7445b3b1ab282c38d60c72f1f09",
+      "name": "AlphaKEK AI",
+      "symbol": "AIKEK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35445/large/alphakek_-_Copy.png?1708620097"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xaec9e50e3397f9ddc635c6c429c8c7eca418a143",
+      "name": "Arcana arcUSD",
+      "symbol": "ARCUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38490/large/USDa.png?1717688209"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb488fcb23333e7baa28d1dfd7b69a5d3a8bfeb3a",
+      "name": "Terminal",
+      "symbol": "TERMINAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51477/large/terminalLogo.png?1731403786"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfafb7581a65a1f554616bf780fc8a8acd2ab8c9b",
+      "name": "Squid Game",
+      "symbol": "SQUID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20506/large/squid.png?1696519912"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8bfac1b375bf2894d6f12fb2eb48b1c1a7916789",
+      "name": "Mey Network",
+      "symbol": "MEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52249/large/logo_mey_200.png?1732828172"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8fe815417913a93ea99049fc0718ee1647a2a07c",
+      "name": "XSwap",
+      "symbol": "XSWAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36000/large/XSwap_Icon_%282%29.png?1710320467"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x29e39327b5b1e500b87fc0fcae3856cd8f96ed2a",
+      "name": "Bark Ruffalo by Virtuals",
+      "symbol": "PAWSY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52205/large/00_Avatar_200x200.png?1732736729"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbf1aea8670d2528e08334083616dd9c5f3b087ae",
+      "name": "MAI  Base ",
+      "symbol": "MIMATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35466/large/mimatic-red.png?1708687857"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x623cd3a3edf080057892aaf8d773bbb7a5c9b6e9",
+      "name": "Sekuya Multiverse",
+      "symbol": "SKYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38096/large/SKYA_Logo_200x200.png?1731909478"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf34e0cff046e154cafcae502c7541b9e5fd8c249",
+      "name": "Thales",
+      "symbol": "THALES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18388/large/CLVZJN_C_400x400.png?1696517879"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x37f24b26bcefbfac7f261b97f8036da98f81a299",
+      "name": "Brish",
+      "symbol": "BRISH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38700/large/brishlogoupdate.png?1718480842"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x59f680f431f5280e7662b96f2dfa195d1693852d",
+      "name": "Magnify Cash",
+      "symbol": "MAG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38992/large/magnifyt.jpg?1719808409"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe0023e73aab4fe9a22f059a9d27e857e027ee3dc",
+      "name": "RWAX",
+      "symbol": "RWAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38266/large/Rwax_Token_Symbol_logo-200.png?1716949733"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x777b2839832982b35213063d850848369390ee16",
+      "name": "Jarvis",
+      "symbol": "JARVIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35812/large/jarvis.png?1709873633"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1287a235474e0331c0975e373bdd066444d1bd35",
+      "name": "TAIKAI",
+      "symbol": "TKAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34827/large/TKAI.jpg?1706191900"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4dd9077269dd08899f2a9e73507125962b5bc87f",
+      "name": "Crash On Base",
+      "symbol": "CRASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38817/large/_iNshlUA.png?1722185418"
     },
     {
       "chainId": 8453,
@@ -2984,7 +2976,7 @@
       "name": "DogeVerse",
       "symbol": "DOGEVERSE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38495/thumb/DogeVerse_200x200.png?1717692269"
+      "logoURI": "https://assets.coingecko.com/coins/images/38495/large/DogeVerse_200x200.png?1717692269"
     },
     {
       "chainId": 8453,
@@ -2992,7 +2984,7 @@
       "name": "Metapro",
       "symbol": "MPRO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35128/thumb/mpro.jpeg?1707440015"
+      "logoURI": "https://assets.coingecko.com/coins/images/35128/large/mpro.jpeg?1707440015"
     },
     {
       "chainId": 8453,
@@ -3000,31 +2992,15 @@
       "name": "Basedmilio",
       "symbol": "BASED",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37685/thumb/tokenicon.png?1715224333"
+      "logoURI": "https://assets.coingecko.com/coins/images/37685/large/tokenicon.png?1715224333"
     },
     {
       "chainId": 8453,
-      "address": "0x645c7aa841087e2e7f741c749ab27422ff5bba8e",
-      "name": "Iona by Virtuals",
-      "symbol": "IONA",
+      "address": "0x8853f0c059c27527d33d02378e5e4f6d5afb574a",
+      "name": "AI INU",
+      "symbol": "AIINU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52166/thumb/iona.jpg?1732682259"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfc60aa1ffca50ce08b3cdec9626c0bb9e9b09bec",
-      "name": "Envision Labs",
-      "symbol": "VIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37142/thumb/Envision_Logo.png?1713421742"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf578ad8809f13dabf921bdd3fcfbe194d0ab5628",
-      "name": "Virtue Poker Points",
-      "symbol": "VPP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3386/thumb/vp-logo-200x200.png?1696504084"
+      "logoURI": "https://assets.coingecko.com/coins/images/36902/large/aiinu.png?1712699681"
     },
     {
       "chainId": 8453,
@@ -3032,7 +3008,23 @@
       "name": "Ethlas",
       "symbol": "ELS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30331/thumb/ELS_Logo_200x200.png?1696529232"
+      "logoURI": "https://assets.coingecko.com/coins/images/30331/large/ELS_Logo_200x200.png?1696529232"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfc60aa1ffca50ce08b3cdec9626c0bb9e9b09bec",
+      "name": "Envision Labs",
+      "symbol": "VIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37142/large/Envision_Logo.png?1713421742"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x645c7aa841087e2e7f741c749ab27422ff5bba8e",
+      "name": "Iona by Virtuals",
+      "symbol": "IONA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52166/large/iona.jpg?1732682259"
     },
     {
       "chainId": 8453,
@@ -3040,7 +3032,15 @@
       "name": "AMC",
       "symbol": "AMC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37977/thumb/amc.jpeg?1716196916"
+      "logoURI": "https://assets.coingecko.com/coins/images/37977/large/amc.jpeg?1716196916"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf578ad8809f13dabf921bdd3fcfbe194d0ab5628",
+      "name": "Virtue Poker Points",
+      "symbol": "VPP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3386/large/vp-logo-200x200.png?1696504084"
     },
     {
       "chainId": 8453,
@@ -3048,15 +3048,7 @@
       "name": "XRGB",
       "symbol": "XRGB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35447/thumb/log2.png?1708620430"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
-      "name": "Lava Network",
-      "symbol": "LAVA",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37354/thumb/lava_logo.png?1714098423"
+      "logoURI": "https://assets.coingecko.com/coins/images/35447/large/log2.png?1708620430"
     },
     {
       "chainId": 8453,
@@ -3064,7 +3056,15 @@
       "name": "Dackie USD",
       "symbol": "DCKUSD",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39966/thumb/Dackie_USD_Stablecoin.png?1724957262"
+      "logoURI": "https://assets.coingecko.com/coins/images/39966/large/Dackie_USD_Stablecoin.png?1724957262"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
+      "name": "Lava Network",
+      "symbol": "LAVA",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37354/large/lava_logo.png?1714098423"
     },
     {
       "chainId": 8453,
@@ -3072,7 +3072,7 @@
       "name": "Aqualibre",
       "symbol": "AQLA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35026/thumb/aq1.png?1707147950"
+      "logoURI": "https://assets.coingecko.com/coins/images/35026/large/aq1.png?1707147950"
     },
     {
       "chainId": 8453,
@@ -3080,23 +3080,7 @@
       "name": "AI Market Compass",
       "symbol": "AIM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39363/thumb/AIM_%282%29.jpg?1723415448"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8931ee05ec111325c1700b68e5ef7b887e00661d",
-      "name": "The Big Guy",
-      "symbol": "BGUY",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/38875/thumb/download.png?1719336441"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
-      "name": "Equalizer  BASE ",
-      "symbol": "SCALE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32221/thumb/SCALE_icon_200x200.png?1696835640"
+      "logoURI": "https://assets.coingecko.com/coins/images/39363/large/AIM_%282%29.jpg?1723415448"
     },
     {
       "chainId": 8453,
@@ -3104,39 +3088,23 @@
       "name": "MASQ",
       "symbol": "MASQ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13699/thumb/masq.png?1696513446"
+      "logoURI": "https://assets.coingecko.com/coins/images/13699/large/masq.png?1696513446"
     },
     {
       "chainId": 8453,
-      "address": "0x28a730de97dc62a8c88363e0b1049056f1274a70",
-      "name": "Chinese Toshi",
-      "symbol": "CTOSHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38635/thumb/231_%28Custom%29_%283%29.png?1718173956"
+      "address": "0x8931ee05ec111325c1700b68e5ef7b887e00661d",
+      "name": "The Big Guy",
+      "symbol": "BGUY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/38875/large/download.png?1719336441"
     },
     {
       "chainId": 8453,
-      "address": "0xebb78043e29f4af24e6266a7d142f5a08443969e",
-      "name": "Derp",
-      "symbol": "DERP",
+      "address": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+      "name": "Equalizer  BASE ",
+      "symbol": "SCALE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33069/thumb/derpdex_%281%29.png?1700793428"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x22a2488fe295047ba13bd8cccdbc8361dbd8cf7c",
-      "name": "Sonne Finance",
-      "symbol": "SONNE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27540/thumb/Token1.png?1696526577"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb0e87796380172f911214208df966a84cceaaf82",
-      "name": "DOM",
-      "symbol": "DOM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51723/thumb/463fac78-dcc9-49cf-879f-b0b1af658295.png?1731903839"
+      "logoURI": "https://assets.coingecko.com/coins/images/32221/large/SCALE_icon_200x200.png?1696835640"
     },
     {
       "chainId": 8453,
@@ -3144,7 +3112,39 @@
       "name": "Wow",
       "symbol": "WOW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51527/thumb/23bafybeialew5mz6o2d6abynkd7kafunbgcgxcatyjdr5s2mgr4ae4zeltwe_%281%29.jpg?1731497334"
+      "logoURI": "https://assets.coingecko.com/coins/images/51527/large/23bafybeialew5mz6o2d6abynkd7kafunbgcgxcatyjdr5s2mgr4ae4zeltwe_%281%29.jpg?1731497334"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x28a730de97dc62a8c88363e0b1049056f1274a70",
+      "name": "Chinese Toshi",
+      "symbol": "CTOSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38635/large/231_%28Custom%29_%283%29.png?1718173956"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xebb78043e29f4af24e6266a7d142f5a08443969e",
+      "name": "Derp",
+      "symbol": "DERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33069/large/derpdex_%281%29.png?1700793428"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x22a2488fe295047ba13bd8cccdbc8361dbd8cf7c",
+      "name": "Sonne Finance",
+      "symbol": "SONNE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27540/large/Token1.png?1696526577"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb0e87796380172f911214208df966a84cceaaf82",
+      "name": "DOM",
+      "symbol": "DOM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51723/large/463fac78-dcc9-49cf-879f-b0b1af658295.png?1731903839"
     },
     {
       "chainId": 8453,
@@ -3152,7 +3152,7 @@
       "name": "BlockAI",
       "symbol": "BAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39638/thumb/logo-200x200-transparent-bg.png?1723278224"
+      "logoURI": "https://assets.coingecko.com/coins/images/39638/large/logo-200x200-transparent-bg.png?1723278224"
     },
     {
       "chainId": 8453,
@@ -3160,31 +3160,7 @@
       "name": "Beni",
       "symbol": "BENI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36691/thumb/Logo_Image_Beni_Uodate.png?1732385556"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x698b49063c14d2753d23064ff891a876cffa6fb5",
-      "name": "NIKITA by Virtuals",
-      "symbol": "NIKITA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52146/thumb/Nikita_Pic.png?1732652736"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3054e8f8fba3055a42e5f5228a2a4e2ab1326933",
-      "name": "zuzalu",
-      "symbol": "ZUZALU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36909/thumb/ZUZALA.jpg?1712732086"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa0a2e84f6f19c09a095d4a83ac8de5a32d303a13",
-      "name": "Lil Brett",
-      "symbol": "LILB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51813/thumb/%28100_x_100_px%29.png?1732029374"
+      "logoURI": "https://assets.coingecko.com/coins/images/36691/large/Logo_Image_Beni_Uodate.png?1732385556"
     },
     {
       "chainId": 8453,
@@ -3192,7 +3168,31 @@
       "name": "Kinetix Finance Token",
       "symbol": "KAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34031/thumb/KFI_Token_1.png?1703675672"
+      "logoURI": "https://assets.coingecko.com/coins/images/34031/large/KFI_Token_1.png?1703675672"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x698b49063c14d2753d23064ff891a876cffa6fb5",
+      "name": "NIKITA by Virtuals",
+      "symbol": "NIKITA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52146/large/Nikita_Pic.png?1732652736"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3054e8f8fba3055a42e5f5228a2a4e2ab1326933",
+      "name": "zuzalu",
+      "symbol": "ZUZALU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36909/large/ZUZALA.jpg?1712732086"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa0a2e84f6f19c09a095d4a83ac8de5a32d303a13",
+      "name": "Lil Brett",
+      "symbol": "LILB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51813/large/%28100_x_100_px%29.png?1732029374"
     },
     {
       "chainId": 8453,
@@ -3200,7 +3200,7 @@
       "name": "Juicybet",
       "symbol": "JSP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38262/thumb/JB_token.png?1717686707"
+      "logoURI": "https://assets.coingecko.com/coins/images/38262/large/JB_token.png?1717686707"
     },
     {
       "chainId": 8453,
@@ -3208,7 +3208,7 @@
       "name": "Roost",
       "symbol": "ROOST",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36458/thumb/roost.jpeg?1711493580"
+      "logoURI": "https://assets.coingecko.com/coins/images/36458/large/roost.jpeg?1711493580"
     },
     {
       "chainId": 8453,
@@ -3216,7 +3216,7 @@
       "name": "Mrs Miggles",
       "symbol": "MRSMIGGLES",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39282/thumb/token.png?1722045136"
+      "logoURI": "https://assets.coingecko.com/coins/images/39282/large/token.png?1722045136"
     },
     {
       "chainId": 8453,
@@ -3224,15 +3224,7 @@
       "name": "Overnight Finance",
       "symbol": "OVN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31970/thumb/OVN.png?1696959174"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066",
-      "name": "Rug World Assets",
-      "symbol": "RWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37119/thumb/0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066.jpg?1713356569"
+      "logoURI": "https://assets.coingecko.com/coins/images/31970/large/OVN.png?1696959174"
     },
     {
       "chainId": 8453,
@@ -3240,15 +3232,15 @@
       "name": "Buz Economy",
       "symbol": "BUZ",
       "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/39793/thumb/buz-economy-logo-dark.png?1724117134"
+      "logoURI": "https://assets.coingecko.com/coins/images/39793/large/buz-economy-logo-dark.png?1724117134"
     },
     {
       "chainId": 8453,
-      "address": "0xa8c2e771288585229eea8dbe072edfa7bcb388bb",
-      "name": "Apollo Name Service",
-      "symbol": "ANS",
+      "address": "0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066",
+      "name": "Rug World Assets",
+      "symbol": "RWA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40040/thumb/star_logo8305.png?1725392202"
+      "logoURI": "https://assets.coingecko.com/coins/images/37119/large/0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066.jpg?1713356569"
     },
     {
       "chainId": 8453,
@@ -3256,7 +3248,15 @@
       "name": "Coinye West",
       "symbol": "COINYE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36403/thumb/Coinye_West.png?1711369153"
+      "logoURI": "https://assets.coingecko.com/coins/images/36403/large/Coinye_West.png?1711369153"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa8c2e771288585229eea8dbe072edfa7bcb388bb",
+      "name": "Apollo Name Service",
+      "symbol": "ANS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40040/large/star_logo8305.png?1725392202"
     },
     {
       "chainId": 8453,
@@ -3264,7 +3264,7 @@
       "name": "DackieSwap",
       "symbol": "DACKIE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30752/thumb/dackieswap_large.png?1707290196"
+      "logoURI": "https://assets.coingecko.com/coins/images/30752/large/dackieswap_large.png?1707290196"
     },
     {
       "chainId": 8453,
@@ -3272,7 +3272,7 @@
       "name": "Tadpole",
       "symbol": "TAD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39783/thumb/IMG_7927.PNG?1724101375"
+      "logoURI": "https://assets.coingecko.com/coins/images/39783/large/IMG_7927.PNG?1724101375"
     },
     {
       "chainId": 8453,
@@ -3280,7 +3280,7 @@
       "name": "DEUS Finance",
       "symbol": "DEUS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18778/thumb/Black_Background_200x200.png?1696518242"
+      "logoURI": "https://assets.coingecko.com/coins/images/18778/large/Black_Background_200x200.png?1696518242"
     },
     {
       "chainId": 8453,
@@ -3288,327 +3288,7 @@
       "name": "Pola On Base",
       "symbol": "POLA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37314/thumb/pola.jpg?1713971028"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcba6fabf7df8ada1995d1f57acaf520198289ca9",
-      "name": "BeromesButt",
-      "symbol": "BUTT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52419/thumb/BUTT_Logo.jpg?1733326535"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf1143f3a8d76f1ca740d29d5671d365f66c44ed1",
-      "name": "Wrapped Bitcoin  Universal ",
-      "symbol": "UBTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50252/thumb/UA-BTC_1.png?1726721793"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xff62ddfa80e513114c3a0bf4d6ffff1c1d17aadf",
-      "name": "Boe",
-      "symbol": "BOE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36712/thumb/79jlrE4M_400x400_%282%29.jpg?1712127456"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xebf7d4d84372f5df1b5d0e3ddd889e5bc286b1c3",
-      "name": "Ali for fx protocol by Virtuals",
-      "symbol": "FX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52319/thumb/imresizer-1732989192834.jpg?1733077790"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x92dc4ab92eb16e781559e612f349916988013d5a",
-      "name": "Agent Zero",
-      "symbol": "WSB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51310/thumb/photo_2024-11-03_07-33-29.jpg?1730643955"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x78b3c724a2f663d11373c4a1978689271895256f",
-      "name": "Token Name Service",
-      "symbol": "TKN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39886/thumb/Tri-gradient_Group_5135_2x.png?1724682287"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa067436db77ab18b1a315095e4b816791609897c",
-      "name": "WASSIE",
-      "symbol": "WASSIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30144/thumb/logo-coingecko.png?1696529065"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x57bd5c33c8002a634b389ab4de5e09ec1c31dce7",
-      "name": "Silo Finance",
-      "symbol": "SILO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21454/thumb/y0iYKZOv_400x400.png?1696520816"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x474f4cb764df9da079d94052fed39625c147c12c",
-      "name": "Bonsai Token",
-      "symbol": "BONSAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35884/thumb/Bonsai_BW_Coingecko-200x200.jpg?1710071621"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x24cb2b89844604c57350776d81e14765d03b91de",
-      "name": "Zunami ETH",
-      "symbol": "ZUNETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37835/thumb/zunETH_200x200.png?1715741123"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2075f6e2147d4ac26036c9b4084f8e28b324397d",
-      "name": "BaseCTO",
-      "symbol": "CTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50716/thumb/IMG_1480.jpeg?1728792869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb34457736aa191ff423f84f5d669f68b231e6c4e",
-      "name": "AGENT DOGE by Virtuals",
-      "symbol": "AIDOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52187/thumb/Screenshot_2024-11-23_at_4.09.40%E2%80%AFPM.png?1732723139"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x75e6b648c91d222b2f6318e8ceeed4b691d5323f",
-      "name": "AnonFi",
-      "symbol": "ANON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50446/thumb/IMG_20240928_164632_277.png?1727771357"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x315b8c9a1123c10228d469551033440441b41f0b",
-      "name": "BEATS on BASE",
-      "symbol": "BEATS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52396/thumb/200x200_transparent.png?1733293803"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x698dc45e4f10966f6d1d98e3bfd7071d8144c233",
-      "name": "PEPE 0x69 ON BASE",
-      "symbol": "PEPE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37400/thumb/lOGO.jpg?1714352456"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc2fe011c3885277c7f0e7ffd45ff90cadc8ecd12",
-      "name": "Poncho",
-      "symbol": "PONCHO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36160/thumb/ponchologo.PNG?1710744293"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb8e564b206032bbcda2c3978bc371da52152f72e",
-      "name": "Base Terminal",
-      "symbol": "BASEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50300/thumb/Base_Terminal_Logo_200x200.png?1727021406"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd85eff20288ca72ea9eecffb428f89ee5066ca5c",
-      "name": "ISKRA Token",
-      "symbol": "ISK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27428/thumb/ISKRA_logo.png?1696526469"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x49c86046903807d0a3193a221c1a3e1b1b6c9ba3",
-      "name": "CYI by Virtuals",
-      "symbol": "CYI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52125/thumb/Cryptoyieldinfo.jpg?1732611368"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x72e72193ea14ac3b469f881989d18a2ba021b4c6",
-      "name": "Dollar",
-      "symbol": "DOLLAR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39312/thumb/pfp_200x200.png?1721706165"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5d9c2457a10d455e0ad8e28e40cc28eacf27a06a",
-      "name": "GM Everyday",
-      "symbol": "GM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52139/thumb/sRavZnte_.png?1732642259"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc9b6ef062fab19d3f1eabc36b1f2e852af1acd18",
-      "name": "Brett s cat",
-      "symbol": "BALT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38428/thumb/IMG_4717.PNG?1717627270"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6112b8714221bbd96ae0a0032a683e38b475d06c",
-      "name": "WAI Combinator by Virtuals",
-      "symbol": "WAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52181/thumb/wai.jpg?1732689732"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x26f1bb40ea88b46ceb21557dc0ffac7b7c0ad40f",
-      "name": "ALF",
-      "symbol": "ALF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38867/thumb/alf200.png?1719283344"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2dc90fa3a0f178ba4bee16cac5d6c9a5a7b4c6cb",
-      "name": "DRINK",
-      "symbol": "DRINK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50167/thumb/2N1fxgBw_400x400.jpg?1726136925"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc227717ef4ae4d982e14789eb33ba942243c3fee",
-      "name": "Mozaic",
-      "symbol": "MOZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30100/thumb/Main_Logo_1-200x200jpg.jpg?1696529024"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb8d98a102b0079b69ffbc760c8d857a31653e56e",
-      "name": "Toby ToadGod",
-      "symbol": "TOBY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36615/thumb/toby1.png?1711976453"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8f4e4221ba88d4e9bb76ecfb91d7c5ce08d7d5b9",
-      "name": "FU Money",
-      "symbol": "FU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38629/thumb/FU_logo_black.png?1718170125"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbd4e5c2f8de5065993d29a9794e2b7cefc41437a",
-      "name": "IPOR",
-      "symbol": "IPOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28373/thumb/IPOR-token-200x200.png?1696527376"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb755506531786c8ac63b756bab1ac387bacb0c04",
-      "name": "ZARP Stablecoin",
-      "symbol": "ZARP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27333/thumb/zarp_coin.png?1696526381"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x72499bddb67f4ca150e1f522ca82c87bc9fb18c8",
-      "name": "Bonk On Base",
-      "symbol": "BONK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37123/thumb/200x200.png?1713367524"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc19669a405067927865b40ea045a2baabbbe57f5",
-      "name": "Star",
-      "symbol": "STAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31277/thumb/coin-icon_Star-200x200.png?1732742256"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1a43287cbfcc5f35082e6e2aa98e5b474fe7bd4e",
-      "name": "Athena by Virtuals",
-      "symbol": "ATHENA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52006/thumb/athenalogo.png?1732304469"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6c7ebb64e258f5712eeec83ceaf41c3dcbb534b1",
-      "name": "Vainguard",
-      "symbol": "VAIN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52365/thumb/Vain_CG.png?1733210740"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xac86f3556cbd2b4d800d17adc3a266b500fcb9f5",
-      "name": "Etherisc DIP",
-      "symbol": "DIP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4586/thumb/dip.png?1696505164"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x506beb7965fc7053059006c7ab4c62c02c2d989f",
-      "name": "Brain Worms",
-      "symbol": "BWORM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39192/thumb/black_square_transparent_200px.png?1720990715"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7cf7132ede0ca592a236b6198a681bb7b42dd5ae",
-      "name": "BOLT on Base",
-      "symbol": "BOLT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38449/thumb/wwwww.png?1717557162"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfb18511f1590a494360069f3640c27d55c2b5290",
-      "name": "Wild Goat Coin",
-      "symbol": "WGC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37966/thumb/COIN_200x200.png?1716778831"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x10a7a84c91988138f8dbbc82a23b02c8639e2552",
-      "name": "ROXY FROG",
-      "symbol": "ROXY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38170/thumb/ROXY.jpg?1716703909"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6bc40d4099f9057b23af309c08d935b890d7adc0",
-      "name": "SnailBrook",
-      "symbol": "SNAIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29922/thumb/snail.jpeg?1713754058"
+      "logoURI": "https://assets.coingecko.com/coins/images/37314/large/pola.jpg?1713971028"
     },
     {
       "chainId": 8453,
@@ -3616,7 +3296,327 @@
       "name": "High Yield USD  Base ",
       "symbol": "HYUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33636/thumb/hyusdlogo.png?1702536133"
+      "logoURI": "https://assets.coingecko.com/coins/images/33636/large/hyusdlogo.png?1702536133"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcba6fabf7df8ada1995d1f57acaf520198289ca9",
+      "name": "BeromesButt",
+      "symbol": "BUTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52419/large/BUTT_Logo.jpg?1733326535"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf1143f3a8d76f1ca740d29d5671d365f66c44ed1",
+      "name": "Wrapped Bitcoin  Universal ",
+      "symbol": "UBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50252/large/UA-BTC_1.png?1726721793"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xff62ddfa80e513114c3a0bf4d6ffff1c1d17aadf",
+      "name": "Boe",
+      "symbol": "BOE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36712/large/79jlrE4M_400x400_%282%29.jpg?1712127456"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xebf7d4d84372f5df1b5d0e3ddd889e5bc286b1c3",
+      "name": "Ali for fx protocol by Virtuals",
+      "symbol": "FX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52319/large/imresizer-1732989192834.jpg?1733077790"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x474f4cb764df9da079d94052fed39625c147c12c",
+      "name": "Bonsai Token",
+      "symbol": "BONSAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35884/large/Bonsai_BW_Coingecko-200x200.jpg?1710071621"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x92dc4ab92eb16e781559e612f349916988013d5a",
+      "name": "Agent Zero",
+      "symbol": "WSB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51310/large/photo_2024-11-03_07-33-29.jpg?1730643955"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa067436db77ab18b1a315095e4b816791609897c",
+      "name": "WASSIE",
+      "symbol": "WASSIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30144/large/logo-coingecko.png?1696529065"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x57bd5c33c8002a634b389ab4de5e09ec1c31dce7",
+      "name": "Silo Finance",
+      "symbol": "SILO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21454/large/y0iYKZOv_400x400.png?1696520816"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x78b3c724a2f663d11373c4a1978689271895256f",
+      "name": "Token Name Service",
+      "symbol": "TKN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39886/large/Tri-gradient_Group_5135_2x.png?1724682287"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x24cb2b89844604c57350776d81e14765d03b91de",
+      "name": "Zunami ETH",
+      "symbol": "ZUNETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37835/large/zunETH_200x200.png?1715741123"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2075f6e2147d4ac26036c9b4084f8e28b324397d",
+      "name": "BaseCTO",
+      "symbol": "CTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50716/large/IMG_1480.jpeg?1728792869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc19669a405067927865b40ea045a2baabbbe57f5",
+      "name": "Star",
+      "symbol": "STAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31277/large/coin-icon_Star-200x200.png?1732742256"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb34457736aa191ff423f84f5d669f68b231e6c4e",
+      "name": "AGENT DOGE by Virtuals",
+      "symbol": "AIDOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52187/large/Screenshot_2024-11-23_at_4.09.40%E2%80%AFPM.png?1732723139"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x75e6b648c91d222b2f6318e8ceeed4b691d5323f",
+      "name": "AnonFi",
+      "symbol": "ANON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50446/large/IMG_20240928_164632_277.png?1727771357"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x315b8c9a1123c10228d469551033440441b41f0b",
+      "name": "BEATS on BASE",
+      "symbol": "BEATS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52396/large/200x200_transparent.png?1733293803"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x698dc45e4f10966f6d1d98e3bfd7071d8144c233",
+      "name": "PEPE 0x69 ON BASE",
+      "symbol": "PEPE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37400/large/lOGO.jpg?1714352456"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb8e564b206032bbcda2c3978bc371da52152f72e",
+      "name": "Base Terminal",
+      "symbol": "BASEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50300/large/Base_Terminal_Logo_200x200.png?1727021406"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x72e72193ea14ac3b469f881989d18a2ba021b4c6",
+      "name": "Dollar",
+      "symbol": "DOLLAR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39312/large/pfp_200x200.png?1721706165"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x49c86046903807d0a3193a221c1a3e1b1b6c9ba3",
+      "name": "CYI by Virtuals",
+      "symbol": "CYI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52125/large/Cryptoyieldinfo.jpg?1732611368"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5d9c2457a10d455e0ad8e28e40cc28eacf27a06a",
+      "name": "GM Everyday",
+      "symbol": "GM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52139/large/sRavZnte_.png?1732642259"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc2fe011c3885277c7f0e7ffd45ff90cadc8ecd12",
+      "name": "Poncho",
+      "symbol": "PONCHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36160/large/ponchologo.PNG?1710744293"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbd4e5c2f8de5065993d29a9794e2b7cefc41437a",
+      "name": "IPOR",
+      "symbol": "IPOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png?1696527376"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc9b6ef062fab19d3f1eabc36b1f2e852af1acd18",
+      "name": "Brett s cat",
+      "symbol": "BALT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38428/large/IMG_4717.PNG?1717627270"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6112b8714221bbd96ae0a0032a683e38b475d06c",
+      "name": "WAI Combinator by Virtuals",
+      "symbol": "WAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52181/large/wai.jpg?1732689732"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x26f1bb40ea88b46ceb21557dc0ffac7b7c0ad40f",
+      "name": "ALF",
+      "symbol": "ALF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38867/large/alf200.png?1719283344"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2dc90fa3a0f178ba4bee16cac5d6c9a5a7b4c6cb",
+      "name": "DRINK",
+      "symbol": "DRINK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50167/large/2N1fxgBw_400x400.jpg?1726136925"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc227717ef4ae4d982e14789eb33ba942243c3fee",
+      "name": "Mozaic",
+      "symbol": "MOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30100/large/Main_Logo_1-200x200jpg.jpg?1696529024"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb8d98a102b0079b69ffbc760c8d857a31653e56e",
+      "name": "Toby ToadGod",
+      "symbol": "TOBY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36615/large/toby1.png?1711976453"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd85eff20288ca72ea9eecffb428f89ee5066ca5c",
+      "name": "ISKRA Token",
+      "symbol": "ISK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27428/large/ISKRA_logo.png?1696526469"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f4e4221ba88d4e9bb76ecfb91d7c5ce08d7d5b9",
+      "name": "FU Money",
+      "symbol": "FU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38629/large/FU_logo_black.png?1718170125"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb755506531786c8ac63b756bab1ac387bacb0c04",
+      "name": "ZARP Stablecoin",
+      "symbol": "ZARP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27333/large/zarp_coin.png?1696526381"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x72499bddb67f4ca150e1f522ca82c87bc9fb18c8",
+      "name": "Bonk On Base",
+      "symbol": "BONK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37123/large/200x200.png?1713367524"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1a43287cbfcc5f35082e6e2aa98e5b474fe7bd4e",
+      "name": "Athena by Virtuals",
+      "symbol": "ATHENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52006/large/athenalogo.png?1732304469"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6c7ebb64e258f5712eeec83ceaf41c3dcbb534b1",
+      "name": "Vainguard",
+      "symbol": "VAIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52365/large/Vain_CG.png?1733210740"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac86f3556cbd2b4d800d17adc3a266b500fcb9f5",
+      "name": "Etherisc DIP",
+      "symbol": "DIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4586/large/dip.png?1696505164"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x506beb7965fc7053059006c7ab4c62c02c2d989f",
+      "name": "Brain Worms",
+      "symbol": "BWORM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39192/large/black_square_transparent_200px.png?1720990715"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfb18511f1590a494360069f3640c27d55c2b5290",
+      "name": "Wild Goat Coin",
+      "symbol": "WGC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37966/large/COIN_200x200.png?1716778831"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7cf7132ede0ca592a236b6198a681bb7b42dd5ae",
+      "name": "BOLT on Base",
+      "symbol": "BOLT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38449/large/wwwww.png?1717557162"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x10a7a84c91988138f8dbbc82a23b02c8639e2552",
+      "name": "ROXY FROG",
+      "symbol": "ROXY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38170/large/ROXY.jpg?1716703909"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6bc40d4099f9057b23af309c08d935b890d7adc0",
+      "name": "SnailBrook",
+      "symbol": "SNAIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29922/large/snail.jpeg?1713754058"
     },
     {
       "chainId": 8453,
@@ -3624,15 +3624,7 @@
       "name": "All Your Base",
       "symbol": "AYB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35777/thumb/AYB-Coingecko.png?1718634946"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1db0fc8933f545648b54a9ee4326209a9a259643",
-      "name": "Zunami Governance Token",
-      "symbol": "ZUN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38298/thumb/ZUN_200x200.png?1717194404"
+      "logoURI": "https://assets.coingecko.com/coins/images/35777/large/AYB-Coingecko.png?1718634946"
     },
     {
       "chainId": 8453,
@@ -3640,7 +3632,15 @@
       "name": "Frame Token",
       "symbol": "FRAME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35034/thumb/Artboard_1_copyd.png?1707189782"
+      "logoURI": "https://assets.coingecko.com/coins/images/35034/large/Artboard_1_copyd.png?1707189782"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1db0fc8933f545648b54a9ee4326209a9a259643",
+      "name": "Zunami Governance Token",
+      "symbol": "ZUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38298/large/ZUN_200x200.png?1717194404"
     },
     {
       "chainId": 8453,
@@ -3648,15 +3648,7 @@
       "name": "UnlockProtocolToken",
       "symbol": "UP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51457/thumb/up2.png?1731318758"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0a14ef61afb32e5ca672e021784f71705ac14908",
-      "name": "NULL MATRIX",
-      "symbol": "NULL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51086/thumb/dark.png?1732460149"
+      "logoURI": "https://assets.coingecko.com/coins/images/51457/large/up2.png?1731318758"
     },
     {
       "chainId": 8453,
@@ -3664,7 +3656,15 @@
       "name": "Siamese",
       "symbol": "SIAM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36489/thumb/transparant-200x200.png?1728005931"
+      "logoURI": "https://assets.coingecko.com/coins/images/36489/large/transparant-200x200.png?1728005931"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0a14ef61afb32e5ca672e021784f71705ac14908",
+      "name": "NULL MATRIX",
+      "symbol": "NULL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51086/large/dark.png?1732460149"
     },
     {
       "chainId": 8453,
@@ -3672,7 +3672,7 @@
       "name": "ParagonsDAO",
       "symbol": "PDT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22642/thumb/pdt_token_image.png?1727376481"
+      "logoURI": "https://assets.coingecko.com/coins/images/22642/large/pdt_token_image.png?1727376481"
     },
     {
       "chainId": 8453,
@@ -3680,7 +3680,7 @@
       "name": "Law of Attraction",
       "symbol": "LOA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38008/thumb/1.png?1716270777"
+      "logoURI": "https://assets.coingecko.com/coins/images/38008/large/1.png?1716270777"
     },
     {
       "chainId": 8453,
@@ -3688,7 +3688,7 @@
       "name": "WoofWork io",
       "symbol": "WOOF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28903/thumb/WWlogoTransparent_200x200.png?1696527879"
+      "logoURI": "https://assets.coingecko.com/coins/images/28903/large/WWlogoTransparent_200x200.png?1696527879"
     },
     {
       "chainId": 8453,
@@ -3696,7 +3696,7 @@
       "name": "Based Lambow",
       "symbol": "LAMBOW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38690/thumb/new-logo.jpg?1731187032"
+      "logoURI": "https://assets.coingecko.com/coins/images/38690/large/new-logo.jpg?1731187032"
     },
     {
       "chainId": 8453,
@@ -3704,7 +3704,7 @@
       "name": "Internet Token",
       "symbol": "INT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36593/thumb/internettoken_logo.png?1711949672"
+      "logoURI": "https://assets.coingecko.com/coins/images/36593/large/internettoken_logo.png?1711949672"
     },
     {
       "chainId": 8453,
@@ -3712,7 +3712,7 @@
       "name": "WEWECOIN",
       "symbol": "WEWE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39135/thumb/wewe_logo.png?1720857800"
+      "logoURI": "https://assets.coingecko.com/coins/images/39135/large/wewe_logo.png?1720857800"
     },
     {
       "chainId": 8453,
@@ -3720,7 +3720,7 @@
       "name": "Moonboots DAO",
       "symbol": "MBDAO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38066/thumb/MBDAO_Token_icon.png?1716441877"
+      "logoURI": "https://assets.coingecko.com/coins/images/38066/large/MBDAO_Token_icon.png?1716441877"
     },
     {
       "chainId": 8453,
@@ -3728,7 +3728,7 @@
       "name": "Brett 2 0",
       "symbol": "BRETT20",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37121/thumb/brett200-modified.png?1713366621"
+      "logoURI": "https://assets.coingecko.com/coins/images/37121/large/brett200-modified.png?1713366621"
     },
     {
       "chainId": 8453,
@@ -3736,7 +3736,7 @@
       "name": "Fire",
       "symbol": "FIRE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50835/thumb/fire-coin-200.png?1729242121"
+      "logoURI": "https://assets.coingecko.com/coins/images/50835/large/fire-coin-200.png?1729242121"
     },
     {
       "chainId": 8453,
@@ -3744,7 +3744,7 @@
       "name": "The Css God by Virtuals",
       "symbol": "WEBSIM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52173/thumb/the_css_god.jpg?1732684452"
+      "logoURI": "https://assets.coingecko.com/coins/images/52173/large/the_css_god.jpg?1732684452"
     },
     {
       "chainId": 8453,
@@ -3752,7 +3752,7 @@
       "name": "Precipitate ai",
       "symbol": "RAIN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32405/thumb/RAIN_200-removebg-preview.png?1711371589"
+      "logoURI": "https://assets.coingecko.com/coins/images/32405/large/RAIN_200-removebg-preview.png?1711371589"
     },
     {
       "chainId": 8453,
@@ -3760,31 +3760,7 @@
       "name": "RMRK",
       "symbol": "RMRK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18656/thumb/download_%281%29_%281%29.png?1696518126"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9124577428c5bd73ad7636cbc5014081384f29d6",
-      "name": "Monky",
-      "symbol": "MONKY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38522/thumb/1000084004.jpg?1717759092"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf95e1c0a67492720ca22842122fe7fa63d5519e5",
-      "name": "Lunarlens",
-      "symbol": "LUNARLENS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39304/thumb/%E6%9C%88%E4%BA%AE%E5%B8%8164.png?1721633565"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x41a22eb30df65d6ab0ce0b4cfe8f4e0eb306d471",
-      "name": "BaseBearCute",
-      "symbol": "BBQ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40006/thumb/logo.jpg?1725221317"
+      "logoURI": "https://assets.coingecko.com/coins/images/18656/large/download_%281%29_%281%29.png?1696518126"
     },
     {
       "chainId": 8453,
@@ -3792,23 +3768,15 @@
       "name": "Workie",
       "symbol": "WORKIE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38774/thumb/Pfp2_%281%29.png?1724903016"
+      "logoURI": "https://assets.coingecko.com/coins/images/38774/large/Pfp2_%281%29.png?1724903016"
     },
     {
       "chainId": 8453,
-      "address": "0x4d58608eff50b691a3b76189af2a7a123df1e9ba",
-      "name": "Boysclubbase",
-      "symbol": "BOYS",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37825/thumb/IMG_20240507_221140_398.jpg?1715668247"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x420b0fa3de2efcf2b2fd04152eb1df36a09717cd",
-      "name": "King Of Memes",
-      "symbol": "KING",
+      "address": "0xf95e1c0a67492720ca22842122fe7fa63d5519e5",
+      "name": "Lunarlens",
+      "symbol": "LUNARLENS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38261/thumb/kingofmemes.png?1716929140"
+      "logoURI": "https://assets.coingecko.com/coins/images/39304/large/%E6%9C%88%E4%BA%AE%E5%B8%8164.png?1721633565"
     },
     {
       "chainId": 8453,
@@ -3816,15 +3784,31 @@
       "name": "High",
       "symbol": "HIGH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36318/thumb/high200x200.png?1711092521"
+      "logoURI": "https://assets.coingecko.com/coins/images/36318/large/high200x200.png?1711092521"
     },
     {
       "chainId": 8453,
-      "address": "0xbf4db8b7a679f89ef38125d5f84dd1446af2ea3b",
-      "name": "Le Bleu Elefant",
-      "symbol": "BLEU",
+      "address": "0x41a22eb30df65d6ab0ce0b4cfe8f4e0eb306d471",
+      "name": "BaseBearCute",
+      "symbol": "BBQ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37811/thumb/b.png?1715597915"
+      "logoURI": "https://assets.coingecko.com/coins/images/40006/large/logo.jpg?1725221317"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4d58608eff50b691a3b76189af2a7a123df1e9ba",
+      "name": "Boysclubbase",
+      "symbol": "BOYS",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37825/large/IMG_20240507_221140_398.jpg?1715668247"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x420b0fa3de2efcf2b2fd04152eb1df36a09717cd",
+      "name": "King Of Memes",
+      "symbol": "KING",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38261/large/kingofmemes.png?1716929140"
     },
     {
       "chainId": 8453,
@@ -3832,7 +3816,23 @@
       "name": "Carlo",
       "symbol": "CARLO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37553/thumb/CARLO_200x200.png?1714752141"
+      "logoURI": "https://assets.coingecko.com/coins/images/37553/large/CARLO_200x200.png?1714752141"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbf4db8b7a679f89ef38125d5f84dd1446af2ea3b",
+      "name": "Le Bleu Elefant",
+      "symbol": "BLEU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37811/large/b.png?1715597915"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9124577428c5bd73ad7636cbc5014081384f29d6",
+      "name": "Monky",
+      "symbol": "MONKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38522/large/1000084004.jpg?1717759092"
     },
     {
       "chainId": 8453,
@@ -3840,7 +3840,7 @@
       "name": "Boshi",
       "symbol": "BOSHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37222/thumb/boshi.jpeg?1713775901"
+      "logoURI": "https://assets.coingecko.com/coins/images/37222/large/boshi.jpeg?1713775901"
     },
     {
       "chainId": 8453,
@@ -3848,7 +3848,7 @@
       "name": "DeFido",
       "symbol": "DEFIDO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18861/thumb/coingecko.png?1712043959"
+      "logoURI": "https://assets.coingecko.com/coins/images/18861/large/coingecko.png?1712043959"
     },
     {
       "chainId": 8453,
@@ -3856,7 +3856,7 @@
       "name": "goatwifhat",
       "symbol": "GIF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37776/thumb/GIF_logo_200x200.png?1715581191"
+      "logoURI": "https://assets.coingecko.com/coins/images/37776/large/GIF_logo_200x200.png?1715581191"
     },
     {
       "chainId": 8453,
@@ -3864,7 +3864,7 @@
       "name": "Sandwich Cat",
       "symbol": "SACA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36876/thumb/200x200_%281%29.png?1712646447"
+      "logoURI": "https://assets.coingecko.com/coins/images/36876/large/200x200_%281%29.png?1712646447"
     },
     {
       "chainId": 8453,
@@ -3872,7 +3872,7 @@
       "name": "DUDEGEN",
       "symbol": "DUDEGEN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39323/thumb/Untitled_Artwork_5-enhanced_copy_2.png?1721711203"
+      "logoURI": "https://assets.coingecko.com/coins/images/39323/large/Untitled_Artwork_5-enhanced_copy_2.png?1721711203"
     },
     {
       "chainId": 8453,
@@ -3880,7 +3880,7 @@
       "name": "BlockChainPeople",
       "symbol": "BCP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38085/thumb/200x200.png?1716477512"
+      "logoURI": "https://assets.coingecko.com/coins/images/38085/large/200x200.png?1716477512"
     },
     {
       "chainId": 8453,
@@ -3888,7 +3888,7 @@
       "name": "Blue Chip",
       "symbol": "CHIP",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/36433/thumb/BlueChip-200x200.png?1711435311"
+      "logoURI": "https://assets.coingecko.com/coins/images/36433/large/BlueChip-200x200.png?1711435311"
     },
     {
       "chainId": 8453,
@@ -3896,7 +3896,7 @@
       "name": "Based Beast Coin",
       "symbol": "BEAST",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/51121/thumb/IMG_7914.png?1730164559"
+      "logoURI": "https://assets.coingecko.com/coins/images/51121/large/IMG_7914.png?1730164559"
     },
     {
       "chainId": 8453,
@@ -3904,7 +3904,7 @@
       "name": "UNLUCKY",
       "symbol": "UNLUCKY",
       "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/38691/thumb/unlucky.jpeg?1718346998"
+      "logoURI": "https://assets.coingecko.com/coins/images/38691/large/unlucky.jpeg?1718346998"
     },
     {
       "chainId": 8453,
@@ -3912,7 +3912,7 @@
       "name": "DogeGF",
       "symbol": "DOGEGF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18651/thumb/dogegf_logo_200x200.png?1712082872"
+      "logoURI": "https://assets.coingecko.com/coins/images/18651/large/dogegf_logo_200x200.png?1712082872"
     },
     {
       "chainId": 8453,
@@ -3920,7 +3920,7 @@
       "name": "Agent Zeek by Virtuals",
       "symbol": "ZEEK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52331/thumb/dwWGlf18_400x400.jpg?1733086398"
+      "logoURI": "https://assets.coingecko.com/coins/images/52331/large/dwWGlf18_400x400.jpg?1733086398"
     },
     {
       "chainId": 8453,
@@ -3928,7 +3928,7 @@
       "name": "OPEN Ticketing Ecosystem",
       "symbol": "OPN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36612/thumb/TOKEN.png?1711975511"
+      "logoURI": "https://assets.coingecko.com/coins/images/36612/large/TOKEN.png?1711975511"
     },
     {
       "chainId": 8453,
@@ -3936,7 +3936,7 @@
       "name": "Rizz",
       "symbol": "RIZZ",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/50598/thumb/200x200px.png?1728446110"
+      "logoURI": "https://assets.coingecko.com/coins/images/50598/large/200x200px.png?1728446110"
     },
     {
       "chainId": 8453,
@@ -3944,7 +3944,7 @@
       "name": "MOON INU",
       "symbol": "MOON",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36493/thumb/moon-200.png?1711612557"
+      "logoURI": "https://assets.coingecko.com/coins/images/36493/large/moon-200.png?1711612557"
     },
     {
       "chainId": 8453,
@@ -3952,7 +3952,7 @@
       "name": "MintStakeShare",
       "symbol": "MSS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39424/thumb/logo200x200.png?1729946358"
+      "logoURI": "https://assets.coingecko.com/coins/images/39424/large/logo200x200.png?1729946358"
     },
     {
       "chainId": 8453,
@@ -3960,7 +3960,7 @@
       "name": "Department Of Government Efficiency",
       "symbol": "DOGE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51896/thumb/coingecko_%282%29.png?1732124666"
+      "logoURI": "https://assets.coingecko.com/coins/images/51896/large/coingecko_%282%29.png?1732124666"
     },
     {
       "chainId": 8453,
@@ -3968,15 +3968,7 @@
       "name": "Kendu Inu",
       "symbol": "KENDU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51087/thumb/Based_Kendu_Logo_%281%29.png?1730019305"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x22222bd682745cf032006394750739684e45a5f8",
-      "name": "Jasse Polluk",
-      "symbol": "POLLUK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38510/thumb/Jasse_Polluk.png?1717754036"
+      "logoURI": "https://assets.coingecko.com/coins/images/51087/large/Based_Kendu_Logo_%281%29.png?1730019305"
     },
     {
       "chainId": 8453,
@@ -3984,7 +3976,23 @@
       "name": "Rewardable",
       "symbol": "REWARD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52274/thumb/reward-token-icon-200x200.png?1732888312"
+      "logoURI": "https://assets.coingecko.com/coins/images/52274/large/reward-token-icon-200x200.png?1732888312"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x22222bd682745cf032006394750739684e45a5f8",
+      "name": "Jasse Polluk",
+      "symbol": "POLLUK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38510/large/Jasse_Polluk.png?1717754036"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8bf591eae535f93a242d5a954d3cde648b48a5a8",
+      "name": "Sumer Money suUSD",
+      "symbol": "SUUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33266/large/Sumer_Money_Logo.jpg?1701321416"
     },
     {
       "chainId": 8453,
@@ -3992,7 +4000,7 @@
       "name": "Samurai Starter",
       "symbol": "SAM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37552/thumb/samurai-coingecko-logo_2.png?1714751141"
+      "logoURI": "https://assets.coingecko.com/coins/images/37552/large/samurai-coingecko-logo_2.png?1714751141"
     },
     {
       "chainId": 8453,
@@ -4000,16 +4008,8 @@
       "name": "LazyCat",
       "symbol": "LAZYCAT",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/40029/thumb/LAZYCAT.jpg?1725360523"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x628c5ba9b775dacecd14e237130c537f497d1cc7",
-      "name": "Jaderoll",
-      "symbol": "JADE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38926/thumb/Asset_2_3x.png?1719542614"
+      "logoURI": "https://assets.coingecko.com/coins/images/40029/large/LAZYCAT.jpg?1725360523"
     }
   ],
-  "timestamp": "2024-12-06T16:10:22.708Z"
+  "timestamp": "2024-12-06T16:14:59.808Z"
 }

--- a/src/public/CoinGecko.8453.json
+++ b/src/public/CoinGecko.8453.json
@@ -1,15 +1,14 @@
 {
-  "name": "CoinGecko",
+  "name": "Coingecko top 500 on base",
   "logoURI": "https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png",
   "keywords": [
     "defi"
   ],
   "version": {
-    "major": 1,
+    "major": 2,
     "minor": 0,
     "patch": 0
   },
-  "timestamp": "2024-11-29T16:27:34.089Z",
   "tokens": [
     {
       "chainId": 8453,
@@ -29,70 +28,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
-      "name": "Coinbase Wrapped BTC",
-      "symbol": "CBBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/40143/thumb/cbbtc.webp?1726136727"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b",
-      "name": "Virtuals Protocol",
-      "symbol": "VIRTUAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34057/thumb/LOGOMARK.png?1708356054"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
-      "name": "CARV",
-      "symbol": "CARV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37689/thumb/CARV_%281%29.png?1728418485"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3055913c90fcc1a6ce9a358911721eeb942013a1",
-      "name": "PancakeSwap",
-      "symbol": "CAKE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12632/thumb/pancakeswap-cake-logo_%281%29.png?1696512440"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb0ffa8000886e57f86dd5264b9582b2ad87b2b91",
-      "name": "Wormhole",
-      "symbol": "W",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35087/thumb/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x96419929d7949d6a801a6909c145c8eef6a40431",
-      "name": "Spectral",
-      "symbol": "SPEC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36138/thumb/ls7wS7vf_400x400.jpg?1724975224"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
-      "name": "Yield Guild Games",
-      "symbol": "YGG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xaac78d1219c08aecc8e37e03858fe885f5ef1799",
-      "name": "Yield Guild Games",
-      "symbol": "YGG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
-    },
-    {
-      "chainId": 8453,
       "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
       "name": "LayerZero",
       "symbol": "ZRO",
@@ -101,99 +36,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x532f27101965dd16442e59d40670faf5ebb142e4",
-      "name": "Brett",
-      "symbol": "BRETT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35529/thumb/1000050750.png?1709031995"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbaa5cc21fd487b8fcc2f632f3f4e8d37262a0842",
-      "name": "Morpho",
-      "symbol": "MORPHO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29837/thumb/Morpho-token-icon.png?1726771230"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
-      "name": "Degen  Base ",
-      "symbol": "DEGEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34515/thumb/android-chrome-512x512.png?1706198225"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x99ac4484e8a1dbd6a185380b3a811913ac884d87",
-      "name": "Savings Dai",
-      "symbol": "SDAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32254/thumb/sdai.png?1697015278"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3992b27da26848c2b19cea6fd25ad5568b68ab98",
-      "name": "MANTRA",
-      "symbol": "OM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12151/thumb/OM_Token.png?1696511991"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7d49a065d17d6d4a55dc13649901fdbb98b2afba",
-      "name": "Sushi",
-      "symbol": "SUSHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1696512101"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9e1028f5f1d5ede59748ffcee5532509976840e0",
-      "name": "Compound",
-      "symbol": "COMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10775/thumb/COMP.png?1696510737"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",
-      "name": "Wrapped stETH",
-      "symbol": "WSTETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18834/thumb/wstETH.png?1696518295"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbcbaf311cec8a4eac0430193a528d9ff27ae38c1",
-      "name": "IoTeX",
-      "symbol": "IOTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3334/thumb/Token_Icon_Token_Icon.png?1727899869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x22e6966b799c4d5b13be962e1d117b56327fda66",
-      "name": "Synthetix Network",
-      "symbol": "SNX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3406/thumb/SNX.png?1696504103"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x940181a94a35a4569e4529a3cdfb74e38fd98631",
-      "name": "Aerodrome Finance",
-      "symbol": "AERO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31745/thumb/token.png?1696530564"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x23ee2343b892b1bb63503a4fabc840e0e2c6810f",
-      "name": "Axelar",
-      "symbol": "AXL",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/27277/thumb/V-65_xQ1_400x400.jpeg?1696526329"
+      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+      "name": "Coinbase Wrapped BTC",
+      "symbol": "CBBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/thumb/cbbtc.webp?1726136727"
     },
     {
       "chainId": 8453,
@@ -205,51 +52,59 @@
     },
     {
       "chainId": 8453,
-      "address": "0x0db510e79909666d6dec7f5e49370838c16d950f",
-      "name": "Anon",
-      "symbol": "ANON",
+      "address": "0x2da56acb9ea78330f947bd57c54119debda7af71",
+      "name": "Mog Coin",
+      "symbol": "MOG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51871/thumb/_.png?1732095727"
+      "logoURI": "https://assets.coingecko.com/coins/images/31059/thumb/MOG_LOGO_200x200.png?1696529893"
     },
     {
       "chainId": 8453,
-      "address": "0x9c7beba8f6ef6643abd725e45a4e8387ef260649",
-      "name": "Gravity",
-      "symbol": "G",
+      "address": "0xbaa5cc21fd487b8fcc2f632f3f4e8d37262a0842",
+      "name": "Morpho",
+      "symbol": "MORPHO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39200/thumb/gravity.jpg?1721020647"
+      "logoURI": "https://assets.coingecko.com/coins/images/29837/thumb/Morpho-token-icon.png?1726771230"
     },
     {
       "chainId": 8453,
-      "address": "0xfa980ced6895ac314e7de34ef1bfae90a5add21b",
-      "name": "Echelon Prime",
-      "symbol": "PRIME",
+      "address": "0xb0ffa8000886e57f86dd5264b9582b2ad87b2b91",
+      "name": "Wormhole",
+      "symbol": "W",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29053/thumb/prime-logo-small-border_%282%29.png?1696528020"
+      "logoURI": "https://assets.coingecko.com/coins/images/35087/thumb/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954"
     },
     {
       "chainId": 8453,
-      "address": "0x4f9fd6be4a90f2620860d680c0d4d5fb53d1a825",
-      "name": "aixbt by Virtuals",
-      "symbol": "AIXBT",
+      "address": "0x3055913c90fcc1a6ce9a358911721eeb942013a1",
+      "name": "PancakeSwap",
+      "symbol": "CAKE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51784/thumb/3.png?1731981138"
+      "logoURI": "https://assets.coingecko.com/coins/images/12632/thumb/pancakeswap-cake-logo_%281%29.png?1696512440"
     },
     {
       "chainId": 8453,
-      "address": "0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42",
-      "name": "EURC",
-      "symbol": "EURC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro.png?1696525125"
+      "address": "0x9e1028f5f1d5ede59748ffcee5532509976840e0",
+      "name": "Compound",
+      "symbol": "COMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10775/thumb/COMP.png?1696510737"
     },
     {
       "chainId": 8453,
-      "address": "0xe3b53af74a4bf62ae5511055290838050bf764df",
-      "name": "Stargate Finance",
-      "symbol": "STG",
+      "address": "0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b",
+      "name": "Virtuals Protocol",
+      "symbol": "VIRTUAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1696523595"
+      "logoURI": "https://assets.coingecko.com/coins/images/34057/thumb/LOGOMARK.png?1708356054"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7d49a065d17d6d4a55dc13649901fdbb98b2afba",
+      "name": "Sushi",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1696512101"
     },
     {
       "chainId": 8453,
@@ -261,27 +116,115 @@
     },
     {
       "chainId": 8453,
-      "address": "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca",
-      "name": "Bridged USDC  Base ",
-      "symbol": "USDBC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/31164/thumb/baseusdc.jpg?1696529993"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2da56acb9ea78330f947bd57c54119debda7af71",
-      "name": "Mog Coin",
-      "symbol": "MOG",
+      "address": "0xaac78d1219c08aecc8e37e03858fe885f5ef1799",
+      "name": "Yield Guild Games",
+      "symbol": "YGG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31059/thumb/MOG_LOGO_200x200.png?1696529893"
+      "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
     },
     {
       "chainId": 8453,
-      "address": "0x50da645f148798f68ef2d7db7c1cb22a6819bb2c",
-      "name": "SPX6900",
-      "symbol": "SPX",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/31401/thumb/sticker_%281%29.jpg?1702371083"
+      "address": "0x940181a94a35a4569e4529a3cdfb74e38fd98631",
+      "name": "Aerodrome Finance",
+      "symbol": "AERO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31745/thumb/token.png?1696530564"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x22e6966b799c4d5b13be962e1d117b56327fda66",
+      "name": "Synthetix Network",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3406/thumb/SNX.png?1696504103"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3992b27da26848c2b19cea6fd25ad5568b68ab98",
+      "name": "MANTRA",
+      "symbol": "OM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12151/thumb/OM_Token.png?1696511991"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x532f27101965dd16442e59d40670faf5ebb142e4",
+      "name": "Brett",
+      "symbol": "BRETT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35529/thumb/1000050750.png?1709031995"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",
+      "name": "Wrapped stETH",
+      "symbol": "WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18834/thumb/wstETH.png?1696518295"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
+      "name": "Degen  Base ",
+      "symbol": "DEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34515/thumb/android-chrome-512x512.png?1706198225"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbcbaf311cec8a4eac0430193a528d9ff27ae38c1",
+      "name": "IoTeX",
+      "symbol": "IOTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3334/thumb/Token_Icon_Token_Icon.png?1727899869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9c7beba8f6ef6643abd725e45a4e8387ef260649",
+      "name": "Gravity",
+      "symbol": "G",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39200/thumb/gravity.jpg?1721020647"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe3b53af74a4bf62ae5511055290838050bf764df",
+      "name": "Stargate Finance",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1696523595"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+      "name": "CARV",
+      "symbol": "CARV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/thumb/CARV_%281%29.png?1728418485"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x23ee2343b892b1bb63503a4fabc840e0e2c6810f",
+      "name": "Axelar",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/thumb/V-65_xQ1_400x400.jpeg?1696526329"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfa980ced6895ac314e7de34ef1bfae90a5add21b",
+      "name": "Echelon Prime",
+      "symbol": "PRIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/thumb/prime-logo-small-border_%282%29.png?1696528020"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42",
+      "name": "EURC",
+      "symbol": "EURC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro.png?1696525125"
     },
     {
       "chainId": 8453,
@@ -293,75 +236,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0x1bc0c42215582d5a085795f4badbac3ff36d1bcb",
-      "name": "tokenbot",
-      "symbol": "CLANKER",
+      "address": "0x96419929d7949d6a801a6909c145c8eef6a40431",
+      "name": "Spectral",
+      "symbol": "SPEC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51440/thumb/CLANKER.png?1731232869"
+      "logoURI": "https://assets.coingecko.com/coins/images/36138/thumb/ls7wS7vf_400x400.jpg?1724975224"
     },
     {
       "chainId": 8453,
-      "address": "0xac1bd2486aaf3b5c0fc3fd868558b082a531b2b4",
-      "name": "Toshi",
-      "symbol": "TOSHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31126/thumb/Toshi_Logo_-_Circular.png?1721677476"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbdf317f9c153246c429f23f4093087164b145390",
-      "name": "AI Agent Layer",
-      "symbol": "AIFUN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51634/thumb/logo_400x400.png?1731686436"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22",
-      "name": "Coinbase Wrapped Staked ETH",
-      "symbol": "CBETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27008/thumb/cbeth.png?1709186989"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x259fac10c5cbfefe3e710e1d9467f70a76138d45",
-      "name": "Cartesi",
-      "symbol": "CTSI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/Cartesi_Logo.png?1696510982"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb1a03eda10342529bbf8eb700a06c60441fef25d",
-      "name": "Mister Miggles",
-      "symbol": "MIGGLES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39251/thumb/photo_2024-11-14_16-50-08_%282%29.jpg?1731814015"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2a06a17cbc6d0032cac2c6696da90f29d39a1a29",
-      "name": "HarryPotterObamaSonic10Inu  ETH ",
-      "symbol": "BITCOIN",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/30323/thumb/hpos10i_logo_casino_night-dexview.png?1696529224"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3b86ad95859b6ab773f55f8d94b4b9d443ee931f",
-      "name": "Solv Protocol SolvBTC",
-      "symbol": "SOLVBTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36800/thumb/solvBTC.png?1719810684"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376",
-      "name": "Overnight fi USD   Base ",
-      "symbol": "USD+",
+      "address": "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca",
+      "name": "Bridged USDC  Base ",
+      "symbol": "USDBC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39624/thumb/USD_.png?1723179227"
+      "logoURI": "https://assets.coingecko.com/coins/images/31164/thumb/baseusdc.jpg?1696529993"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x99ac4484e8a1dbd6a185380b3a811913ac884d87",
+      "name": "Savings Dai",
+      "symbol": "SDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32254/thumb/sdai.png?1697015278"
     },
     {
       "chainId": 8453,
@@ -381,6 +276,14 @@
     },
     {
       "chainId": 8453,
+      "address": "0x259fac10c5cbfefe3e710e1d9467f70a76138d45",
+      "name": "Cartesi",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/Cartesi_Logo.png?1696510982"
+    },
+    {
+      "chainId": 8453,
       "address": "0x4e200fe2f3efb977d5fd9c430a41531fb04d97b8",
       "name": "Orderly Network",
       "symbol": "ORDER",
@@ -389,75 +292,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0x4158734d47fc9692176b5085e0f52ee0da5d47f1",
-      "name": "Balancer",
-      "symbol": "BAL",
+      "address": "0x4f9fd6be4a90f2620860d680c0d4d5fb53d1a825",
+      "name": "aixbt by Virtuals",
+      "symbol": "AIXBT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1696511572"
+      "logoURI": "https://assets.coingecko.com/coins/images/51784/thumb/3.png?1731981138"
     },
     {
       "chainId": 8453,
-      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
-      "name": "Axelar Bridged USDC",
-      "symbol": "AXLUSDC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/26476/thumb/uausdc_D_3x.png?1696525548"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x236aa50979d5f3de3bd1eeb40e81137f22ab794b",
-      "name": "tBTC",
-      "symbol": "TBTC",
+      "address": "0xac1bd2486aaf3b5c0fc3fd868558b082a531b2b4",
+      "name": "Toshi",
+      "symbol": "TOSHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+      "logoURI": "https://assets.coingecko.com/coins/images/31126/thumb/Toshi_Logo_-_Circular.png?1721677476"
     },
     {
       "chainId": 8453,
-      "address": "0xa88594d404727625a9437c3f886c7643872296ae",
-      "name": "Moonwell",
-      "symbol": "WELL",
+      "address": "0xbdf317f9c153246c429f23f4093087164b145390",
+      "name": "AI Agent Layer",
+      "symbol": "AIFUN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26133/thumb/WELL.png?1696525221"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x64b88c73a5dfa78d1713fe1b4c69a22d7e0faaa7",
-      "name": "Maverick Protocol",
-      "symbol": "MAV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30850/thumb/MAV_Logo.png?1696529701"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",
-      "name": "L2 Standard Bridged USDT  Base ",
-      "symbol": "USDT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39963/thumb/usdt.png?1724952731"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb166e8b140d35d9d8226e40c09f757bac5a4d87d",
-      "name": "Non Playable Coin",
-      "symbol": "NPC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31193/thumb/NPC_200x200.png?1696530021"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x417ac0e078398c154edfadd9ef675d30be60af93",
-      "name": "crvUSD",
-      "symbol": "CRVUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30118/thumb/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x91ad1b44913cd1b8241a4ff1e2eaa198da6bf4c9",
-      "name": "Altura",
-      "symbol": "ALU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15127/thumb/logo-dark.png?1696514784"
+      "logoURI": "https://assets.coingecko.com/coins/images/51634/thumb/logo_400x400.png?1731686436"
     },
     {
       "chainId": 8453,
@@ -469,435 +324,43 @@
     },
     {
       "chainId": 8453,
-      "address": "0x55cd6469f597452b5a7536e2cd98fde4c1247ee4",
-      "name": "Luna by Virtuals",
-      "symbol": "LUNA",
+      "address": "0x236aa50979d5f3de3bd1eeb40e81137f22ab794b",
+      "name": "tBTC",
+      "symbol": "TBTC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50880/thumb/luna.png?1729478763"
+      "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
     },
     {
       "chainId": 8453,
-      "address": "0x750cf88d9e0c2bcedeec31d5faad6ed6e3f1abc6",
-      "name": "XCAD Network",
-      "symbol": "XCAD",
+      "address": "0x4158734d47fc9692176b5085e0f52ee0da5d47f1",
+      "name": "Balancer",
+      "symbol": "BAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15857/thumb/xcad_logo.jpg?1707832192"
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1696511572"
     },
     {
       "chainId": 8453,
-      "address": "0x731814e491571a2e9ee3c5b1f7f3b962ee8f4870",
-      "name": "VaderAI by Virtuals",
-      "symbol": "VADER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51910/thumb/vaderai.jpg?1732171696"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1c4cca7c5db003824208adda61bd749e55f463a3",
-      "name": "GAME by Virtuals",
-      "symbol": "GAME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51063/thumb/Gaming_Agent_1fe70d54ba.jpg?1729925539"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9c632e6aaa3ea73f91554f8a3cb2ed2f29605e0c",
-      "name": "Onyxcoin",
-      "symbol": "XCN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/onyxlogo.jpg?1696523397"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1185cb5122edad199bdbc0cbd7a0457e448f23c7",
-      "name": "sekoia by Virtuals",
-      "symbol": "SEKOIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51785/thumb/sekoia.jpg?1731982234"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb676f87a6e701f0de8de5ab91b56b66109766db1",
-      "name": "BLOCKLORDS",
-      "symbol": "LRDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34775/thumb/LRDS_PNG.png?1706001771"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c",
-      "name": "Rocket Pool ETH",
-      "symbol": "RETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20764/thumb/reth.png?1696520159"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
-      "name": "Renzo Restaked ETH",
-      "symbol": "EZETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34753/thumb/Ezeth_logo_circle.png?1713496404"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3e31966d4f81c72d2a55310a6365a56a4393e98d",
-      "name": "World Mobile Token",
-      "symbol": "WMTX",
+      "address": "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376",
+      "name": "Overnight fi USD   Base ",
+      "symbol": "USD+",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17333/thumb/1000097112.png?1727698144"
+      "logoURI": "https://assets.coingecko.com/coins/images/39624/thumb/USD_.png?1723179227"
     },
     {
       "chainId": 8453,
-      "address": "0x2676e4e0e2eb58d9bdb5078358ff8a3a964cedf5",
-      "name": "Polytrader by Virtuals",
-      "symbol": "POLY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52168/thumb/poly.jpg?1732682921"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x57f5fbd3de65dfc0bd3630f732969e5fb97e6d37",
-      "name": "MAGA",
-      "symbol": "TRUMP",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/31498/thumb/Maga-Trump-Logo-200px.png?1696530309"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf5bc3439f53a45607ccad667abc7daf5a583633f",
-      "name": "AgentLayer",
-      "symbol": "AGENT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50213/thumb/Logo-Mark-White_256.png?1726433757"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe3086852a4b125803c815a158249ae468a3254ca",
-      "name": "mfercoin",
-      "symbol": "MFER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36550/thumb/mfercoin-logo.png?1711876821"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x619c4bbbd65f836b78b36cbe781513861d57f39d",
-      "name": "Bitget Wallet Token",
-      "symbol": "BWB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37767/thumb/bwb.png?1715480561"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc26c9099bd3789107888c35bb41178079b282561",
-      "name": "Solv Protocol SolvBTC BBN",
-      "symbol": "SOLVBTCBBN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39384/thumb/unnamed.png?1721961640"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc48823ec67720a04a9dfd8c7d109b2c3d6622094",
-      "name": "Metacade",
-      "symbol": "MCADE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29764/thumb/Square_Profile_Photo_1080_x_1080px.png?1699396445"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x97c806e7665d3afd84a8fe1837921403d59f3dcc",
-      "name": "Artificial Liquid Intelligence",
-      "symbol": "ALI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/ALI-v2.webp?1728501978"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x63cb9a22cbc00bf9159429e9dede4b88c3dba8ce",
-      "name": "LaunchTokenBot",
-      "symbol": "CAPO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52234/thumb/f22a0bcbbfa4da6930bf8c1d37c2e0a0.jpeg?1732804814"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x18dd5b087bca9920562aff7a0199b96b9230438b",
-      "name": "Propy",
-      "symbol": "PRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1696502002"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe997017e0cb0ceb503565f181e9ea922cd979c35",
-      "name": "LimeWire",
-      "symbol": "LMWR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30356/thumb/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
-      "name": "Cookie",
-      "symbol": "COOKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38450/thumb/Cookie_FUN_logo_white.png?1732807035"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfb1aaba03c31ea98a3eec7591808acb1947ee7ac",
-      "name": "Gains Network",
-      "symbol": "GNS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19737/thumb/logo.png?1696519161"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9a26f5433671751c3276a065f57e5a02d2817973",
-      "name": "Keyboard Cat  Base ",
-      "symbol": "KEYCAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36608/thumb/keyboard_cat.jpeg?1711965348"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x029a3b0532871735809a51e8653d6017ef04b6fa",
-      "name": "TYBENG",
-      "symbol": "TYBENG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31022/thumb/NVoa_mZ6_400x400.jpg?1721805735"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0fd7a301b51d0a83fcaf6718628174d527b373b6",
-      "name": "Luminous",
-      "symbol": "LUM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51439/thumb/LUM.jpg?1731232511"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x04c0599ae5a44757c0af6f9ec3b93da8976c150a",
-      "name": "ether fi Bridged weETH  Base ",
-      "symbol": "WEETHBASE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39950/thumb/WETH.PNG?1724902237"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xedfa23602d0ec14714057867a78d01e94176bea0",
-      "name": "Wrapped rsETH",
-      "symbol": "WRSETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37919/thumb/rseth.png?1715936438"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x41e0fe1317bd6e8944b037cd59b22d428c1434c2",
-      "name": "Virtu by Virtuals",
-      "symbol": "VIRTU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51827/thumb/_removal.ai__24fd4161-77b5-412f-b553-a99e9012f575_photo_2024-11-07_08-05-59.png?1732042711"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
-      "name": "OX Coin",
-      "symbol": "OX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35365/thumb/9.png?1727331352"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x04055057677807d2a53d2b25a80ff3b4d932ae1a",
-      "name": "LogX Network",
-      "symbol": "LOGX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50226/thumb/Token_200px.png?1726556358"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x50c5725949a6f0c72e6c4a641f24049a917db0cb",
-      "name": "L2 Standard Bridged DAI  Base ",
-      "symbol": "DAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39807/thumb/dai.png?1724126571"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0f1cfd0bb452db90a3bfc0848349463010419ab2",
-      "name": "Guru Network",
-      "symbol": "GURU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38583/thumb/tGURU_token_circle.png?1718087986"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd6aaf4d477999fa50c5a1aa35f708862113a73cc",
-      "name": "Propbase",
-      "symbol": "PROPS",
+      "address": "0x50da645f148798f68ef2d7db7c1cb22a6819bb2c",
+      "name": "SPX6900",
+      "symbol": "SPX",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/32932/thumb/PROP_BASE_%286%29.png?1699870054"
+      "logoURI": "https://assets.coingecko.com/coins/images/31401/thumb/sticker_%281%29.jpg?1702371083"
     },
     {
       "chainId": 8453,
-      "address": "0x04d5ddf5f3a8939889f11e97f8c4bb48317f1938",
-      "name": "Anzen USDz",
-      "symbol": "USDZ",
+      "address": "0x64b88c73a5dfa78d1713fe1b4c69a22d7e0faaa7",
+      "name": "Maverick Protocol",
+      "symbol": "MAV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38039/thumb/usdz-image-200x200.png?1716334412"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x15ac90165f8b45a80534228bdcb124a011f62fee",
-      "name": "MOEW",
-      "symbol": "MOEW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36737/thumb/MOEW.jpeg?1712210114"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x98f4779fccb177a6d856dd1dfd78cd15b7cd2af5",
-      "name": "MISATO",
-      "symbol": "MISATO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52231/thumb/misatocleanboost.png?1732802425"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcc0adb6c436eb1f65b2f27733bf926691b94c5f1",
-      "name": "Guanciale by Virtuals",
-      "symbol": "GUAN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51865/thumb/guanciale.jpeg?1732173396"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbc45647ea894030a4e9801ec03479739fa2485f0",
-      "name": "Basenji",
-      "symbol": "BENJI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36416/thumb/ben200x200.jpg?1711420807"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6b2504a03ca4d43d0d73776f6ad46dab2f2a4cfd",
-      "name": "Unit 00   Rei",
-      "symbol": "REI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52005/thumb/Unit_00_-_Rei.jpg?1732592775"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x98d59767cd1335071a4e9b9d3482685c915131e8",
-      "name": "DREAM",
-      "symbol": "DREAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52029/thumb/dream-logo.png?1732358413"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4621b7a9c75199271f773ebd9a499dbd165c3191",
-      "name": "DOLA",
-      "symbol": "DOLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14287/thumb/dola.png?1696513984"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe2b1dc2d4a3b4e59fdf0c47b71a7a86391a8b35a",
-      "name": "RWA Inc ",
-      "symbol": "RWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50975/thumb/logo_%281%29.png?1732594737"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc7dcca0a3e69bd762c8db257f868f76be36c8514",
-      "name": "KiboShib",
-      "symbol": "KIBSHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29335/thumb/foto_no_exif_%2811%29%282%29_%281%29.png?1696528285"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x32e0f9d26d1e33625742a52620cc76c1130efde6",
-      "name": "BASED",
-      "symbol": "BASED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39669/thumb/BASED.jpg?1723603780"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2c8c89c442436cc6c0a77943e09c8daf49da3161",
-      "name": "Zeebu",
-      "symbol": "ZBU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31145/thumb/200x200_Front_token.png?1696529974"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1dd2d631c92b1acdfcdd51a0f7145a50130050c4",
-      "name": "Alien Base",
-      "symbol": "ALB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31301/thumb/ALB.png?1720133373"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x368181499736d0c0cc614dbb145e2ec1ac86b8c6",
-      "name": "Liquity USD",
-      "symbol": "LUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1696514341"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4",
-      "name": "Electronic USD",
-      "symbol": "EUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28445/thumb/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x858c50c3af1913b0e849afdb74617388a1a5340d",
-      "name": "SubQuery Network",
-      "symbol": "SQT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23359/thumb/LinkedIn_Avatar_Op1.png?1724379155"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc43f3ae305a92043bd9b62ebd2fe14f7547ee485",
-      "name": "CHEX Token",
-      "symbol": "CHEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10349/thumb/logo-dark-200.png?1701121978"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfbb75a59193a3525a8825bebe7d4b56899e2f7e1",
-      "name": "ResearchCoin",
-      "symbol": "RSC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28146/thumb/RH_BOTTLE_CLEAN_Aug_2024_1.png?1732742001"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x38815a4455921667d673b4cb3d48f0383ee93400",
-      "name": "pSTAKE Finance",
-      "symbol": "PSTAKE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23931/thumb/512_x_512_Dark.png?1721243699"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd3c68968137317a57a9babeacc7707ec433548b4",
-      "name": "Phavercoin",
-      "symbol": "SOCIAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50304/thumb/Phavercoin-_Social-MAIN-purple-logo-square.png?1727024458"
+      "logoURI": "https://assets.coingecko.com/coins/images/30850/thumb/MAV_Logo.png?1696529701"
     },
     {
       "chainId": 8453,
@@ -909,675 +372,147 @@
     },
     {
       "chainId": 8453,
-      "address": "0xcb327b99ff831bf8223cced12b1338ff3aa322ff",
-      "name": "Based ETH",
-      "symbol": "BSDETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35774/thumb/Icon_White_on_Blue.png?1709793654"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfb0c734fc3008683c5eff45bcf8128836c4d97d0",
-      "name": "Vertex",
-      "symbol": "VRTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27927/thumb/vrtx.png?1696526947"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xafb89a09d82fbde58f18ac6437b3fc81724e4df6",
-      "name": "The Doge NFT",
-      "symbol": "DOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18111/thumb/Doge.png?1696517615"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x890a40bfae3bf25a5e7c50a31505774ee7a5d33b",
-      "name": "Worldwide USD",
-      "symbol": "WUSD",
+      "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",
+      "name": "L2 Standard Bridged USDT  Base ",
+      "symbol": "USDT",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35358/thumb/WUSD%282%29.png?1715042139"
+      "logoURI": "https://assets.coingecko.com/coins/images/39963/thumb/usdt.png?1724952731"
     },
     {
       "chainId": 8453,
-      "address": "0xbb22ff867f8ca3d5f2251b4084f6ec86d4666e14",
-      "name": "Cryptex Finance",
-      "symbol": "CTX",
+      "address": "0x0db510e79909666d6dec7f5e49370838c16d950f",
+      "name": "Anon",
+      "symbol": "ANON",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/CTX_Logo_200px.png?1723514786"
+      "logoURI": "https://assets.coingecko.com/coins/images/51871/thumb/_.png?1732095727"
     },
     {
       "chainId": 8453,
-      "address": "0x9e81f6495ba29a6b4d48bddd042c0598fa8abc9f",
-      "name": "MATH",
-      "symbol": "MATH",
+      "address": "0xb1a03eda10342529bbf8eb700a06c60441fef25d",
+      "name": "Mister Miggles",
+      "symbol": "MIGGLES",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1696511257"
+      "logoURI": "https://assets.coingecko.com/coins/images/39251/thumb/photo_2024-11-14_16-50-08_%282%29.jpg?1731814015"
     },
     {
       "chainId": 8453,
-      "address": "0x01facc69ec7360640aa5898e852326752801674a",
-      "name": "Fuse",
-      "symbol": "FUSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10347/thumb/fuse.png?1696510348"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x29e39327b5b1e500b87fc0fcae3856cd8f96ed2a",
-      "name": "Bark Ruffalo by Virtuals",
-      "symbol": "PAWSY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52205/thumb/00_Avatar_200x200.png?1732736729"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x39fed555ff57cb1154bfa6b1a2492bb914ce2d9b",
-      "name": "EchoLeaks by Virtuals",
-      "symbol": "ECHO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52172/thumb/echoleaks.jpg?1732683705"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2615a94df961278dcbc41fb0a54fec5f10a693ae",
-      "name": "Wrapped XRP  Universal ",
-      "symbol": "UXRP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51658/thumb/UA-XRP_1.png?1731703523"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x511ef9ad5e645e533d15df605b4628e3d0d0ff53",
-      "name": "Velvet Unicorn by Virtuals",
-      "symbol": "VU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52175/thumb/velvet_unicorn.jpg?1732684869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
-      "name": "Pocket Network",
-      "symbol": "POKT",
+      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
+      "name": "Axelar Bridged USDC",
+      "symbol": "AXLUSDC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/22506/thumb/POKT.jpg?1703257310"
+      "logoURI": "https://assets.coingecko.com/coins/images/26476/thumb/uausdc_D_3x.png?1696525548"
     },
     {
       "chainId": 8453,
-      "address": "0xaa6cccdce193698d33deb9ffd4be74eaa74c4898",
-      "name": "ElonRWA",
-      "symbol": "ELONRWA",
+      "address": "0x417ac0e078398c154edfadd9ef675d30be60af93",
+      "name": "crvUSD",
+      "symbol": "CRVUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36970/thumb/elonrwa.png?1712910039"
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/thumb/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
     },
     {
       "chainId": 8453,
-      "address": "0x60d01ec2d5e98ac51c8b4cf84dfcce98d527c747",
-      "name": "iZUMi Finance",
-      "symbol": "IZI",
+      "address": "0x67f0870bb897f5e1c369976b4a2962d527b9562c",
+      "name": "Department Of Government Efficiency",
+      "symbol": "DOGE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21791/thumb/izumi-logo-symbol.png?1696521144"
+      "logoURI": "https://assets.coingecko.com/coins/images/39841/thumb/IMG_9775.PNG?1729771739"
     },
     {
       "chainId": 8453,
-      "address": "0xc0fbc4967259786c743361a5885ef49380473dcf",
-      "name": "Aleph im",
-      "symbol": "ALEPH",
+      "address": "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22",
+      "name": "Coinbase Wrapped Staked ETH",
+      "symbol": "CBETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Aleph-Logo-BW.png?1696511566"
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/thumb/cbeth.png?1709186989"
     },
     {
       "chainId": 8453,
-      "address": "0x99298c6be0e8ec9e56b7a2be5850abe1fc109d94",
-      "name": "Degen Capital by Virtuals",
-      "symbol": "DEGENC",
+      "address": "0x1bc0c42215582d5a085795f4badbac3ff36d1bcb",
+      "name": "tokenbot",
+      "symbol": "CLANKER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52246/thumb/Degen_Capital_DEGENC.png?1732824263"
+      "logoURI": "https://assets.coingecko.com/coins/images/51440/thumb/CLANKER.png?1731232869"
     },
     {
       "chainId": 8453,
-      "address": "0xeb6d78148f001f3aa2f588997c5e102e489ad341",
-      "name": "Super Champs",
-      "symbol": "CHAMP",
+      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51900/thumb/CHAMP_Token_256x256.png?1732131989"
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/thumb/Ezeth_logo_circle.png?1713496404"
     },
     {
       "chainId": 8453,
-      "address": "0x9b8df6e244526ab5f6e6400d331db28c8fdddb55",
-      "name": "Wrapped Solana  Universal ",
-      "symbol": "USOL",
+      "address": "0xa88594d404727625a9437c3f886c7643872296ae",
+      "name": "Moonwell",
+      "symbol": "WELL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39987/thumb/UA-SOL_1.png?1725027946"
+      "logoURI": "https://assets.coingecko.com/coins/images/26133/thumb/WELL.png?1696525221"
     },
     {
       "chainId": 8453,
-      "address": "0x4e719699e4197f4bf4370c49acd3e3b8de11974f",
-      "name": "Lovely Inu Finance",
-      "symbol": "LOVELY",
+      "address": "0xb166e8b140d35d9d8226e40c09f757bac5a4d87d",
+      "name": "Non Playable Coin",
+      "symbol": "NPC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19053/thumb/lovely-inu-logo-new.png?1696518503"
+      "logoURI": "https://assets.coingecko.com/coins/images/31193/thumb/NPC_200x200.png?1696530021"
     },
     {
       "chainId": 8453,
-      "address": "0x1a43287cbfcc5f35082e6e2aa98e5b474fe7bd4e",
-      "name": "Athena by Virtuals",
-      "symbol": "ATHENA",
+      "address": "0x9c632e6aaa3ea73f91554f8a3cb2ed2f29605e0c",
+      "name": "Onyxcoin",
+      "symbol": "XCN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52006/thumb/athenalogo.png?1732304469"
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/onyxlogo.jpg?1696523397"
     },
     {
       "chainId": 8453,
-      "address": "0x18e692c03de43972fe81058f322fa542ae1a5e2c",
-      "name": "imgnAI",
-      "symbol": "IMGNAI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/28666/thumb/imgnai-200x200.png?1698476572"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb0505e5a99abd03d94a1169e638b78edfed26ea4",
-      "name": "Wrapped SUI  Universal ",
-      "symbol": "USUI",
+      "address": "0x91ad1b44913cd1b8241a4ff1e2eaa198da6bf4c9",
+      "name": "Altura",
+      "symbol": "ALU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50482/thumb/UA-SUI-PAD.png?1727888681"
+      "logoURI": "https://assets.coingecko.com/coins/images/15127/thumb/logo-dark.png?1696514784"
     },
     {
       "chainId": 8453,
-      "address": "0xcde172dc5ffc46d228838446c57c1227e0b82049",
-      "name": "Boomer",
-      "symbol": "BOOMER",
+      "address": "0xfb1aaba03c31ea98a3eec7591808acb1947ee7ac",
+      "name": "Gains Network",
+      "symbol": "GNS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36477/thumb/Token_Image_200x200.png?1714757172"
+      "logoURI": "https://assets.coingecko.com/coins/images/19737/thumb/logo.png?1696519161"
     },
     {
       "chainId": 8453,
-      "address": "0xbdf5bafee1291eec45ae3aadac89be8152d4e673",
-      "name": "Catamoto",
-      "symbol": "CATA",
+      "address": "0xd89d90d26b48940fa8f58385fe84625d468e057a",
+      "name": "Avail",
+      "symbol": "AVAIL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37218/thumb/200x200.png?1713774219"
+      "logoURI": "https://assets.coingecko.com/coins/images/37372/thumb/avail-logo.png?1714145201"
     },
     {
       "chainId": 8453,
-      "address": "0x9a33406165f562e16c3abd82fd1185482e01b49a",
-      "name": "Talent Protocol",
-      "symbol": "TALENT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51120/thumb/Ticker-logo-200.png?1730128751"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x698b49063c14d2753d23064ff891a876cffa6fb5",
-      "name": "NIKITA by Virtuals",
-      "symbol": "NIKITA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52146/thumb/Nikita_Pic.png?1732652736"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066",
-      "name": "Rug World Assets",
-      "symbol": "RWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37119/thumb/0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066.jpg?1713356569"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6921b130d297cc43754afba22e5eac0fbf8db75b",
-      "name": "doginme",
-      "symbol": "DOGINME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35123/thumb/doginme-logo1-transparent200.png?1710856784"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x455234ab787665a219125235fb01b22b512dfcaa",
-      "name": "DOSE",
-      "symbol": "DOSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18847/thumb/dose.PNG?1696518308"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3124678d62d2aa1f615b54525310fbfda6dcf7ae",
-      "name": "Sensay",
-      "symbol": "SNSY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36121/thumb/sensay.jpeg?1710495398"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2d189eabb667aa1ecfc01963a6a3a5d83960f558",
-      "name": "GALAXIS Token",
-      "symbol": "GALAXIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36221/thumb/500x500.png?1714755244"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xea651c035f52b644856cab1f59775369c36ecadd",
-      "name": "La ka",
-      "symbol": "LAIKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39364/thumb/logo_laika.jpg?1721895773"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0bbbead62f7647ae8323d2cb243a0db74b7c2b80",
-      "name": "Ambire Wallet",
-      "symbol": "WALLET",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23154/thumb/wallet.PNG?1696522445"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x54b659832f59c24cec0e4a2cd193377f1bcefc3c",
-      "name": "Akashalife",
-      "symbol": "AK1111",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50533/thumb/Akasha-CoinIcon_%283%29.png?1728206155"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfe550bffb51eb645ea3b324d772a19ac449e92c5",
-      "name": "IX Swap",
-      "symbol": "IXS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18069/thumb/ixswap.PNG?1696517577"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd2012fc1b913ce50732ebcaa7e601fe37ac728c6",
-      "name": "StakeStone ETH",
-      "symbol": "STONE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33103/thumb/200_200.png?1702602672"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf3708859c178709d5319ad5405bc81511b72b9e9",
-      "name": "Aethernet",
-      "symbol": "AETHER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51065/thumb/Aether_Farcaster_frame.png?1729943869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1db0c569ebb4a8b57ac01833b9792f526305e062",
-      "name": "GenomesDAO GENOME",
-      "symbol": "GENOME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36763/thumb/images.jpg?1712282056"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd07379a755a8f11b57610154861d694b2a0f615a",
-      "name": "Base",
-      "symbol": "BASE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31199/thumb/59302ba8-022e-45a4-8d00-e29fe2ee768c-removebg-preview.png?1696530026"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x24569d33653c404f90af10a2b98d6e0030d3d267",
-      "name": "Unagi Token",
-      "symbol": "UNA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34733/thumb/unagi.png?1705922276"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x703d57164ca270b0b330a87fd159cfef1490c0a5",
-      "name": "RAI Finance",
-      "symbol": "SOFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14686/thumb/sofi.png?1696514359"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x645c7aa841087e2e7f741c749ab27422ff5bba8e",
-      "name": "Iona by Virtuals",
-      "symbol": "IONA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52166/thumb/iona.jpg?1732682259"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1c7a460413dd4e964f96d8dfc56e7223ce88cd85",
-      "name": "Seamless Protocol",
-      "symbol": "SEAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33480/thumb/Seamless_Logo_Black_Transparent.png?1702019657"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x27e3bc3a66e24cad043ac3d93a12a8070e3897ba",
-      "name": "Ovr",
-      "symbol": "OVR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13429/thumb/LOGO-OVER-ICON-200X200PX.png?1699396496"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c03ce270b4826ec62e7dd007f0b716068639f7b",
-      "name": "The Innovation Game",
-      "symbol": "TIG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50669/thumb/TIG_Logo_200x200.png?1729604604"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8216e8143902a8fe0b676006bc25eb23829c123d",
-      "name": "Wow",
-      "symbol": "WOW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51527/thumb/23bafybeialew5mz6o2d6abynkd7kafunbgcgxcatyjdr5s2mgr4ae4zeltwe_%281%29.jpg?1731497334"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x23a96680ccde03bd4bdd9a3e9a0cb56a5d27f7c9",
-      "name": "Henlo",
-      "symbol": "HENLO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52083/thumb/henlo.webp?1732532244"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfd4330b0312fdeec6d4225075b82e00493ff2e3f",
-      "name": "SmarDex",
-      "symbol": "SDEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29470/thumb/SDEX_logo_transparent_outside_240x240.png?1696930070"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdaf3c78f165d26f821d3d39d6598a96e962b1508",
-      "name": "The Css God by Virtuals",
-      "symbol": "WEBSIM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52173/thumb/the_css_god.jpg?1732684452"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3c281a39944a2319aa653d81cfd93ca10983d234",
-      "name": "Build",
-      "symbol": "BUILD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37836/thumb/buildlogo.png?1715741487"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x52b492a33e447cdb854c7fc19f1e57e8bfa1777d",
-      "name": "Based Pepe",
-      "symbol": "PEPE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39763/thumb/based_pepe_transparent.png?1724010222"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3c4b6cd7874edc945797123fce2d9a871818524b",
-      "name": "PARADOX",
-      "symbol": "PARADOX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51590/thumb/IMG_1408.jpeg?1731570502"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0d97f261b1e88845184f678e2d1e7a98d9fd38de",
-      "name": "Base God",
-      "symbol": "TYBG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34563/thumb/tybg.png?1705400778"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x85e90a5430af45776548adb82ee4cd9e33b08077",
-      "name": "Coding Dino",
-      "symbol": "DINO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36637/thumb/dino_icon_copy.png?1712029544"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
-      "name": "Gyroscope GYD",
-      "symbol": "GYD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33428/thumb/GYD-gradient_resized_transparent.png?1702316822"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdfbea88c4842d30c26669602888d746d30f9d60d",
-      "name": "crow with knife",
-      "symbol": "CAW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36067/thumb/200px.png?1710405601"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9b700b043e9587dde9a0c29a9483e2f8fa450d54",
-      "name": "AxonDAO Governance Token",
-      "symbol": "AXGT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35290/thumb/AXGT-logo-7.png?1708076161"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0578d8a44db98b23bf096a382e016e29a5ce0ffe",
-      "name": "higher",
-      "symbol": "HIGHER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36084/thumb/200x200logo.png?1710427814"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4e74d4db6c0726ccded4656d0bce448876bb4c7a",
-      "name": "Wrapped BMX Liquidity Token",
-      "symbol": "WBLT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31532/thumb/wBLT_200x200.png?1696530341"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5d9c2457a10d455e0ad8e28e40cc28eacf27a06a",
-      "name": "GM Everyday",
-      "symbol": "GM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52139/thumb/sRavZnte_.png?1732642259"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6d3b8c76c5396642960243febf736c6be8b60562",
-      "name": "Skull of Pepe Token",
-      "symbol": "SKOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38342/thumb/skop.jpeg?1717141011"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x92dc4ab92eb16e781559e612f349916988013d5a",
-      "name": "Agent Zero",
-      "symbol": "WSB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51310/thumb/photo_2024-11-03_07-33-29.jpg?1730643955"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc7edf7b7b3667a06992508e7b156eff794a9e1c8",
-      "name": "Persistence One",
-      "symbol": "XPRT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/14582/thumb/Download%28black_Dark%29.png?1723470571"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x354d6890caa31a5e28b6059d46781f40880786a6",
-      "name": "ghffb47yii2rteeyy10op",
-      "symbol": "GHFFB47YII2RTEEYY10",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52104/thumb/0x354d6890caa31a5e28b6059d46781f40880786a6.png?1732591949"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbfefd7a0eda8a0feb06d0f52cf431afd0f9b2dd0",
-      "name": "Wokie Plumpkin by Virtuals",
-      "symbol": "WOKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52176/thumb/wokie.jpg?1732685106"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2c002ffec41568d138acc36f5894d6156398d539",
-      "name": "Lucky Dog",
-      "symbol": "LUCKY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51334/thumb/LUCKYTokenSymbol.png?1730797716"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb488fcb23333e7baa28d1dfd7b69a5d3a8bfeb3a",
-      "name": "Terminal",
-      "symbol": "TERMINAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51477/thumb/terminalLogo.png?1731403786"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c5142bc58f9a61ab8c3d2085dd2f4e550c5ce0b",
-      "name": "RUSSELL",
-      "symbol": "RUSSELL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50690/thumb/russelllogo.png?1730010143"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf2d3d488626a117984fda70f8106abc0049018d3",
-      "name": "Miracle Play",
-      "symbol": "MPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32653/thumb/MPT.png?1698895300"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf0268c5f9aa95baf5c25d646aabb900ac12f0800",
-      "name": "RealGoat",
-      "symbol": "RGOAT",
+      "address": "0xecac9c5f704e954931349da37f60e39f515c11c1",
+      "name": "Lombard Staked BTC",
+      "symbol": "LBTC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/38923/thumb/IMG_20240625_033037_003.jpg?1719521003"
+      "logoURI": "https://assets.coingecko.com/coins/images/39969/thumb/LBTC_Logo.png?1724959872"
     },
     {
       "chainId": 8453,
-      "address": "0xdcefd8c8fcc492630b943abcab3429f12ea9fea2",
-      "name": "KlimaDAO",
-      "symbol": "KLIMA",
+      "address": "0xe997017e0cb0ceb503565f181e9ea922cd979c35",
+      "name": "LimeWire",
+      "symbol": "LMWR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19169/thumb/Klima-Token.png?1696518618"
+      "logoURI": "https://assets.coingecko.com/coins/images/30356/thumb/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
     },
     {
       "chainId": 8453,
-      "address": "0x2eac9b08a4d86f347b9e856fb3ec082e61c76545",
-      "name": "AIRENE by Virtuals",
-      "symbol": "AIRENE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51485/thumb/airene_icon_1to1.png?1731405207"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa7d68d155d17cb30e311367c2ef1e82ab6022b67",
-      "name": "Braintrust",
-      "symbol": "BTRST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1696517605"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x614577036f0a024dbc1c88ba616b394dd65d105a",
-      "name": "GENIUS AI",
-      "symbol": "GNUS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36914/thumb/IMG_5346.png?1712769235"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0a953dd9fc813fefaf6015b804c9dfa0624690c0",
-      "name": "Cornucopias",
-      "symbol": "COPI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21452/thumb/g56WwJDA_400x400.jpg?1696520814"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x91273b316240879fd902c0c3fcf7c0158777b42f",
-      "name": "Olyn by Virtuals",
-      "symbol": "OLYN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52167/thumb/olyn.jpg?1732682477"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
-      "name": "Truflation",
-      "symbol": "TRUF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36642/thumb/e52f62a0-96a1-11ef-b151-8e2df017c507.jpg?1730305274"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x548f93779fbc992010c07467cbaf329dd5f059b7",
-      "name": "BMX",
-      "symbol": "BMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31699/thumb/bmx_white.png?1696530517"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8fbd0648971d56f1f2c35fa075ff5bc75fb0e39d",
-      "name": "UNKJD",
-      "symbol": "MBS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20841/thumb/monkeyball.png?1696520233"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
-      "name": "Seedworld",
-      "symbol": "SWORLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51000/thumb/IMG_2798.PNG?1729685531"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
-      "name": "Any Inu",
-      "symbol": "AI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34126/thumb/anyinulogo200.png?1704174269"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x461ee40928677644b8195662ab91bcdaae6ef105",
-      "name": "Dook",
-      "symbol": "DOOK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38594/thumb/P3oYXNbf_400x400.jpeg?1718927359"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf31e6d62bfc485857af2186eb3d8ee94b4379fed",
-      "name": "Chinese Doge Wow",
-      "symbol": "CHIDO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52054/thumb/1.png?1732449299"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x49c86046903807d0a3193a221c1a3e1b1b6c9ba3",
-      "name": "CYI by Virtuals",
-      "symbol": "CYI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52125/thumb/Cryptoyieldinfo.jpg?1732611368"
+      "address": "0x2a06a17cbc6d0032cac2c6696da90f29d39a1a29",
+      "name": "HarryPotterObamaSonic10Inu  ETH ",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/30323/thumb/hpos10i_logo_casino_night-dexview.png?1696529224"
     },
     {
       "chainId": 8453,
@@ -1589,67 +524,211 @@
     },
     {
       "chainId": 8453,
-      "address": "0xa3a34a0d9a08ccddb6ed422ac0a28a06731335aa",
-      "name": "Wrapped ADA  Universal ",
-      "symbol": "UADA",
+      "address": "0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c",
+      "name": "Rocket Pool ETH",
+      "symbol": "RETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51868/thumb/UA-ADA.png?1732095196"
+      "logoURI": "https://assets.coingecko.com/coins/images/20764/thumb/reth.png?1696520159"
     },
     {
       "chainId": 8453,
-      "address": "0x9aaae745cf2830fb8ddc6248b17436dc3a5e701c",
-      "name": "Gochujangcoin",
-      "symbol": "GOCHU",
+      "address": "0xb0505e5a99abd03d94a1169e638b78edfed26ea4",
+      "name": "Wrapped SUI  Universal ",
+      "symbol": "USUI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39318/thumb/GochujangLogo_200_3x.png?1721709656"
+      "logoURI": "https://assets.coingecko.com/coins/images/50482/thumb/UA-SUI-PAD.png?1727888681"
     },
     {
       "chainId": 8453,
-      "address": "0x6112b8714221bbd96ae0a0032a683e38b475d06c",
-      "name": "WAI Combinator by Virtuals",
-      "symbol": "WAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52181/thumb/wai.jpg?1732689732"
+      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
+      "name": "Pocket Network",
+      "symbol": "POKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22506/thumb/POKT.jpg?1703257310"
     },
     {
       "chainId": 8453,
-      "address": "0x5ed25e305e08f58afd7995eac72563e6be65a617",
-      "name": "Wrapped NEAR  Universal ",
-      "symbol": "UNEAR",
+      "address": "0xf5bc3439f53a45607ccad667abc7daf5a583633f",
+      "name": "AgentLayer",
+      "symbol": "AGENT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50645/thumb/UA-NEAR_1.png?1728579564"
+      "logoURI": "https://assets.coingecko.com/coins/images/50213/thumb/Logo-Mark-White_256.png?1726433757"
     },
     {
       "chainId": 8453,
-      "address": "0x3ee5e23eee121094f1cfc0ccc79d6c809ebd22e5",
-      "name": "Ionic Protocol",
-      "symbol": "ION",
+      "address": "0x619c4bbbd65f836b78b36cbe781513861d57f39d",
+      "name": "Bitget Wallet Token",
+      "symbol": "BWB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36713/thumb/Ionic-icon-green.png?1712127547"
+      "logoURI": "https://assets.coingecko.com/coins/images/37767/thumb/bwb.png?1715480561"
     },
     {
       "chainId": 8453,
-      "address": "0xff0c532fdb8cd566ae169c1cb157ff2bdc83e105",
-      "name": "Fren Pet",
-      "symbol": "FP",
+      "address": "0x161e113b8e9bbaefb846f73f31624f6f9607bd44",
+      "name": "Simmi Token",
+      "symbol": "SIMMI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33022/thumb/token.png?1700274697"
+      "logoURI": "https://assets.coingecko.com/coins/images/52349/thumb/simmi.png?1733160996"
     },
     {
       "chainId": 8453,
-      "address": "0xebff2db643cf955247339c8c6bcd8406308ca437",
-      "name": "ChompCoin",
-      "symbol": "CHOMP",
+      "address": "0x04c0599ae5a44757c0af6f9ec3b93da8976c150a",
+      "name": "ether fi Bridged weETH  Base ",
+      "symbol": "WEETHBASE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36942/thumb/chomplogo200.png?1712864472"
+      "logoURI": "https://assets.coingecko.com/coins/images/39950/thumb/WETH.PNG?1724902237"
     },
     {
       "chainId": 8453,
-      "address": "0x2974dc646e375e83bd1c0342625b49f288987fa4",
-      "name": "Swarm Markets",
-      "symbol": "SMT",
+      "address": "0x9a26f5433671751c3276a065f57e5a02d2817973",
+      "name": "Keyboard Cat  Base ",
+      "symbol": "KEYCAT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17488/thumb/swarm-SMT-token-symbol_200x200.png?1696517029"
+      "logoURI": "https://assets.coingecko.com/coins/images/36608/thumb/keyboard_cat.jpeg?1711965348"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x20d704099b62ada091028bcfc44445041ed16f09",
+      "name": "Chaos",
+      "symbol": "CHAOS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52444/thumb/chaos-2.jpg?1733365634"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3b86ad95859b6ab773f55f8d94b4b9d443ee931f",
+      "name": "Solv Protocol SolvBTC",
+      "symbol": "SOLVBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36800/thumb/solvBTC.png?1719810684"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3e31966d4f81c72d2a55310a6365a56a4393e98d",
+      "name": "World Mobile Token",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/thumb/1000097112.png?1727698144"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x57f5fbd3de65dfc0bd3630f732969e5fb97e6d37",
+      "name": "MAGA",
+      "symbol": "TRUMP",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/31498/thumb/Maga-Trump-Logo-200px.png?1696530309"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc48823ec67720a04a9dfd8c7d109b2c3d6622094",
+      "name": "Metacade",
+      "symbol": "MCADE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29764/thumb/Square_Profile_Photo_1080_x_1080px.png?1699396445"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc0fbc4967259786c743361a5885ef49380473dcf",
+      "name": "Aleph im",
+      "symbol": "ALEPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Aleph-Logo-BW.png?1696511566"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x50c5725949a6f0c72e6c4a641f24049a917db0cb",
+      "name": "L2 Standard Bridged DAI  Base ",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39807/thumb/dai.png?1724126571"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc43f3ae305a92043bd9b62ebd2fe14f7547ee485",
+      "name": "CHEX Token",
+      "symbol": "CHEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10349/thumb/logo-white-bg-dark.png?1733475849"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x97c806e7665d3afd84a8fe1837921403d59f3dcc",
+      "name": "Artificial Liquid Intelligence",
+      "symbol": "ALI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/ALI-v2.webp?1728501978"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x23a96680ccde03bd4bdd9a3e9a0cb56a5d27f7c9",
+      "name": "Henlo",
+      "symbol": "HENLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52083/thumb/henlo.webp?1732532244"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/thumb/9.png?1727331352"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe2b1dc2d4a3b4e59fdf0c47b71a7a86391a8b35a",
+      "name": "RWA Inc ",
+      "symbol": "RWA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50975/thumb/logo_%281%29.png?1732594737"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x18dd5b087bca9920562aff7a0199b96b9230438b",
+      "name": "Propy",
+      "symbol": "PRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1696502002"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa6f774051dfb6b54869227fda2df9cb46f296c09",
+      "name": "SKI MASK CAT",
+      "symbol": "SKICAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52355/thumb/logo200x.png?1733168346"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4621b7a9c75199271f773ebd9a499dbd165c3191",
+      "name": "DOLA",
+      "symbol": "DOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/thumb/dola.png?1696513984"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x029a3b0532871735809a51e8653d6017ef04b6fa",
+      "name": "TYBENG",
+      "symbol": "TYBENG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31022/thumb/NVoa_mZ6_400x400.jpg?1721805735"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x455234ab787665a219125235fb01b22b512dfcaa",
+      "name": "DOSE",
+      "symbol": "DOSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18847/thumb/dose.PNG?1696518308"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb676f87a6e701f0de8de5ab91b56b66109766db1",
+      "name": "BLOCKLORDS",
+      "symbol": "LRDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34775/thumb/LRDS_PNG.png?1706001771"
     },
     {
       "chainId": 8453,
@@ -1661,731 +740,51 @@
     },
     {
       "chainId": 8453,
-      "address": "0x0808bf94d57c905f1236212654268ef82e1e594e",
-      "name": "ritestream",
-      "symbol": "RITE",
+      "address": "0xf31e6d62bfc485857af2186eb3d8ee94b4379fed",
+      "name": "Chinese Doge Wow",
+      "symbol": "CHIDO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24130/thumb/rite.png?1696523321"
+      "logoURI": "https://assets.coingecko.com/coins/images/52054/thumb/1.png?1732449299"
     },
     {
       "chainId": 8453,
-      "address": "0x18a8bd1fe17a1bb9ffb39ecd83e9489cfd17a022",
-      "name": "Andy",
-      "symbol": "ANDY",
+      "address": "0xe3086852a4b125803c815a158249ae468a3254ca",
+      "name": "mfercoin",
+      "symbol": "MFER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36552/thumb/ANDY.jpg?1711896298"
+      "logoURI": "https://assets.coingecko.com/coins/images/36550/thumb/mfercoin-logo.png?1711876821"
     },
     {
       "chainId": 8453,
-      "address": "0x36912b5cf63e509f18e53ac98b3012fa79e77bf5",
-      "name": "FUEGO",
-      "symbol": "FUEGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51345/thumb/FUEGO_200x200.jpg?1730825086"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x489fe42c267fe0366b16b0c39e7aeef977e841ef",
-      "name": "Wrapped Ampleforth",
-      "symbol": "WAMPL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1696520218"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x717d31a60a9e811469673429c9f8ea24358990f1",
-      "name": "Everyworld",
-      "symbol": "EVERY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36799/thumb/coin_gecko.png?1714459237"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c41f1fc9022feb69af6dc666abfe73c9ffda7ce",
-      "name": "Bitcoin on Base",
-      "symbol": "BTCB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38868/thumb/BTCB_Official_Logo_July_2024.png?1721753012"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa0a2e84f6f19c09a095d4a83ac8de5a32d303a13",
-      "name": "Lil Brett",
-      "symbol": "LILB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51813/thumb/%28100_x_100_px%29.png?1732029374"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
-      "name": "Dexalot",
-      "symbol": "ALOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24188/thumb/logo_200x200.png?1696523376"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x47b464edb8dc9bc67b5cd4c9310bb87b773845bd",
-      "name": "NORMIE",
-      "symbol": "NORMIE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/35880/thumb/NORMIEsite.png?1709983341"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x99b2b1a2adb02b38222adcd057783d7e5d1fcc7d",
-      "name": "Common Wealth",
-      "symbol": "WLTH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37858/thumb/WLTH_TICKER_200x200.png?1730241264"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9c0e042d65a2e1ff31ac83f404e5cb79f452c337",
-      "name": "Wrapped Aptos  Universal ",
-      "symbol": "UAPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50646/thumb/UA-APTOS-PAD_1.png?1728579627"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe2dca969624795985f2f083bcd0b674337ba130a",
-      "name": "Saakuru",
-      "symbol": "SKR",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/37058/thumb/saakuru.jpeg?1713172376"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc734635cd30e882037c3f3de1ebccf9fa9d27d9f",
-      "name": "Lyvely",
-      "symbol": "LVLY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50215/thumb/symbol_color.png?1726436150"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5b2124d427fac9c80c902cbdd74b03dd85d7d3fe",
-      "name": "Dypius",
-      "symbol": "DYP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33016/thumb/RS-zDhFE_400x400.jpg?1700157370"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf6e932ca12afa26665dc4dde7e27be02a7c02e50",
-      "name": "Mochi",
-      "symbol": "MOCHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33083/thumb/CIRCLE-200x200.png?1713297273"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x06a63c498ef95ad1fa4fff841955e512b4b2198a",
-      "name": "Gluteus Maximus by Virtuals",
-      "symbol": "GLUTEU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52177/thumb/gluteu.jpg?1732685854"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x12e96c2bfea6e835cf8dd38a5834fa61cf723736",
-      "name": "Wrapped DOGE  Universal ",
-      "symbol": "UDOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40099/thumb/UA-DOGE_1.png?1725632510"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x076bf099c7aabd0bc9bc37930113428906f51d89",
-      "name": "DEFLI",
-      "symbol": "FLI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50582/thumb/defli_lgo_2_%28200_x_200_px%29.png?1728415750"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x051fb509e4a775fabd257611eea1efaed8f91359",
-      "name": "CateCoin",
-      "symbol": "CATE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/15364/thumb/logo.png?1696515013"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf3c7cecf8cbc3066f9a87b310cebe198d00479ac",
-      "name": "FEED EVERY GORILLA",
-      "symbol": "FEG",
-      "decimals": 11,
-      "logoURI": "https://assets.coingecko.com/coins/images/29643/thumb/IMG_3919.jpeg?1721352213"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe8aae6251c6cf39927b0ff31399030c60bec798f",
-      "name": "SUMI",
-      "symbol": "SUMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51253/thumb/SUMI.jpg?1730477794"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa9f5031b54c44c3603b4300fde9b8f5cd18ad06f",
-      "name": "Mars Battle",
-      "symbol": "SHOOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36553/thumb/icon.png?1711896644"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x71a67215a2025f501f386a49858a9ced2fc0249d",
-      "name": "Wrapped SEI  Universal ",
-      "symbol": "USEI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51023/thumb/UA-SEI_1.png?1729770680"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfc60aa1ffca50ce08b3cdec9626c0bb9e9b09bec",
-      "name": "Envision Labs",
-      "symbol": "VIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37142/thumb/Envision_Logo.png?1713421742"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xac12f930318be4f9d37f602cbf89cd33e99aa9d4",
-      "name": "Wexo",
-      "symbol": "WEXO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33801/thumb/wexo_token_200x200.png?1702991908"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x041fdf3f472d2c8a7ecc458fc3b7f543e6c57ef7",
-      "name": "Shiba Armstrong",
-      "symbol": "SHIBA",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37708/thumb/LOGO256.png?1715273986"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x23471e7250bcd7ee21df3f39ed6151931d1e076b",
-      "name": "AI Waifu",
-      "symbol": "WAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50441/thumb/Logo.png?1727768050"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf544251d25f3d243a36b07e7e7962a678f952691",
-      "name": "Tarot",
-      "symbol": "TAROT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31800/thumb/TAROT.jpg?1696530615"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x30121d81f4407474a6d93f5c3060f14aaa098a61",
-      "name": "Insane Labz  Base ",
-      "symbol": "LABZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51886/thumb/Photo_May_18_2024__6_11_22_PM.jpg?1732120518"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x554bba833518793056cf105e66abea330672c0de",
-      "name": "Maha",
-      "symbol": "MAHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13404/thumb/black.png?1724679606"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
-      "name": "PAW",
-      "symbol": "PAW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28946/thumb/PawLogo.png?1699394612"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5a7a2bf9ffae199f088b25837dcd7e115cf8e1bb",
-      "name": "IMO",
-      "symbol": "IMO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14831/thumb/IMO_logo_rond_200.png?1729798616"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6797b6244fa75f2e78cdffc3a4eb169332b730cc",
-      "name": "Eagle AI",
-      "symbol": "EAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38650/thumb/Eagle_AI.png?1718215736"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xed2d13a70acbd61074fc56bd0d0845e35f793e5e",
-      "name": "Planet Mojo",
-      "symbol": "MOJO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36670/thumb/MOJOIcon.jpg?1712061269"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcacf1ca03983ce6c7e235fb20c70acc70ed13509",
-      "name": "AstroPepeX",
-      "symbol": "APX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31839/thumb/astropepexcoingecko.png?1731814766"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe095780ba2a64a4efa7a74830f0b71656f0b0ad4",
-      "name": "Byte",
-      "symbol": "BYTE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/33527/thumb/Byte200.jpeg?1702138460"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2dad3a13ef0c6366220f989157009e501e7938f8",
-      "name": "Extra Finance",
-      "symbol": "EXTRA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30973/thumb/Ex_logo-white-blue_ring_288x.png?1696529812"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xae2bddbcc932c2d2cf286bad0028c6f5074c77b5",
-      "name": "Falcons",
-      "symbol": "FAH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50297/thumb/Falcons.png?1726935509"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe642657e4f43e6dcf0bd73ef24008394574dee28",
-      "name": "Music Protocol",
-      "symbol": "RECORD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39243/thumb/MP-mark-color.png?1724879503"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x73e2a6320314883ff8cc08b53f1460a5f4c47f2c",
-      "name": "Hacken",
-      "symbol": "HAI",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/11081/thumb/hacken-symbol-with-bg.png?1696511022"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbf1aea8670d2528e08334083616dd9c5f3b087ae",
-      "name": "MAI  Base ",
-      "symbol": "MIMATIC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35466/thumb/mimatic-red.png?1708687857"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6e51b3a19f114013e5dc09d0477a536c7e4e0207",
-      "name": "Media Network",
-      "symbol": "MEDIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15142/thumb/media50x50.png?1696514798"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf7c1cefcf7e1dd8161e00099facd3e1db9e528ee",
-      "name": "Tower",
-      "symbol": "TOWER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14134/thumb/tower-circular-1000.png?1696513854"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9f95e17b2668afe01f8fbd157068b0a4405cc08d",
-      "name": "Bullieverse",
-      "symbol": "BULL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24174/thumb/KR3qVAQe_400x400.jpg?1696523362"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5a76a56ad937335168b30df3aa1327277421c6ae",
-      "name": "Vela Token",
-      "symbol": "VELA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28739/thumb/VELA_logo_-_no_background.png?1696527719"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd652c5425aea2afd5fb142e120fecf79e18fafc3",
-      "name": "PoolTogether",
-      "symbol": "POOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14003/thumb/PoolTogether.png?1696513732"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x655a51e6803faf50d4ace80fa501af2f29c856cf",
-      "name": "PAID",
-      "symbol": "PAID",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13761/thumb/PAID_Logo_new.png?1730798431"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xac27fa800955849d6d17cc8952ba9dd6eaa66187",
-      "name": "UnlockProtocolToken",
-      "symbol": "UP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51457/thumb/up2.png?1731318758"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x74ccbe53f77b08632ce0cb91d3a545bf6b8e0979",
-      "name": "Fantom Bomb",
-      "symbol": "BOMB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24109/thumb/logo-blue.png?1696523301"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x814fe70e85025bec87d4ad3f3b713bdcaac0579b",
-      "name": "Based Bario",
-      "symbol": "BARIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50719/thumb/bario.jpg?1728803763"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xaec9e50e3397f9ddc635c6c429c8c7eca418a143",
-      "name": "Arcana arcUSD",
-      "symbol": "ARCUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38490/thumb/USDa.png?1717688209"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4da78059d97f155e18b37765e2e042270f4e0fc4",
-      "name": "WUFFI",
-      "symbol": "WUF",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/36933/thumb/WUFFI.jpg?1720613603"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe2c86869216ac578bd62a4b8313770d9ee359a05",
-      "name": "EMAIL Token",
-      "symbol": "EMT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38631/thumb/EMT_square_LG%282%29.png?1718171885"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdfd579dd6aeb232e95a15d964a135a61925b5c93",
-      "name": "Marso Tech",
-      "symbol": "MARSO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50292/thumb/QKbwAja.png?1726905588"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x78a087d713be963bf307b18f2ff8122ef9a63ae9",
-      "name": "BaseSwap",
-      "symbol": "BSWAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31245/thumb/Baseswap_LogoNew.jpg?1696530070"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2f20cf3466f80a5f7f532fca553c8cbc9727fef6",
-      "name": "Akuma Inu",
-      "symbol": "AKUMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52182/thumb/IMG_7527.PNG?1732690402"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x56a38e7216304108e841579041249feb236c887b",
-      "name": "Libertum",
-      "symbol": "LBM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37147/thumb/wmGmpgSW_400x400.jpg?1713469301"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3816dd4bd44c8830c2fa020a5605bac72fa3de7a",
-      "name": "Presearch",
-      "symbol": "PRE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1299/thumb/presearch.png?1696502369"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb4e017223fd3d639d0264de4da1b9e080325cb5e",
-      "name": "SyncVault",
-      "symbol": "SVTS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50447/thumb/White_SV_logo_200x200.png?1727771615"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1cd38856ee0fdfd65c757e530e3b1de3061008d3",
-      "name": "GROOVE",
-      "symbol": "GROOVE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38234/thumb/WhatsApp_Image_2024-05-25_at_15.01.21.png?1716860760"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
-      "name": "Overnight Finance",
-      "symbol": "OVN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31970/thumb/OVN.png?1696959174"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x70737489dfdf1a29b7584d40500d3561bd4fe196",
-      "name": "BORED",
-      "symbol": "BORED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37050/thumb/bored.jpeg?1713340233"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x728f0a7fec1859cb0d71a432271d4e80310d235f",
-      "name": "Pog Coin",
-      "symbol": "POGS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37524/thumb/Untitled_design_%2860%29.png?1731815368"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8bfac1b375bf2894d6f12fb2eb48b1c1a7916789",
-      "name": "Mey Network",
-      "symbol": "MEY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52249/thumb/logo_mey_200.png?1732828172"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
-      "name": "Osaka Protocol",
-      "symbol": "OSAK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30911/thumb/OSAK_LOGO_200x200.png?1723662197"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb34457736aa191ff423f84f5d669f68b231e6c4e",
-      "name": "AGENT DOGE by Virtuals",
-      "symbol": "AIDOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52187/thumb/Screenshot_2024-11-23_at_4.09.40%E2%80%AFPM.png?1732723139"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6009e7cd237087e6d7570990e8bdac09c3e182b0",
-      "name": "TaskBunny",
-      "symbol": "BNY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51478/thumb/Bunny_coin_200x200.png?1731404290"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9f235d23354857efe6c541db92a9ef1877689bcb",
-      "name": "Goodle",
-      "symbol": "GOODLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39688/thumb/Screenshot_2024-07-26_at_5.38.55_PM-removebg-preview.png?1723660779"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7ed613ab8b2b4c6a781ddc97ea98a666c6437511",
-      "name": "All Your Base",
-      "symbol": "AYB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35777/thumb/AYB-Coingecko.png?1718634946"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x42069de48741db40aef864f8764432bbccbd0b69",
-      "name": "All Street Bets",
-      "symbol": "BETS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36906/thumb/Screenshot_2024-03-17_034831_no_background.png?1712728634"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfaa4f3bcfc87d791e9305951275e0f62a98bcb10",
-      "name": "Super Best Friends",
-      "symbol": "SUBF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36368/thumb/1000017215.jpg?1711338058"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8f2e6758c4d6570344bd5007dec6301cd57590a0",
-      "name": "Spot",
-      "symbol": "SPOT",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/28426/thumb/SPOT_Logo_200x200_sq_small_centered.png?1696527423"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x776aaef8d8760129a0398cf8674ee28cefc0eab9",
-      "name": "Floppa Cat",
-      "symbol": "FLOPPA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36969/thumb/floppa.jpg?1722771377"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdbb975d6c449d2ac63a23ae3cbc80e40054b8921",
-      "name": "Ajna Protocol",
-      "symbol": "AJNA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30187/thumb/AJNA-Icon-200.png?1696529105"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8853f0c059c27527d33d02378e5e4f6d5afb574a",
-      "name": "AI INU",
-      "symbol": "AIINU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36902/thumb/aiinu.png?1712699681"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x76734b57dfe834f102fb61e1ebf844adf8dd931e",
-      "name": "Weirdo",
-      "symbol": "WEIRDO",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/37847/thumb/New_Project_%2823%29.png?1726539603"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x689644b86075ed61c647596862c7403e1c474dbf",
-      "name": "Bamboo on Base",
-      "symbol": "BAMBOO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39126/thumb/Bamboo_Logo_800x800.png?1720656497"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4194f4e29d652656b6dc84f10363482c5ac101b5",
-      "name": "MPAA",
-      "symbol": "MPAA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39521/thumb/photo_2024-08-03_12-01-50.jpg?1722790299"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x64cb1bafc59bf93aeb90676885c63540cf4f4106",
-      "name": "Coin6900",
-      "symbol": "COIN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51425/thumb/logo.jpg?1731186114"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc19669a405067927865b40ea045a2baabbbe57f5",
-      "name": "Star",
-      "symbol": "STAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31277/thumb/coin-icon_Star-200x200.png?1732742256"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf56b3b3972f2f154555a0b62ff5a22b7b2a3c90b",
-      "name": "ZAP",
-      "symbol": "ZAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50515/thumb/zap.jpg?1728033535"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc48e605c7b722a57277e087a6170b9e227e5ac0a",
-      "name": "OmniCat",
-      "symbol": "OMNI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33917/thumb/omnicatlogo.png?1717544778"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf9569cfb8fd265e91aa478d86ae8c78b8af55df4",
-      "name": "AUKI",
-      "symbol": "AUKI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39811/thumb/COINGECKO-200-x-200_%281%29.png?1724166209"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdbe125089d0752ef458c0685436ace93a7f1f8ca",
-      "name": "Aqualibre",
-      "symbol": "AQLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35026/thumb/aq1.png?1707147950"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
-      "name": "Mountain Protocol USD",
-      "symbol": "USDM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31719/thumb/usdm.png?1696530540"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
-      "name": "Aura Finance",
-      "symbol": "AURA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25942/thumb/logo.png?1696525021"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8c9037d1ef5c6d1f6816278c7aaf5491d24cd527",
-      "name": "Moxie",
-      "symbol": "MOXIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39451/thumb/favicon_-_200_x_200.png?1722311978"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd33c7b753ecaa85e5d5f5b5fd99dec59f26a087e",
-      "name": "Defactor",
-      "symbol": "FACTR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19201/thumb/jFLSu4U9_400x400.png?1696518648"
+      "address": "0x890a40bfae3bf25a5e7c50a31505774ee7a5d33b",
+      "name": "Worldwide USD",
+      "symbol": "WUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/thumb/WUSD%282%29.png?1715042139"
     },
     {
       "chainId": 8453,
-      "address": "0x01aac2b594f7bdbec740f0f1aa22910ebb4b74ab",
-      "name": "Unio Coin",
-      "symbol": "UNIO",
+      "address": "0x04d5ddf5f3a8939889f11e97f8c4bb48317f1938",
+      "name": "Anzen USDz",
+      "symbol": "USDZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50191/thumb/uniocoin-200x200.png?1726206790"
+      "logoURI": "https://assets.coingecko.com/coins/images/38039/thumb/usdz-image-200x200.png?1716334412"
     },
     {
       "chainId": 8453,
-      "address": "0x91f45aa2bde7393e0af1cc674ffe75d746b93567",
-      "name": "Frame Token",
-      "symbol": "FRAME",
+      "address": "0xbc45647ea894030a4e9801ec03479739fa2485f0",
+      "name": "Basenji",
+      "symbol": "BENJI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35034/thumb/Artboard_1_copyd.png?1707189782"
+      "logoURI": "https://assets.coingecko.com/coins/images/36416/thumb/ben200x200.jpg?1711420807"
     },
     {
       "chainId": 8453,
-      "address": "0x4dd9077269dd08899f2a9e73507125962b5bc87f",
-      "name": "Crash On Base",
-      "symbol": "CRASH",
+      "address": "0xb33ff54b9f7242ef1593d2c9bcd8f9df46c77935",
+      "name": "Freysa AI",
+      "symbol": "FAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38817/thumb/_iNshlUA.png?1722185418"
+      "logoURI": "https://assets.coingecko.com/coins/images/52315/thumb/FAI.png?1733076295"
     },
     {
       "chainId": 8453,
@@ -2397,1379 +796,347 @@
     },
     {
       "chainId": 8453,
-      "address": "0x52c2b317eb0bb61e650683d2f287f56c413e4cf6",
-      "name": "Tree",
-      "symbol": "TREE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33727/thumb/circle_green.png?1709894067"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdb6e0e5094a25a052ab6845a9f1e486b9a9b3dde",
-      "name": "Okayeg",
-      "symbol": "OKAYEG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37748/thumb/Okayeg_200.png?1715442444"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x31b28012f61fc3600e1c076bafc9fd997fb2da90",
-      "name": "Mrs Miggles",
-      "symbol": "MRSMIGGLES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39282/thumb/token.png?1722045136"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x10f434b3d1cc13a4a79b062dcc25706f64d10d47",
-      "name": "BEPE",
-      "symbol": "BEPE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/35989/thumb/NEW_LOGO200x200.png?1721595288"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdcf5130274753c8050ab061b1a1dcbf583f5bfd0",
-      "name": "ViciCoin",
-      "symbol": "VCNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31305/thumb/ViciCoin_-_small.png?1696530124"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd1917629b3e6a72e6772aab5dbe58eb7fa3c2f33",
-      "name": "Settled EthXY Token",
-      "symbol": "SEXY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33032/thumb/logo-circle.png?1700348518"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3ecced5b416e58664f04a39dd18935eb71d33b15",
-      "name": "Brian",
-      "symbol": "BRIAN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51099/thumb/Brian_Arm_Strong.png?1730083824"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x120edc8e391ba4c94cb98bb65d8856ae6ec1525f",
-      "name": "LOUDER",
-      "symbol": "LOUDER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39495/thumb/louder_icon_200x200.png?1722539190"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa3a2cdd230f9b3ff6e01a01534a3ed3cbf049815",
-      "name": "zkRace",
-      "symbol": "ZERC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17438/thumb/zkRace-logomark-border.png?1716518566"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x85483696cc9970ad9edd786b2c5ef735f38d156f",
-      "name": "Overnight fi USDC ",
-      "symbol": "USDC+",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/34763/thumb/USDC_.png?1705990720"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x106c8a8ba4d7fcc70e35a3ffaa35252047bc5271",
-      "name": "GOAT BASED",
-      "symbol": "GOAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52221/thumb/200x200-_2_.png?1732783193"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3203856eac03d343f9d5245ba2f39861838a7b36",
-      "name": "Aviator",
-      "symbol": "AVI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31024/thumb/avi-200x200png.png?1711119363"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe0023e73aab4fe9a22f059a9d27e857e027ee3dc",
-      "name": "RWAX",
-      "symbol": "RWAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38266/thumb/Rwax_Token_Symbol_logo-200.png?1716949733"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1287a235474e0331c0975e373bdd066444d1bd35",
-      "name": "TAIKAI",
-      "symbol": "TKAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34827/thumb/TKAI.jpg?1706191900"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc4d44c155f95fd4e94600d191a4a01bb571df7df",
-      "name": "GammaSwap",
-      "symbol": "GS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29222/thumb/newLogo2.png?1731702645"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-      "name": "Hop Protocol",
-      "symbol": "HOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25445/thumb/hop.png?1696524577"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7431ada8a591c955a994a21710752ef9b882b8e3",
-      "name": "MorpheusAI",
-      "symbol": "MOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37969/thumb/MOR200X200.png?1716327119"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8a638ea79f71f3b91bdc96bbdf9fb27c93013d60",
-      "name": "Baby Tiger",
-      "symbol": "BBT",
-      "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/51933/thumb/BBT_%282%29_%281%29.png?1732205350"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3c5fdf0ee37d62c774025599e3b692d027746e24",
-      "name": "Bonkey",
-      "symbol": "BONKEY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51629/thumb/nWKo5DZvrtkwwjtT7YXyYQeDstBhvwrqxdOmGmWvUNN6d_GSurf_TR1InJS8oLo2WYIJG2ZsX2Lffmr8z1bjqjygtVNcAKuMIX3TJPg65wPZepTpTQnXCXZrbA_oXuiIkzN2PU1vd1i6scKtGgJa4ffeecm1R7WzR7NX65j6JVu_ys42VMrpvNuNJ2ovRGM8sh9V-MovD8Mbs9NkaYQ_%281%29.jpg?1731664154"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa8c2e771288585229eea8dbe072edfa7bcb388bb",
-      "name": "Apollo Name Service",
-      "symbol": "ANS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40040/thumb/star_logo8305.png?1725392202"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x63228048121877a9e0f52020834a135074e8207c",
-      "name": "Moonsama",
-      "symbol": "SAMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28308/thumb/Small.png?1696527312"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x54bc229d1cb15f8b6415efeab4290a40bc8b7d84",
-      "name": "dHEDGE DAO",
-      "symbol": "DHT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12508/thumb/dht.png?1696512323"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3fbde9864362ce4abb244ebef2ef0482aba8ea39",
-      "name": "Baklava",
-      "symbol": "BAVA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23780/thumb/200x200_BAVA_LOGO_%282%29.png?1696522980"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x474f4cb764df9da079d94052fed39625c147c12c",
-      "name": "Bonsai Token",
-      "symbol": "BONSAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35884/thumb/Bonsai_BW_Coingecko-200x200.jpg?1710071621"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x82b0e1a2374ea0198f62a48b14ffab53db6c1e36",
-      "name": "PokPok Golden Egg",
-      "symbol": "PEGG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40102/thumb/golden_eggs_%281%29.png?1725694597"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb8e564b206032bbcda2c3978bc371da52152f72e",
-      "name": "Base Terminal",
-      "symbol": "BASEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50300/thumb/Base_Terminal_Logo_200x200.png?1727021406"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x968d6a288d7b024d5012c0b25d67a889e4e3ec19",
-      "name": "Internet Token",
-      "symbol": "INT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36593/thumb/internettoken_logo.png?1711949672"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x72e72193ea14ac3b469f881989d18a2ba021b4c6",
-      "name": "Dollar",
-      "symbol": "DOLLAR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39312/thumb/pfp_200x200.png?1721706165"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x74aa9bb52b36a378a6e641b86d7acb76dc9b3940",
-      "name": "Dtravel",
-      "symbol": "TRVL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20911/thumb/trvl.jpeg?1696520301"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x18b6f6049a0af4ed2bbe0090319174eeef89f53a",
-      "name": "RUNNER",
-      "symbol": "RUNNER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52160/thumb/RUNNERTP.png?1732675799"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x004aa1586011f3454f487eac8d0d5c647d646c69",
-      "name": "DogeVerse",
-      "symbol": "DOGEVERSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38495/thumb/DogeVerse_200x200.png?1717692269"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x623cd3a3edf080057892aaf8d773bbb7a5c9b6e9",
-      "name": "Sekuya Multiverse",
-      "symbol": "SKYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38096/thumb/SKYA_Logo_200x200.png?1731909478"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xecaf81eb42cd30014eb44130b89bcd6d4ad98b92",
-      "name": "Based Chad",
-      "symbol": "CHAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36285/thumb/logo_200_200_square.jpg?1712167823"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6a4f69da1e2fb2a9b11d1aad60d03163fe567732",
-      "name": "SHOG",
-      "symbol": "SHOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39328/thumb/149291639.png?1721742924"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8931ee05ec111325c1700b68e5ef7b887e00661d",
-      "name": "The Big Guy",
-      "symbol": "BGUY",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/38875/thumb/download.png?1719336441"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3054e8f8fba3055a42e5f5228a2a4e2ab1326933",
-      "name": "zuzalu",
-      "symbol": "ZUZALU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36909/thumb/ZUZALA.jpg?1712732086"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
-      "name": "Wagmi",
-      "symbol": "WAGMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31887/thumb/wagmi_token_logo.png?1696530698"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb8d98a102b0079b69ffbc760c8d857a31653e56e",
-      "name": "Toby ToadGod",
-      "symbol": "TOBY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36615/thumb/toby1.png?1711976453"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3d1d651761d535df881740ab50ba4bd8a2ec2c00",
-      "name": "Synthesizer Dog",
-      "symbol": "SYNDOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51577/thumb/SYNDOG_LOGO.png?1731534533"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xefb97aaf77993922ac4be4da8fbc9a2425322677",
-      "name": "Web 3 Dollar",
-      "symbol": "USD3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38073/thumb/usd3%28200_x_200_px%29.png?1716449060"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4498cd8ba045e00673402353f5a4347562707e7d",
-      "name": "r DataDAO",
-      "symbol": "RDAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39174/thumb/Q7oVa2cC_400x400.png?1720799391"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfb18511f1590a494360069f3640c27d55c2b5290",
-      "name": "Wild Goat Coin",
-      "symbol": "WGC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37966/thumb/COIN_200x200.png?1716778831"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
-      "name": "Glo Dollar",
-      "symbol": "USDGLO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29319/thumb/GLO_logo_pine_on_cyan_1_3.png?1716971065"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x13741c5df9ab03e7aa9fb3bf1f714551dd5a5f8a",
-      "name": "Noggles",
-      "symbol": "NOGS",
-      "decimals": 15,
-      "logoURI": "https://assets.coingecko.com/coins/images/37238/thumb/nogs.jpeg?1713851209"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0a14ef61afb32e5ca672e021784f71705ac14908",
-      "name": "NULL MATRIX",
-      "symbol": "NULL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51086/thumb/dark.png?1732460149"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4b6f82a4ed0b9e3767f53309b87819a78d041a7f",
-      "name": "Juicybet",
-      "symbol": "JSP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38262/thumb/JB_token.png?1717686707"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
-      "name": "Equalizer  BASE ",
-      "symbol": "SCALE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32221/thumb/SCALE_icon_200x200.png?1696835640"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5cc5e64ab764a0f1e97f23984e20fd4528356a6a",
-      "name": "XRGB",
-      "symbol": "XRGB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35447/thumb/log2.png?1708620430"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xebb78043e29f4af24e6266a7d142f5a08443969e",
-      "name": "Derp",
-      "symbol": "DERP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33069/thumb/derpdex_%281%29.png?1700793428"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6a27cd26a373530835b9fe7ac472b3e080070f64",
-      "name": "BlockAI",
-      "symbol": "BAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39638/thumb/logo-200x200-transparent-bg.png?1723278224"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
-      "name": "Nya",
-      "symbol": "NYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40082/thumb/nya.jpg?1725523655"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8fe815417913a93ea99049fc0718ee1647a2a07c",
-      "name": "XSwap",
-      "symbol": "XSWAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36000/thumb/XSwap_Icon_%282%29.png?1710320467"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x22a2488fe295047ba13bd8cccdbc8361dbd8cf7c",
-      "name": "Sonne Finance",
-      "symbol": "SONNE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27540/thumb/Token1.png?1696526577"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf34e0cff046e154cafcae502c7541b9e5fd8c249",
-      "name": "Thales",
-      "symbol": "THALES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18388/thumb/CLVZJN_C_400x400.png?1696517879"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x65e570b560027f493f2b1907e8e8e3b9546053bd",
-      "name": "Tyler",
-      "symbol": "TYLER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50734/thumb/photo_2024-09-23_09-14-08.jpg?1728916087"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0028e1e60167b48a938b785aa5292917e7eaca8b",
-      "name": "Coinye West",
-      "symbol": "COINYE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36403/thumb/Coinye_West.png?1711369153"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3c3860d89b81c91974fc1f8a41aeeef604c17058",
-      "name": "Kinetix Finance Token",
-      "symbol": "KAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34031/thumb/KFI_Token_1.png?1703675672"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9a6d24c02ec35ad970287ee8296d4d6552a31dbe",
-      "name": "OPEN Ticketing Ecosystem",
-      "symbol": "OPN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36612/thumb/TOKEN.png?1711975511"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8e16d46cb2da01cdd49601ec73d7b0344969ae33",
-      "name": "Coin on Base",
-      "symbol": "COIN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36089/thumb/download_%284%29.png?1710466413"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5597ce42b315f29e42071d231dcd0158da35b77b",
-      "name": "Kendu Inu",
-      "symbol": "KENDU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51087/thumb/Based_Kendu_Logo_%281%29.png?1730019305"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcde90558fc317c69580deeaf3efc509428df9080",
-      "name": "Normilio",
-      "symbol": "NORMILIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36915/thumb/cg.png?1712769420"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x97b959385dfdcaf252223838746beb232ac601aa",
-      "name": "AI Market Compass",
-      "symbol": "AIM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39363/thumb/AIM_%282%29.jpg?1723415448"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x57bd5c33c8002a634b389ab4de5e09ec1c31dce7",
-      "name": "Silo Finance",
-      "symbol": "SILO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21454/thumb/y0iYKZOv_400x400.png?1696520816"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x357655df177fb0229dc8aca977114a420bf81799",
-      "name": "Royal Finance Coin",
-      "symbol": "RFC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39205/thumb/1718077177995-c26be60cfd1ba40772b5ac48b95ab19b.png?1721067386"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xde5ed76e7c05ec5e4572cfc88d1acea165109e44",
-      "name": "DEUS Finance",
-      "symbol": "DEUS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18778/thumb/Black_Background_200x200.png?1696518242"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9beec80e62aa257ced8b0edd8692f79ee8783777",
-      "name": "This Is My Iguana",
-      "symbol": "TIMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39361/thumb/200x200.png?1722464115"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4d25e94291fe8dcfbfa572cbb2aaa7b755087c91",
-      "name": "High",
-      "symbol": "HIGH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36318/thumb/high200x200.png?1711092521"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8761155c814c807cd3ccd15b256d69d3c10f198c",
-      "name": "Joystream",
-      "symbol": "JOY",
-      "decimals": 10,
-      "logoURI": "https://assets.coingecko.com/coins/images/24785/thumb/joy.png?1696523945"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbd4e5c2f8de5065993d29a9794e2b7cefc41437a",
-      "name": "IPOR",
-      "symbol": "IPOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28373/thumb/IPOR-token-200x200.png?1696527376"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5babfc2f240bc5de90eb7e19d789412db1dec402",
-      "name": "Burning Circle",
-      "symbol": "CIRCLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35274/thumb/circle.png?1708048159"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcc7ff230365bd730ee4b352cc2492cedac49383e",
-      "name": "High Yield USD  Base ",
-      "symbol": "HYUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33636/thumb/hyusdlogo.png?1702536133"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x42069babe14fb1802c5cb0f50bb9d2ad6fef55e2",
-      "name": "Frok ai",
-      "symbol": "FROK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36028/thumb/Frok_logo.png?1710389187"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x52e0d3c27cc9e3607c1ca7914b9049be3d5e9c41",
-      "name": "Blu",
-      "symbol": "BLU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51922/thumb/Blu.jpg?1732190348"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1b6a569dd61edce3c383f6d565e2f79ec3a12980",
-      "name": "Young Peezy AKA Pepe",
-      "symbol": "PEEZY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36649/thumb/PFP_CG_200x200.jpeg?1719953176"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x88faea256f789f8dd50de54f9c807eef24f71b16",
-      "name": "Landwolf",
-      "symbol": "WOLF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36803/thumb/IMG_8678.jpeg?1712469842"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbf4db8b7a679f89ef38125d5f84dd1446af2ea3b",
-      "name": "Le Bleu Elefant",
-      "symbol": "BLEU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37811/thumb/b.png?1715597915"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf5e89006cbeff2dabcfda0def5bf45ebe7f8429f",
-      "name": "Ragdoll",
-      "symbol": "RAGDOLL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51848/thumb/O0_Ds5Ad_400x400.jpg?1732060576"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbe35071605277d8be5a52c84a66ab1bc855a758d",
-      "name": "Be For FWX",
-      "symbol": "B4FWX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38663/thumb/B4FWX_Logo-02_200x200.png?1718256956"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa067436db77ab18b1a315095e4b816791609897c",
-      "name": "WASSIE",
-      "symbol": "WASSIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30144/thumb/logo-coingecko.png?1696529065"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x38d513ec43dda20f323f26c7bef74c5cf80b6477",
-      "name": "Carlo",
-      "symbol": "CARLO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37553/thumb/CARLO_200x200.png?1714752141"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3933012dcf9beb0d63778725345e04dcc0c69c7e",
-      "name": "UNLUCKY",
-      "symbol": "UNLUCKY",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/38691/thumb/unlucky.jpeg?1718346998"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfd1013c72cbb0ffb920d347c5836bf88965d0d5e",
-      "name": "STIX",
-      "symbol": "STIX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52015/thumb/STIX_Logo_Transparent_200x200.png?1732346967"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd85eff20288ca72ea9eecffb428f89ee5066ca5c",
-      "name": "ISKRA Token",
-      "symbol": "ISK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27428/thumb/ISKRA_logo.png?1696526469"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6b9bb36519538e0c073894e964e90172e1c0b41f",
-      "name": "WEWECOIN",
-      "symbol": "WEWE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39135/thumb/wewe_logo.png?1720857800"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfafb7581a65a1f554616bf780fc8a8acd2ab8c9b",
-      "name": "Squid Game",
-      "symbol": "SQUID",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20506/thumb/squid.png?1696519912"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8c81b4c816d66d36c4bf348bdec01dbcbc70e987",
-      "name": "Briun Armstrung",
-      "symbol": "BRIUN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36183/thumb/200x200.png?1710758416"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xed899bfdb28c8ad65307fa40f4acab113ae2e14c",
-      "name": "Roost",
-      "symbol": "ROOST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36458/thumb/roost.jpeg?1711493580"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xab964f7b7b6391bd6c4e8512ef00d01f255d9c0d",
-      "name": "Prefrontal Cortex Convo Agent by Virtua",
-      "symbol": "CONVO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51064/thumb/Convo_Agent_89ef084f87.jpg?1729926154"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5b5dee44552546ecea05edea01dcd7be7aa6144a",
-      "name": "TN100x",
-      "symbol": "TN100X",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35729/thumb/patch-transparent-blue.png?1729878068"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2dc90fa3a0f178ba4bee16cac5d6c9a5a7b4c6cb",
-      "name": "DRINK",
-      "symbol": "DRINK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50167/thumb/2N1fxgBw_400x400.jpg?1726136925"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x506beb7965fc7053059006c7ab4c62c02c2d989f",
-      "name": "Brain Worms",
-      "symbol": "BWORM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39192/thumb/black_square_transparent_200px.png?1720990715"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x949185d3be66775ea648f4a306740ea9eff9c567",
-      "name": "Yel Finance",
-      "symbol": "YEL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17429/thumb/Logo200.png?1696516976"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x698dc45e4f10966f6d1d98e3bfd7071d8144c233",
-      "name": "PEPE 0x69 ON BASE",
-      "symbol": "PEPE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37400/thumb/lOGO.jpg?1714352456"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
-      "name": "Lava Network",
-      "symbol": "LAVA",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37354/thumb/lava_logo.png?1714098423"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2075f6e2147d4ac26036c9b4084f8e28b324397d",
-      "name": "BaseCTO",
-      "symbol": "CTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50716/thumb/IMG_1480.jpeg?1728792869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7ccdba6198db389cf37b714fd6573b73f3670236",
-      "name": "Basket",
-      "symbol": "BSKT",
-      "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/34661/thumb/BSKT_Logo.png?1705636891"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0bd4887f7d41b35cd75dff9ffee2856106f86670",
-      "name": "Friend tech",
-      "symbol": "FRIEND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37475/thumb/friend.jpeg?1714464901"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc227717ef4ae4d982e14789eb33ba942243c3fee",
-      "name": "Mozaic",
-      "symbol": "MOZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30100/thumb/Main_Logo_1-200x200jpg.jpg?1696529024"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc0d3700000987c99b3c9009069e4f8413fd22330",
-      "name": "Cod3x USD",
-      "symbol": "CDXUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51438/thumb/logo-128x128.png?1731224236"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7d9ce55d54ff3feddb611fc63ff63ec01f26d15f",
-      "name": "Fungi",
-      "symbol": "FUNGI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/36690/thumb/image_2024-03-29_20-10-19_%282%29_%283%29.png?1712091884"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x45d9c101a3870ca5024582fd788f4e1e8f7971c3",
-      "name": "MASQ",
-      "symbol": "MASQ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13699/thumb/masq.png?1696513446"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd2699f9fddc04d262a819808f561c153098c2408",
-      "name": "Moon",
-      "symbol": "MOON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52138/thumb/jjl.jpg?1732641211"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x72499bddb67f4ca150e1f522ca82c87bc9fb18c8",
-      "name": "Bonk On Base",
-      "symbol": "BONK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37123/thumb/200x200.png?1713367524"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5d559ea7bb2dae4b694a079cb8328a2145fd32f6",
-      "name": "SoMon",
-      "symbol": "OWO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39575/thumb/0x5d559ea7bb2dae4b694a079cb8328a2145fd32f6.png?1723003348"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd27c288fd69f228e0c02f79e5ecadff962e05a2b",
-      "name": "Fire",
-      "symbol": "FIRE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50835/thumb/fire-coin-200.png?1729242121"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x576bca23dcb6d94ff8e537d88b0d3e1bead444a2",
-      "name": "Base Carbon Tonne",
-      "symbol": "BCT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19240/thumb/BCT_500.png?1721039552"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe3cf8dbcbdc9b220ddead0bd6342e245daff934d",
-      "name": "Piggy",
-      "symbol": "PIGGY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52128/thumb/image_%288%29.png?1732740724"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4d58608eff50b691a3b76189af2a7a123df1e9ba",
-      "name": "Boysclubbase",
-      "symbol": "BOYS",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37825/thumb/IMG_20240507_221140_398.jpg?1715668247"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc2fe011c3885277c7f0e7ffd45ff90cadc8ecd12",
-      "name": "Poncho",
-      "symbol": "PONCHO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36160/thumb/ponchologo.PNG?1710744293"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc2bc7a73613b9bd5f373fe10b55c59a69f4d617b",
-      "name": "DackieSwap",
-      "symbol": "DACKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30752/thumb/dackieswap_large.png?1707290196"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd88611a629265c9af294ffdd2e7fa4546612273e",
-      "name": "Metapro",
-      "symbol": "MPRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35128/thumb/mpro.jpeg?1707440015"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb4e1b230dd0476238fc64c99ff9d6ccdfdb2258d",
-      "name": "Florence Finance Medici",
-      "symbol": "FFM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34382/thumb/M_PNG_200x200_copy.png?1704779326"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf0d336e3a429596c924dd2723c0c4a0100a421db",
-      "name": "PulseLaunch",
-      "symbol": "LAUNCH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36829/thumb/gradient_black_rocket_200x200.png?1712557340"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x55027a5b06f4340cc4c82dcc74c90ca93dcb173e",
-      "name": "Tadpole",
-      "symbol": "TAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39783/thumb/IMG_7927.PNG?1724101375"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc9b6ef062fab19d3f1eabc36b1f2e852af1acd18",
-      "name": "Brett s cat",
-      "symbol": "BALT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38428/thumb/IMG_4717.PNG?1717627270"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd1db4851bcf5b41442caa32025ce0afe6b8eabc2",
-      "name": "Zoomer",
-      "symbol": "ZOOMER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30894/thumb/zoooooooooomer.jpg?1696529740"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7f62ac1e974d65fab4a81821ca6af659a5f46298",
-      "name": "Ethlas",
-      "symbol": "ELS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30331/thumb/ELS_Logo_200x200.png?1696529232"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5e432eecd01c12ee7071ee9219c2477a347da192",
-      "name": "ARQx AI",
-      "symbol": "ARQX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37808/thumb/ARQX_GC.png?1715591796"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6668d4a6605a27e5ee51eda040581155eddc6666",
-      "name": "White Monster",
-      "symbol": "WMSTER",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/38698/thumb/photo_2024-10-16_11-05-11.jpg?1729411381"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x26f1bb40ea88b46ceb21557dc0ffac7b7c0ad40f",
-      "name": "ALF",
-      "symbol": "ALF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38867/thumb/alf200.png?1719283344"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc2e660c62f72c2ad35ace6db78a616215e2f2222",
-      "name": "Zunami ETH",
-      "symbol": "ZUNETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37835/thumb/zunETH_200x200.png?1715741123"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x24cb2b89844604c57350776d81e14765d03b91de",
-      "name": "Zunami ETH",
-      "symbol": "ZUNETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37835/thumb/zunETH_200x200.png?1715741123"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7cf7132ede0ca592a236b6198a681bb7b42dd5ae",
-      "name": "BOLT on Base",
-      "symbol": "BOLT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38449/thumb/wwwww.png?1717557162"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1c9f5e5b5c172955660c11ec0df65b68ecb5fb69",
-      "name": "Help",
-      "symbol": "HELP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51165/thumb/help.png?1731654094"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0718f45bbf4781ce891e4e18182f025725f0fc95",
-      "name": "Misser",
-      "symbol": "MISSER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39315/thumb/misser_pic.png?1721707572"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xde7a416ac821c77478340eebaa21b68297025ef3",
-      "name": "Beni",
-      "symbol": "BENI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36691/thumb/Logo_Image_Beni_Uodate.png?1732385556"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7480527815ccae421400da01e052b120cc4255e9",
-      "name": "Workie",
-      "symbol": "WORKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38774/thumb/Pfp2_%281%29.png?1724903016"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbeb0fd48c2ba0f1aacad2814605f09e08a96b94e",
-      "name": "GME  Base ",
-      "symbol": "GME",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37229/thumb/gamestop.jpeg?1713780481"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x613ce28076289de255f1a6487437f03e37e4a71d",
-      "name": "Dackie USD",
-      "symbol": "DCKUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39966/thumb/Dackie_USD_Stablecoin.png?1724957262"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf95e1c0a67492720ca22842122fe7fa63d5519e5",
-      "name": "Lunarlens",
-      "symbol": "LUNARLENS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39304/thumb/%E6%9C%88%E4%BA%AE%E5%B8%8164.png?1721633565"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd20ab1015f6a2de4a6fddebab270113f689c2f7c",
-      "name": "DeHub",
-      "symbol": "DHB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18094/thumb/dehub.PNG?1696517599"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc73dc7ae7a4fa40517aafa941ae1ee436b91a12c",
-      "name": "Buz Economy",
-      "symbol": "BUZ",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/39793/thumb/buz-economy-logo-dark.png?1724117134"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4b556f3a476b58be7f35df77edd68fbe5076f706",
-      "name": "MintStakeShare",
-      "symbol": "MSS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39424/thumb/logo200x200.png?1729946358"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x41a22eb30df65d6ab0ce0b4cfe8f4e0eb306d471",
-      "name": "BaseBearCute",
-      "symbol": "BBQ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40006/thumb/logo.jpg?1725221317"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x45e7eaedb8e3360f850c963c5419a5236e451217",
-      "name": "Satoshi Nakamoto",
-      "symbol": "SATOSHI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37611/thumb/SATOSHI_LOGO.PNG?1715054986"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x474cb5b5087e13ea006e13702e330c93c825ab5d",
-      "name": "Make Fun",
-      "symbol": "MF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51437/thumb/logo-128.png?1731224206"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1db0fc8933f545648b54a9ee4326209a9a259643",
-      "name": "Zunami Governance Token",
-      "symbol": "ZUN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38298/thumb/ZUN_200x200.png?1717194404"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbe58fda3bcf03b6bbc821d1f0e6b764c86709227",
-      "name": "Vabble",
-      "symbol": "VFX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52126/thumb/vabble.jpg?1732611797"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x78b3c724a2f663d11373c4a1978689271895256f",
-      "name": "Token Name Service",
-      "symbol": "TKN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39886/thumb/Tri-gradient_Group_5135_2x.png?1724682287"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf8a99f2bf2ce5bb6ce4aafcf070d8723bc904aa2",
-      "name": "Chinese Brett",
-      "symbol": "CHRETT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38541/thumb/GNQP9A7WwAIcolJ_%282%29.png?1717926712"
+      "address": "0xd6aaf4d477999fa50c5a1aa35f708862113a73cc",
+      "name": "Propbase",
+      "symbol": "PROPS",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/32932/thumb/PROP_BASE_%286%29.png?1699870054"
     },
     {
       "chainId": 8453,
-      "address": "0xf1143f3a8d76f1ca740d29d5671d365f66c44ed1",
-      "name": "Wrapped Bitcoin  Universal ",
-      "symbol": "UBTC",
+      "address": "0x15ac90165f8b45a80534228bdcb124a011f62fee",
+      "name": "MOEW",
+      "symbol": "MOEW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50252/thumb/UA-BTC_1.png?1726721793"
+      "logoURI": "https://assets.coingecko.com/coins/images/36737/thumb/img_v3_02h9_c36546da-c4b6-4636-bc50-5239ab5d78hu.png?1733472868"
     },
     {
       "chainId": 8453,
-      "address": "0x92af6f53febd6b4c6f5293840b6076a1b82c4bc2",
-      "name": "Bird Dog on Base",
-      "symbol": "BIRDDOG",
+      "address": "0x9b8df6e244526ab5f6e6400d331db28c8fdddb55",
+      "name": "Wrapped Solana  Universal ",
+      "symbol": "USOL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38437/thumb/birddog_logo_sticker_200x200_final_%281%29.png?1719953537"
+      "logoURI": "https://assets.coingecko.com/coins/images/39987/thumb/UA-SOL_1.png?1725027946"
     },
     {
       "chainId": 8453,
-      "address": "0x80f6bcedd3d4fa1035285affa30e38f464db3895",
-      "name": "BetBase",
-      "symbol": "BET",
+      "address": "0x0fd7a301b51d0a83fcaf6718628174d527b373b6",
+      "name": "Luminous",
+      "symbol": "LUM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37440/thumb/BaseXprofile.png?1714380705"
+      "logoURI": "https://assets.coingecko.com/coins/images/51439/thumb/LUM.jpg?1731232511"
     },
     {
       "chainId": 8453,
-      "address": "0x75e6b648c91d222b2f6318e8ceeed4b691d5323f",
-      "name": "AnonFi",
-      "symbol": "ANON",
+      "address": "0x1dd2d631c92b1acdfcdd51a0f7145a50130050c4",
+      "name": "Alien Base",
+      "symbol": "ALB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50446/thumb/IMG_20240928_164632_277.png?1727771357"
+      "logoURI": "https://assets.coingecko.com/coins/images/31301/thumb/ALB.png?1720133373"
     },
     {
       "chainId": 8453,
-      "address": "0x314d7f9e2f55b430ef656fbb98a7635d43a2261e",
-      "name": "Naym",
-      "symbol": "NAYM",
+      "address": "0x1185cb5122edad199bdbc0cbd7a0457e448f23c7",
+      "name": "sekoia by Virtuals",
+      "symbol": "SEKOIA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50981/thumb/naym.jpg?1729651162"
+      "logoURI": "https://assets.coingecko.com/coins/images/51785/thumb/sekoia.jpg?1731982234"
     },
     {
       "chainId": 8453,
-      "address": "0x1f1aa4d239002bb818536c95e9b762a1fc8484c1",
-      "name": "Precipitate ai",
-      "symbol": "RAIN",
+      "address": "0xea651c035f52b644856cab1f59775369c36ecadd",
+      "name": "La ka",
+      "symbol": "LAIKA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32405/thumb/RAIN_200-removebg-preview.png?1711371589"
+      "logoURI": "https://assets.coingecko.com/coins/images/39364/thumb/logo_laika.jpg?1721895773"
     },
     {
       "chainId": 8453,
-      "address": "0x4b61e2f1bbdee6d746209a693156952936f1702c",
-      "name": "Based Lambow",
-      "symbol": "LAMBOW",
+      "address": "0xfb0c734fc3008683c5eff45bcf8128836c4d97d0",
+      "name": "Vertex",
+      "symbol": "VRTX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38690/thumb/new-logo.jpg?1731187032"
+      "logoURI": "https://assets.coingecko.com/coins/images/27927/thumb/vrtx.png?1696526947"
     },
     {
       "chainId": 8453,
-      "address": "0x7466de7bb8b5e41ee572f4167de6be782a7fa75d",
-      "name": "WAGMI",
-      "symbol": "WAGMI",
+      "address": "0xa7d68d155d17cb30e311367c2ef1e82ab6022b67",
+      "name": "Braintrust",
+      "symbol": "BTRST",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37576/thumb/Logo_2.png?1714957412"
+      "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1696517605"
     },
     {
       "chainId": 8453,
-      "address": "0xece7b98bd817ee5b1f2f536daf34d0b6af8bb542",
-      "name": "Just a Black Rock on Base",
-      "symbol": "ROCK",
+      "address": "0x0a953dd9fc813fefaf6015b804c9dfa0624690c0",
+      "name": "Cornucopias",
+      "symbol": "COPI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36495/thumb/photo_2024-04-05_12-19-47.jpg?1712427724"
+      "logoURI": "https://assets.coingecko.com/coins/images/21452/thumb/g56WwJDA_400x400.jpg?1696520814"
     },
     {
       "chainId": 8453,
-      "address": "0x3636a7734b669ce352e97780df361ce1f809c58c",
-      "name": "ROCKY",
-      "symbol": "ROCKY",
+      "address": "0x9e81f6495ba29a6b4d48bddd042c0598fa8abc9f",
+      "name": "MATH",
+      "symbol": "MATH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37465/thumb/rocky3.png?1714454996"
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1696511257"
     },
     {
       "chainId": 8453,
-      "address": "0xf8b1b47aa748f5c7b5d0e80c726a843913eb573a",
-      "name": "LibertAI",
-      "symbol": "LTAI",
+      "address": "0xfd4330b0312fdeec6d4225075b82e00493ff2e3f",
+      "name": "SmarDex",
+      "symbol": "SDEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39288/thumb/LibertAI_FavIcon_Secondary.png?1721589002"
+      "logoURI": "https://assets.coingecko.com/coins/images/29470/thumb/SDEX_logo_transparent_outside_240x240.png?1696930070"
     },
     {
       "chainId": 8453,
-      "address": "0x7f65323e468939073ef3b5287c73f13951b0ff5b",
-      "name": "Blue",
-      "symbol": "BLUE",
+      "address": "0x750cf88d9e0c2bcedeec31d5faad6ed6e3f1abc6",
+      "name": "XCAD Network",
+      "symbol": "XCAD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51053/thumb/Blue200p.png?1729873273"
+      "logoURI": "https://assets.coingecko.com/coins/images/15857/thumb/xcad_logo.jpg?1707832192"
     },
     {
       "chainId": 8453,
-      "address": "0x33ad778e6c76237d843c52d7cafc972bb7cf8729",
-      "name": "Boshi",
-      "symbol": "BOSHI",
+      "address": "0x04055057677807d2a53d2b25a80ff3b4d932ae1a",
+      "name": "LogX Network",
+      "symbol": "LOGX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37222/thumb/boshi.jpeg?1713775901"
+      "logoURI": "https://assets.coingecko.com/coins/images/50226/thumb/Token_200px.png?1726556358"
     },
     {
       "chainId": 8453,
-      "address": "0x11d41056ff636107dd710ec4ea772490a710cdb7",
-      "name": "Speculation",
-      "symbol": "SPECU",
+      "address": "0x55cd6469f597452b5a7536e2cd98fde4c1247ee4",
+      "name": "Luna by Virtuals",
+      "symbol": "LUNA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51676/thumb/specu_logo.png?1731778446"
+      "logoURI": "https://assets.coingecko.com/coins/images/50880/thumb/luna.png?1729478763"
     },
     {
       "chainId": 8453,
-      "address": "0x255f1b39172f65dc6406b8bee8b08155c45fe1b6",
-      "name": "HarambeCoin",
-      "symbol": "HARAMBE",
+      "address": "0x2c8c89c442436cc6c0a77943e09c8daf49da3161",
+      "name": "Zeebu",
+      "symbol": "ZBU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36043/thumb/HarambeCoin_full_cameo_200.png?1710400612"
+      "logoURI": "https://assets.coingecko.com/coins/images/31145/thumb/200x200_Front_token.png?1696529974"
     },
     {
       "chainId": 8453,
-      "address": "0xa202b2b7b4d2fe56bf81492ffdda657fe512de07",
-      "name": "Baby Miggles",
-      "symbol": "BABYMIGGLES",
+      "address": "0x0bbbead62f7647ae8323d2cb243a0db74b7c2b80",
+      "name": "Ambire Wallet",
+      "symbol": "WALLET",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51834/thumb/IMG_6772.png?1732044511"
+      "logoURI": "https://assets.coingecko.com/coins/images/23154/thumb/wallet.PNG?1696522445"
     },
     {
       "chainId": 8453,
-      "address": "0x9e53e88dcff56d3062510a745952dec4cefdff9e",
-      "name": "Basic Dog Meme",
+      "address": "0xafb89a09d82fbde58f18ac6437b3fc81724e4df6",
+      "name": "Own The Doge",
       "symbol": "DOG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33749/thumb/Round_Logo.png?1703245893"
+      "logoURI": "https://assets.coingecko.com/coins/images/18111/thumb/Doge.png?1696517615"
     },
     {
       "chainId": 8453,
-      "address": "0x881ed0fcef78120a135ec6cc66cef2779fe95bba",
-      "name": "DogeGF",
-      "symbol": "DOGEGF",
+      "address": "0x08c81699f9a357a9f0d04a09b353576ca328d60d",
+      "name": "nftxbt by Virtuals",
+      "symbol": "NFTXBT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18651/thumb/dogegf_logo_200x200.png?1712082872"
+      "logoURI": "https://assets.coingecko.com/coins/images/52332/thumb/nftxbt_logo.jpg?1733087152"
     },
     {
       "chainId": 8453,
-      "address": "0x599f07567656e6961e20fa6a90685d393808c192",
-      "name": "Department Of Government Efficiency",
-      "symbol": "DOGE",
+      "address": "0x368181499736d0c0cc614dbb145e2ec1ac86b8c6",
+      "name": "Liquity USD",
+      "symbol": "LUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51896/thumb/coingecko_%282%29.png?1732124666"
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1696514341"
     },
     {
       "chainId": 8453,
-      "address": "0xd1e6f3f0a7f40d5412f7471875879381441bf722",
-      "name": "ARI",
-      "symbol": "ARI",
+      "address": "0xd2012fc1b913ce50732ebcaa7e601fe37ac728c6",
+      "name": "StakeStone ETH",
+      "symbol": "STONE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51167/thumb/ARI_TOKEN_WHITE_2_%281%29.png?1730267906"
+      "logoURI": "https://assets.coingecko.com/coins/images/33103/thumb/200_200.png?1702602672"
     },
     {
       "chainId": 8453,
-      "address": "0xbe5614875952b1683cb0a2c20e6509be46d353a4",
-      "name": "Baby Brett on Base",
-      "symbol": "BBRETT",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/38887/thumb/200x200.png?1719380024"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb3a9bd4861454ba94931ebff410c3d828525dce2",
-      "name": "WoofWork io",
-      "symbol": "WOOF",
+      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+      "name": "Mountain Protocol USD",
+      "symbol": "USDM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28903/thumb/WWlogoTransparent_200x200.png?1696527879"
+      "logoURI": "https://assets.coingecko.com/coins/images/31719/thumb/usdm.png?1696530540"
     },
     {
       "chainId": 8453,
-      "address": "0x7a8a5012022bccbf3ea4b03cd2bb5583d915fb1a",
-      "name": "Chuck",
-      "symbol": "CHUCK",
+      "address": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
+      "name": "Cookie DAO",
+      "symbol": "COOKIE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37468/thumb/1000030138.jpg?1714457112"
+      "logoURI": "https://assets.coingecko.com/coins/images/38450/thumb/cookie_token_logo_200x200.png?1733194528"
     },
     {
       "chainId": 8453,
-      "address": "0x58cd93c4a91c3940109fa27d700f5013b18b5dc2",
-      "name": "MAGA VP",
-      "symbol": "MVP",
+      "address": "0x27e3bc3a66e24cad043ac3d93a12a8070e3897ba",
+      "name": "Ovr",
+      "symbol": "OVR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37462/thumb/1000017296.jpg?1714451792"
+      "logoURI": "https://assets.coingecko.com/coins/images/13429/thumb/LOGO-OVER-ICON-200X200PX.png?1699396496"
     },
     {
       "chainId": 8453,
-      "address": "0x9124577428c5bd73ad7636cbc5014081384f29d6",
-      "name": "Monky",
-      "symbol": "MONKY",
+      "address": "0x6921b130d297cc43754afba22e5eac0fbf8db75b",
+      "name": "doginme",
+      "symbol": "DOGINME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38522/thumb/1000084004.jpg?1717759092"
+      "logoURI": "https://assets.coingecko.com/coins/images/35123/thumb/doginme-logo1-transparent200.png?1710856784"
     },
     {
       "chainId": 8453,
-      "address": "0xdf690c65d067035364a58369c26820d3696d7799",
-      "name": "Hoge Finance",
-      "symbol": "HOGE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/14360/thumb/hoge.jpg?1696514046"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6ce7c23b917284e21d55cea20acaeb2bc58594be",
-      "name": "Rizz",
-      "symbol": "RIZZ",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/50598/thumb/200x200px.png?1728446110"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x09579452bc3872727a5d105f342645792bb8a82b",
-      "name": "Aardvark",
-      "symbol": "VARK",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/32678/thumb/VARK.jpg?1698929830"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x22222bd682745cf032006394750739684e45a5f8",
-      "name": "Jasse Polluk",
-      "symbol": "POLLUK",
+      "address": "0xedfa23602d0ec14714057867a78d01e94176bea0",
+      "name": "Wrapped rsETH",
+      "symbol": "WRSETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38510/thumb/Jasse_Polluk.png?1717754036"
+      "logoURI": "https://assets.coingecko.com/coins/images/37919/thumb/rseth.png?1715936438"
     },
     {
       "chainId": 8453,
-      "address": "0xa617c0c739845b2941bd8edd05c9f993ecc97c18",
-      "name": "GAMER",
-      "symbol": "GMR",
+      "address": "0x1c7a460413dd4e964f96d8dfc56e7223ce88cd85",
+      "name": "Seamless Protocol",
+      "symbol": "SEAM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21288/thumb/ezgif-1-7f6a016717.jpg?1696520658"
+      "logoURI": "https://assets.coingecko.com/coins/images/33480/thumb/Seamless_Logo_Black_Transparent.png?1702019657"
     },
     {
       "chainId": 8453,
-      "address": "0xed1779845520339693cdbffec49a74246e7d671b",
-      "name": "Samurai Starter",
-      "symbol": "SAM",
+      "address": "0xc7dcca0a3e69bd762c8db257f868f76be36c8514",
+      "name": "KiboShib",
+      "symbol": "KIBSHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37552/thumb/samurai-coingecko-logo_2.png?1714751141"
+      "logoURI": "https://assets.coingecko.com/coins/images/29335/thumb/foto_no_exif_%2811%29%282%29_%281%29.png?1696528285"
     },
     {
       "chainId": 8453,
-      "address": "0xdb173587d459ddb1b9b0f2d6d88febef039304a2",
-      "name": "Crypto Journey",
-      "symbol": "DADDY",
+      "address": "0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4",
+      "name": "Electronic USD",
+      "symbol": "EUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38388/thumb/_daddy_%282%29.png?1717417360"
+      "logoURI": "https://assets.coingecko.com/coins/images/28445/thumb/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x50ce4129ca261ccde4eb100c170843c2936bc11b",
+      "name": "KOLZ",
+      "symbol": "KOLZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51235/thumb/KOLZ.png?1730447667"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc26c9099bd3789107888c35bb41178079b282561",
+      "name": "Solv Protocol SolvBTC BBN",
+      "symbol": "SOLVBTCBBN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39384/thumb/unnamed.png?1721961640"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x38815a4455921667d673b4cb3d48f0383ee93400",
+      "name": "pSTAKE Finance",
+      "symbol": "PSTAKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23931/thumb/512_x_512_Dark.png?1721243699"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
+      "name": "PAW",
+      "symbol": "PAW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28946/thumb/PawLogo.png?1699394612"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x32e0f9d26d1e33625742a52620cc76c1130efde6",
+      "name": "BASED",
+      "symbol": "BASED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39669/thumb/BASED.jpg?1723603780"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x489fe42c267fe0366b16b0c39e7aeef977e841ef",
+      "name": "Wrapped Ampleforth",
+      "symbol": "WAMPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1696520218"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd3c68968137317a57a9babeacc7707ec433548b4",
+      "name": "Phavercoin",
+      "symbol": "SOCIAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50304/thumb/Phavercoin-_Social-MAIN-purple-logo-square.png?1727024458"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3124678d62d2aa1f615b54525310fbfda6dcf7ae",
+      "name": "Sensay",
+      "symbol": "SNSY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36121/thumb/sensay.jpeg?1710495398"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x01facc69ec7360640aa5898e852326752801674a",
+      "name": "Fuse",
+      "symbol": "FUSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/thumb/fuse.png?1696510348"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1c4cca7c5db003824208adda61bd749e55f463a3",
+      "name": "GAME by Virtuals",
+      "symbol": "GAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51063/thumb/Gaming_Agent_1fe70d54ba.jpg?1729925539"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4e73420dcc85702ea134d91a262c8ffc0a72aa70",
+      "name": "SKI MASK PUP",
+      "symbol": "SKIPUP",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/38093/thumb/SkiPup_Logo.png?1716486539"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x731814e491571a2e9ee3c5b1f7f3b962ee8f4870",
+      "name": "VaderAI by Virtuals",
+      "symbol": "VADER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51910/thumb/kare_pepe.png?1733345833"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcde172dc5ffc46d228838446c57c1227e0b82049",
+      "name": "Boomer",
+      "symbol": "BOOMER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36477/thumb/Token_Image_200x200.png?1714757172"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0578d8a44db98b23bf096a382e016e29a5ce0ffe",
+      "name": "higher",
+      "symbol": "HIGHER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36084/thumb/200x200logo.png?1710427814"
     },
     {
       "chainId": 8453,
@@ -3781,67 +1148,955 @@
     },
     {
       "chainId": 8453,
-      "address": "0xd3741ac9b3f280b0819191e4b30be4ecd990771e",
-      "name": "DOOMER",
-      "symbol": "DOOMER",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/37448/thumb/DOOMER_ICON_final_CG.png?1715046773"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3f14920c99beb920afa163031c4e47a3e03b3e4a",
-      "name": " send",
-      "symbol": "SEND",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/30847/thumb/avatar.png?1716654949"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x87c211144b1d9bdaa5a791b8099ea4123dc31d21",
-      "name": "BlockChainPeople",
-      "symbol": "BCP",
+      "address": "0x4f81837c2f4a189a0b69370027cc2627d93785b4",
+      "name": "Seraph by Virtuals",
+      "symbol": "SERAPH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38085/thumb/200x200.png?1716477512"
+      "logoURI": "https://assets.coingecko.com/coins/images/52442/thumb/fire_guy.png?1733351187"
     },
     {
       "chainId": 8453,
-      "address": "0xf7263070440677f8458a2c1414b2400e3accb531",
-      "name": "POKO",
-      "symbol": "POKO",
+      "address": "0x858c50c3af1913b0e849afdb74617388a1a5340d",
+      "name": "SubQuery Network",
+      "symbol": "SQT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23359/thumb/LinkedIn_Avatar_Op1.png?1724379155"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbb22ff867f8ca3d5f2251b4084f6ec86d4666e14",
+      "name": "Cryptex Finance",
+      "symbol": "CTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/CTX_Logo_200px.png?1723514786"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4e719699e4197f4bf4370c49acd3e3b8de11974f",
+      "name": "Lovely Inu Finance",
+      "symbol": "LOVELY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19053/thumb/lovely-inu-logo-new.png?1696518503"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdb6e0e5094a25a052ab6845a9f1e486b9a9b3dde",
+      "name": "Okayeg",
+      "symbol": "OKAYEG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37748/thumb/Okayeg_200.png?1715442444"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4e74d4db6c0726ccded4656d0bce448876bb4c7a",
+      "name": "Wrapped BMX Liquidity Token",
+      "symbol": "WBLT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31532/thumb/wBLT_200x200.png?1696530341"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2676e4e0e2eb58d9bdb5078358ff8a3a964cedf5",
+      "name": "Polytrader by Virtuals",
+      "symbol": "POLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52168/thumb/poly.jpg?1732682921"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x18e692c03de43972fe81058f322fa542ae1a5e2c",
+      "name": "imgnAI",
+      "symbol": "IMGNAI",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/36802/thumb/poko_logo.png?1712469618"
+      "logoURI": "https://assets.coingecko.com/coins/images/28666/thumb/imgnai-200x200.png?1698476572"
     },
     {
       "chainId": 8453,
-      "address": "0x681a09a902d9c7445b3b1ab282c38d60c72f1f09",
-      "name": "AlphaKEK AI",
-      "symbol": "AIKEK",
+      "address": "0x02454a97a8372f3a760a033dbb39e67d73bd6d87",
+      "name": "Katana Inu",
+      "symbol": "KATA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35445/thumb/alphakek_-_Copy.png?1708620097"
+      "logoURI": "https://assets.coingecko.com/coins/images/21872/thumb/Katana_Inu512.png?1696521226"
     },
     {
       "chainId": 8453,
-      "address": "0xfe4717f60ac5603dc6863700cd8ecf805908688d",
-      "name": "Streamer Inu",
-      "symbol": "STRM",
+      "address": "0x0d97f261b1e88845184f678e2d1e7a98d9fd38de",
+      "name": "Base God",
+      "symbol": "TYBG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27994/thumb/logo.png?1696527011"
+      "logoURI": "https://assets.coingecko.com/coins/images/34563/thumb/tybg.png?1705400778"
     },
     {
       "chainId": 8453,
-      "address": "0xf83759099dc88f75fc83de854c41e0d9e83ada9b",
-      "name": "Obortech",
-      "symbol": "OBOT",
+      "address": "0x9a33406165f562e16c3abd82fd1185482e01b49a",
+      "name": "Talent Protocol",
+      "symbol": "TALENT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14929/thumb/OBORTECH_200.png?1696514590"
+      "logoURI": "https://assets.coingecko.com/coins/images/51120/thumb/Ticker-logo-200.png?1730128751"
     },
     {
       "chainId": 8453,
-      "address": "0x9de16c805a3227b9b92e39a446f9d56cf59fe640",
-      "name": "Bento",
-      "symbol": "BENTO",
+      "address": "0xeb6d78148f001f3aa2f588997c5e102e489ad341",
+      "name": "Super Champs",
+      "symbol": "CHAMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37138/thumb/logo-bento-200-200.png?1713419221"
+      "logoURI": "https://assets.coingecko.com/coins/images/51900/thumb/CHAMP_Token_256x256.png?1732131989"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2615a94df961278dcbc41fb0a54fec5f10a693ae",
+      "name": "Wrapped XRP  Universal ",
+      "symbol": "UXRP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51658/thumb/UA-XRP_1.png?1731703523"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x52b492a33e447cdb854c7fc19f1e57e8bfa1777d",
+      "name": "Based Pepe",
+      "symbol": "PEPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39763/thumb/based_pepe_transparent.png?1724010222"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6e51b3a19f114013e5dc09d0477a536c7e4e0207",
+      "name": "Media Network",
+      "symbol": "MEDIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15142/thumb/media50x50.png?1696514798"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2d189eabb667aa1ecfc01963a6a3a5d83960f558",
+      "name": "GALAXIS Token",
+      "symbol": "GALAXIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36221/thumb/500x500.png?1714755244"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfbb75a59193a3525a8825bebe7d4b56899e2f7e1",
+      "name": "ResearchCoin",
+      "symbol": "RSC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28146/thumb/RH_BOTTLE_CLEAN_Aug_2024_1.png?1732742001"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfe550bffb51eb645ea3b324d772a19ac449e92c5",
+      "name": "IX Swap",
+      "symbol": "IXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18069/thumb/ixswap.PNG?1696517577"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa3a2cdd230f9b3ff6e01a01534a3ed3cbf049815",
+      "name": "zkRace",
+      "symbol": "ZERC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17438/thumb/zkRace-logomark-border.png?1716518566"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x703d57164ca270b0b330a87fd159cfef1490c0a5",
+      "name": "RAI Finance",
+      "symbol": "SOFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14686/thumb/sofi.png?1696514359"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x64cb1bafc59bf93aeb90676885c63540cf4f4106",
+      "name": "Coin6900",
+      "symbol": "COIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51425/thumb/logo.jpg?1731186114"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7588880d9c78e81fade7b7e8dc0781e95995a792",
+      "name": "Satoshi AI agent by Virtuals",
+      "symbol": "SAINT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52336/thumb/saint.jpg?1733121865"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5ed25e305e08f58afd7995eac72563e6be65a617",
+      "name": "Wrapped NEAR  Universal ",
+      "symbol": "UNEAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50645/thumb/UA-NEAR_1.png?1728579564"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc4d44c155f95fd4e94600d191a4a01bb571df7df",
+      "name": "GammaSwap",
+      "symbol": "GS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29222/thumb/newLogo2.png?1731702645"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x24569d33653c404f90af10a2b98d6e0030d3d267",
+      "name": "Unagi Token",
+      "symbol": "UNA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34733/thumb/unagi.png?1705922276"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd07379a755a8f11b57610154861d694b2a0f615a",
+      "name": "Base",
+      "symbol": "BASE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31199/thumb/59302ba8-022e-45a4-8d00-e29fe2ee768c-removebg-preview.png?1696530026"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x73e2a6320314883ff8cc08b53f1460a5f4c47f2c",
+      "name": "Hacken",
+      "symbol": "HAI",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/11081/thumb/hacken-symbol-with-bg.png?1696511022"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x85483696cc9970ad9edd786b2c5ef735f38d156f",
+      "name": "Overnight fi USDC ",
+      "symbol": "USDC+",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/34763/thumb/USDC_.png?1705990720"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9aaae745cf2830fb8ddc6248b17436dc3a5e701c",
+      "name": "Gochujangcoin",
+      "symbol": "GOCHU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39318/thumb/GochujangLogo_200_3x.png?1721709656"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcf67815cce72e682eb4429eca46843bed81ca739",
+      "name": "GAM3S GG",
+      "symbol": "G3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35662/thumb/G3_logo.jpg?1709454143"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xebff2db643cf955247339c8c6bcd8406308ca437",
+      "name": "ChompCoin",
+      "symbol": "CHOMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36942/thumb/chomplogo200.png?1712864472"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe2dca969624795985f2f083bcd0b674337ba130a",
+      "name": "Saakuru",
+      "symbol": "SKR",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/37058/thumb/saakuru.jpeg?1713172376"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c5fdf0ee37d62c774025599e3b692d027746e24",
+      "name": "Bonkey",
+      "symbol": "BONKEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51629/thumb/nWKo5DZvrtkwwjtT7YXyYQeDstBhvwrqxdOmGmWvUNN6d_GSurf_TR1InJS8oLo2WYIJG2ZsX2Lffmr8z1bjqjygtVNcAKuMIX3TJPg65wPZepTpTQnXCXZrbA_oXuiIkzN2PU1vd1i6scKtGgJa4ffeecm1R7WzR7NX65j6JVu_ys42VMrpvNuNJ2ovRGM8sh9V-MovD8Mbs9NkaYQ_%281%29.jpg?1731664154"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x478e03d45716dda94f6dbc15a633b0d90c237e2f",
+      "name": "Shaka",
+      "symbol": "SHAKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36850/thumb/sharetheshaka.png?1712585688"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8319767a7b602f88e376368dca1b92d38869b9b4",
+      "name": "Based Peaches",
+      "symbol": "PEACH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36762/thumb/Peaches-New-Logo-200x200.png?1719742607"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c281a39944a2319aa653d81cfd93ca10983d234",
+      "name": "Build",
+      "symbol": "BUILD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37836/thumb/buildlogo.png?1715741487"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3ecced5b416e58664f04a39dd18935eb71d33b15",
+      "name": "Brian",
+      "symbol": "BRIAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51099/thumb/Brian_Arm_Strong.png?1730083824"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf6e932ca12afa26665dc4dde7e27be02a7c02e50",
+      "name": "Mochi",
+      "symbol": "MOCHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33083/thumb/CIRCLE-200x200.png?1713297273"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x98f4779fccb177a6d856dd1dfd78cd15b7cd2af5",
+      "name": "MISATO",
+      "symbol": "MISATO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52231/thumb/misatocleanboost.png?1732802425"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6d3b8c76c5396642960243febf736c6be8b60562",
+      "name": "Skull of Pepe Token",
+      "symbol": "SKOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38342/thumb/skop.jpeg?1717141011"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xca4569949699d56e1834efe9f58747ca0f151b01",
+      "name": "Token Metrics AI",
+      "symbol": "TMAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37707/thumb/Mascot_200x200.png?1733173189"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x85e90a5430af45776548adb82ee4cd9e33b08077",
+      "name": "Coding Dino",
+      "symbol": "DINO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36637/thumb/dino_icon_copy.png?1712029544"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3d1d651761d535df881740ab50ba4bd8a2ec2c00",
+      "name": "Synthesizer Dog",
+      "symbol": "SYNDOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51577/thumb/SYNDOG_LOGO.png?1731534533"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdcefd8c8fcc492630b943abcab3429f12ea9fea2",
+      "name": "KlimaDAO",
+      "symbol": "KLIMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19169/thumb/Klima-Token.png?1696518618"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x47b464edb8dc9bc67b5cd4c9310bb87b773845bd",
+      "name": "NORMIE",
+      "symbol": "NORMIE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/35880/thumb/NORMIEsite.png?1709983341"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe2c86869216ac578bd62a4b8313770d9ee359a05",
+      "name": "EMAIL Token",
+      "symbol": "EMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38631/thumb/EMT_square_LG%282%29.png?1718171885"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
+      "name": "Osaka Protocol",
+      "symbol": "OSAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30911/thumb/OSAK_LOGO_200x200.png?1723662197"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2974dc646e375e83bd1c0342625b49f288987fa4",
+      "name": "Swarm Markets",
+      "symbol": "SMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17488/thumb/swarm-SMT-token-symbol_200x200.png?1696517029"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6b2504a03ca4d43d0d73776f6ad46dab2f2a4cfd",
+      "name": "Unit 00   Rei",
+      "symbol": "REI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52005/thumb/Unit_00_-_Rei.jpg?1732592775"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbdf5bafee1291eec45ae3aadac89be8152d4e673",
+      "name": "Catamoto",
+      "symbol": "CATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37218/thumb/200x200.png?1713774219"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x10f434b3d1cc13a4a79b062dcc25706f64d10d47",
+      "name": "BEPE",
+      "symbol": "BEPE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/35989/thumb/NEW_LOGO200x200.png?1721595288"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf2d3d488626a117984fda70f8106abc0049018d3",
+      "name": "Miracle Play",
+      "symbol": "MPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32653/thumb/MPT.png?1698895300"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9b700b043e9587dde9a0c29a9483e2f8fa450d54",
+      "name": "AxonDAO Governance Token",
+      "symbol": "AXGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35290/thumb/AXGT-logo-7.png?1708076161"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x30121d81f4407474a6d93f5c3060f14aaa098a61",
+      "name": "Insane Labz  Base ",
+      "symbol": "LABZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51886/thumb/Photo_May_18_2024__6_11_22_PM.jpg?1732120518"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc7edf7b7b3667a06992508e7b156eff794a9e1c8",
+      "name": "Persistence One",
+      "symbol": "XPRT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14582/thumb/Download%28black_Dark%29.png?1723470571"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5b2124d427fac9c80c902cbdd74b03dd85d7d3fe",
+      "name": "Dypius",
+      "symbol": "DYP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33016/thumb/RS-zDhFE_400x400.jpg?1700157370"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
+      "name": "Gyroscope GYD",
+      "symbol": "GYD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33428/thumb/GYD-gradient_resized_transparent.png?1702316822"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x589864a9892b1a736ae70a91824ab4dc591fd8cd",
+      "name": "Gibape",
+      "symbol": "GIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37691/thumb/gib_ape_logo.jpeg?1715650189"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9c0e042d65a2e1ff31ac83f404e5cb79f452c337",
+      "name": "Wrapped Aptos  Universal ",
+      "symbol": "UAPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50646/thumb/UA-APTOS-PAD_1.png?1728579627"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdfbea88c4842d30c26669602888d746d30f9d60d",
+      "name": "crow with knife",
+      "symbol": "CAW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36067/thumb/200px.png?1710405601"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5a7a2bf9ffae199f088b25837dcd7e115cf8e1bb",
+      "name": "IMO",
+      "symbol": "IMO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14831/thumb/IMO_logo_rond_200.png?1729798616"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5a76a56ad937335168b30df3aa1327277421c6ae",
+      "name": "Vela Token",
+      "symbol": "VELA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28739/thumb/VELA_logo_-_no_background.png?1696527719"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2c002ffec41568d138acc36f5894d6156398d539",
+      "name": "Lucky Dog",
+      "symbol": "LUCKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51334/thumb/LUCKYTokenSymbol.png?1730797716"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0c5142bc58f9a61ab8c3d2085dd2f4e550c5ce0b",
+      "name": "RUSSELL",
+      "symbol": "RUSSELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50690/thumb/russelllogo.png?1730010143"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc1ffaef4e7d553bbaf13926e258a1a555a363a07",
+      "name": "Human Intelligence Machin",
+      "symbol": "HIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37898/thumb/Human_Intelligence_Machine.png?1715848133"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcb327b99ff831bf8223cced12b1338ff3aa322ff",
+      "name": "Based ETH",
+      "symbol": "BSDETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35774/thumb/Icon_White_on_Blue.png?1709793654"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf0268c5f9aa95baf5c25d646aabb900ac12f0800",
+      "name": "RealGoat",
+      "symbol": "RGOAT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/38923/thumb/IMG_20240625_033037_003.jpg?1719521003"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
+      "name": "Wagmi",
+      "symbol": "WAGMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31887/thumb/wagmi_token_logo.png?1696530698"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x051fb509e4a775fabd257611eea1efaed8f91359",
+      "name": "CateCoin",
+      "symbol": "CATE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/15364/thumb/logo.png?1696515013"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x12e96c2bfea6e835cf8dd38a5834fa61cf723736",
+      "name": "Wrapped DOGE  Universal ",
+      "symbol": "UDOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40099/thumb/UA-DOGE_1.png?1725632510"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x776aaef8d8760129a0398cf8674ee28cefc0eab9",
+      "name": "Floppa Cat",
+      "symbol": "FLOPPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36969/thumb/floppa.jpg?1722771377"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x71a67215a2025f501f386a49858a9ced2fc0249d",
+      "name": "Wrapped SEI  Universal ",
+      "symbol": "USEI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51023/thumb/UA-SEI_1.png?1729770680"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf544251d25f3d243a36b07e7e7962a678f952691",
+      "name": "Tarot",
+      "symbol": "TAROT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31800/thumb/TAROT.jpg?1696530615"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd98832e8a59156acbee4744b9a94a9989a728f36",
+      "name": "AgentAIgo",
+      "symbol": "AGENT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52294/thumb/agent_logo.jpg?1732966712"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
+      "name": "Truflation",
+      "symbol": "TRUF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36642/thumb/truflation.jpg?1733315818"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf8a99f2bf2ce5bb6ce4aafcf070d8723bc904aa2",
+      "name": "Chinese Brett",
+      "symbol": "CHRETT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38541/thumb/GNQP9A7WwAIcolJ_%282%29.png?1717926712"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xed2d13a70acbd61074fc56bd0d0845e35f793e5e",
+      "name": "Planet Mojo",
+      "symbol": "MOJO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36670/thumb/MOJOIcon.jpg?1712061269"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0f1cfd0bb452db90a3bfc0848349463010419ab2",
+      "name": "Guru Network",
+      "symbol": "GURU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38583/thumb/tGURU_token_circle.png?1718087986"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x354d6890caa31a5e28b6059d46781f40880786a6",
+      "name": "ghffb47yii2rteeyy10op",
+      "symbol": "GHFFB47YII2RTEEYY10",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52104/thumb/0x354d6890caa31a5e28b6059d46781f40880786a6.png?1732591949"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x18a8bd1fe17a1bb9ffb39ecd83e9489cfd17a022",
+      "name": "Andy",
+      "symbol": "ANDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36552/thumb/ANDY.jpg?1711896298"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf5e89006cbeff2dabcfda0def5bf45ebe7f8429f",
+      "name": "Ragdoll",
+      "symbol": "RAGDOLL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51848/thumb/O0_Ds5Ad_400x400.jpg?1732060576"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x314d7f9e2f55b430ef656fbb98a7635d43a2261e",
+      "name": "Naym",
+      "symbol": "NAYM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50981/thumb/naym.jpg?1729651162"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
+      "name": "Any Inu",
+      "symbol": "AI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34126/thumb/anyinulogo200.png?1704174269"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0808bf94d57c905f1236212654268ef82e1e594e",
+      "name": "ritestream",
+      "symbol": "RITE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24130/thumb/rite.png?1696523321"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3ee5e23eee121094f1cfc0ccc79d6c809ebd22e5",
+      "name": "Ionic Protocol",
+      "symbol": "ION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36713/thumb/Ionic-icon-green.png?1712127547"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x814fe70e85025bec87d4ad3f3b713bdcaac0579b",
+      "name": "Based Bario",
+      "symbol": "BARIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50719/thumb/bario.jpg?1728803763"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x65e570b560027f493f2b1907e8e8e3b9546053bd",
+      "name": "Tyler",
+      "symbol": "TYLER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50734/thumb/photo_2024-09-23_09-14-08.jpg?1728916087"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x749e5334752466cda899b302ed4176b8573dc877",
+      "name": "Assimilate",
+      "symbol": "SIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52377/thumb/SIM_LOGO.jpeg?1733253732"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1db0c569ebb4a8b57ac01833b9792f526305e062",
+      "name": "GenomesDAO GENOME",
+      "symbol": "GENOME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36763/thumb/images.jpg?1712282056"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x60d01ec2d5e98ac51c8b4cf84dfcce98d527c747",
+      "name": "iZUMi Finance",
+      "symbol": "IZI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21791/thumb/izumi-logo-symbol.png?1696521144"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xab964f7b7b6391bd6c4e8512ef00d01f255d9c0d",
+      "name": "Prefrontal Cortex Convo Agent by Virtua",
+      "symbol": "CONVO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51064/thumb/Convo_Agent_89ef084f87.jpg?1729926154"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf7c1cefcf7e1dd8161e00099facd3e1db9e528ee",
+      "name": "Tower",
+      "symbol": "TOWER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14134/thumb/tower-circular-1000.png?1696513854"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf3c7cecf8cbc3066f9a87b310cebe198d00479ac",
+      "name": "FEED EVERY GORILLA",
+      "symbol": "FEG",
+      "decimals": 11,
+      "logoURI": "https://assets.coingecko.com/coins/images/29643/thumb/IMG_3919.jpeg?1721352213"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x614577036f0a024dbc1c88ba616b394dd65d105a",
+      "name": "GENIUS AI",
+      "symbol": "GNUS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36914/thumb/IMG_5346.png?1712769235"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa3a34a0d9a08ccddb6ed422ac0a28a06731335aa",
+      "name": "Wrapped ADA  Universal ",
+      "symbol": "UADA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51868/thumb/UA-ADA.png?1732095196"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5babfc2f240bc5de90eb7e19d789412db1dec402",
+      "name": "Burning Circle",
+      "symbol": "CIRCLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35274/thumb/circle.png?1708048159"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf04d220b8136e2d3d4be08081dbb565c3c302ffd",
+      "name": "Freya by Virtuals",
+      "symbol": "FREYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52325/thumb/FREYA_%281%29.png?1733079799"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x63cb9a22cbc00bf9159429e9dede4b88c3dba8ce",
+      "name": "LaunchTokenBot",
+      "symbol": "CAPO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52234/thumb/f22a0bcbbfa4da6930bf8c1d37c2e0a0.jpeg?1732804814"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdfd579dd6aeb232e95a15d964a135a61925b5c93",
+      "name": "Marso Tech",
+      "symbol": "MARSO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50292/thumb/QKbwAja.png?1726905588"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9f95e17b2668afe01f8fbd157068b0a4405cc08d",
+      "name": "Bullieverse",
+      "symbol": "BULL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24174/thumb/KR3qVAQe_400x400.jpg?1696523362"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x74ccbe53f77b08632ce0cb91d3a545bf6b8e0979",
+      "name": "Fantom Bomb",
+      "symbol": "BOMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24109/thumb/logo-blue.png?1696523301"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbeb0fd48c2ba0f1aacad2814605f09e08a96b94e",
+      "name": "GME  Base ",
+      "symbol": "GME",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37229/thumb/gamestop.jpeg?1713780481"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x06a63c498ef95ad1fa4fff841955e512b4b2198a",
+      "name": "Gluteus Maximus by Virtuals",
+      "symbol": "GLUTEU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52177/thumb/gluteu.jpg?1732685854"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac743b05f5e590d9db6a4192e02457838e4af61e",
+      "name": "OnlyCalls by Virtuals",
+      "symbol": "CALLS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52481/thumb/onlyCalls_%281%29.jpg?1733425816"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x655a51e6803faf50d4ace80fa501af2f29c856cf",
+      "name": "PAID",
+      "symbol": "PAID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13761/thumb/PAID_Logo_new.png?1730798431"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcc0adb6c436eb1f65b2f27733bf926691b94c5f1",
+      "name": "Guanciale by Virtuals",
+      "symbol": "GUAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51865/thumb/guanciale.jpeg?1732173396"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x548f93779fbc992010c07467cbaf329dd5f059b7",
+      "name": "BMX",
+      "symbol": "BMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31699/thumb/bmx_white.png?1696530517"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
+      "name": "Dexalot",
+      "symbol": "ALOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24188/thumb/logo_200x200.png?1696523376"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9beec80e62aa257ced8b0edd8692f79ee8783777",
+      "name": "This Is My Iguana",
+      "symbol": "TIMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39361/thumb/200x200.png?1722464115"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x076bf099c7aabd0bc9bc37930113428906f51d89",
+      "name": "DEFLI",
+      "symbol": "FLI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50582/thumb/defli_lgo_2_%28200_x_200_px%29.png?1728415750"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbfefd7a0eda8a0feb06d0f52cf431afd0f9b2dd0",
+      "name": "Wokie Plumpkin by Virtuals",
+      "symbol": "WOKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52176/thumb/wokie.jpg?1732685106"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x56a38e7216304108e841579041249feb236c887b",
+      "name": "Libertum",
+      "symbol": "LBM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37147/thumb/wmGmpgSW_400x400.jpg?1713469301"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x74aa9bb52b36a378a6e641b86d7acb76dc9b3940",
+      "name": "Dtravel",
+      "symbol": "TRVL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20911/thumb/trvl.jpeg?1696520301"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc734635cd30e882037c3f3de1ebccf9fa9d27d9f",
+      "name": "Lyvely",
+      "symbol": "LVLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50215/thumb/symbol_color.png?1726436150"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcde90558fc317c69580deeaf3efc509428df9080",
+      "name": "Normilio",
+      "symbol": "NORMILIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36915/thumb/vm2byD93.jpg?1733436102"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa9f5031b54c44c3603b4300fde9b8f5cd18ad06f",
+      "name": "Mars Battle",
+      "symbol": "SHOOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36553/thumb/icon.png?1711896644"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcacf1ca03983ce6c7e235fb20c70acc70ed13509",
+      "name": "AstroPepeX",
+      "symbol": "APX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31839/thumb/astropepexcoingecko.png?1731814766"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf9569cfb8fd265e91aa478d86ae8c78b8af55df4",
+      "name": "AUKI",
+      "symbol": "AUKI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39811/thumb/COINGECKO-200-x-200_%281%29.png?1724166209"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xeb9e49fb4c33d9f6aefb1b03f9133435e24c0ec6",
+      "name": "Newton On Base",
+      "symbol": "NEWB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38475/thumb/IMG_1092.JPG?1724476844"
     },
     {
       "chainId": 8453,
@@ -3853,107 +2108,115 @@
     },
     {
       "chainId": 8453,
-      "address": "0xba5b9b2d2d06a9021eb3190ea5fb0e02160839a4",
-      "name": "Sendit",
-      "symbol": "SENDIT",
+      "address": "0x30d19fb77c3ee5cfa97f73d72c6a1e509fa06aef",
+      "name": "CONDO",
+      "symbol": "CONDO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36789/thumb/Sendit-token-logo.png?1712416889"
+      "logoURI": "https://assets.coingecko.com/coins/images/37174/thumb/1000012387.jpg?1724589415"
     },
     {
       "chainId": 8453,
-      "address": "0x25e1c298f100d7c600e9e44d46788c1ebbd4f69b",
-      "name": "Pike Finance",
-      "symbol": "P",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50771/thumb/image.png?1729132574"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8f019931375454fe4ee353427eb94e2e0c9e0a8c",
-      "name": "KOMPETE",
-      "symbol": "KOMPETE",
+      "address": "0x8761155c814c807cd3ccd15b256d69d3c10f198c",
+      "name": "Joystream",
+      "symbol": "JOY",
       "decimals": 10,
-      "logoURI": "https://assets.coingecko.com/coins/images/24298/thumb/200x200.png?1732826917"
+      "logoURI": "https://assets.coingecko.com/coins/images/24785/thumb/joy.png?1696523945"
     },
     {
       "chainId": 8453,
-      "address": "0x01ccf4941298a0b5ac4714c0e1799a2df8387048",
-      "name": "Yup",
-      "symbol": "YUP",
+      "address": "0x2f20cf3466f80a5f7f532fca553c8cbc9727fef6",
+      "name": "Akuma Inu",
+      "symbol": "AKUMA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12322/thumb/photo_2021-10-26_00-47-35.jpg?1696512151"
+      "logoURI": "https://assets.coingecko.com/coins/images/52182/thumb/IMG_7527.PNG?1732690402"
     },
     {
       "chainId": 8453,
-      "address": "0x729031b3995538ddf6b6bce6e68d5d6fdeb3ccb5",
-      "name": "Riky The Raccoon",
-      "symbol": "RIKY",
+      "address": "0x0c03ce270b4826ec62e7dd007f0b716068639f7b",
+      "name": "The Innovation Game",
+      "symbol": "TIG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37438/thumb/logo_200x.png?1714380580"
+      "logoURI": "https://assets.coingecko.com/coins/images/50669/thumb/TIG_Logo_200x200.png?1729604604"
     },
     {
       "chainId": 8453,
-      "address": "0xb01cf1be9568f09449382a47cd5bf58e2a9d5922",
-      "name": "Lightspeed",
-      "symbol": "SPEED",
+      "address": "0x6797b6244fa75f2e78cdffc3a4eb169332b730cc",
+      "name": "Eagle AI",
+      "symbol": "EAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51401/thumb/lightspeed-round-200.png?1731085512"
+      "logoURI": "https://assets.coingecko.com/coins/images/38650/thumb/Eagle_AI.png?1718215736"
     },
     {
       "chainId": 8453,
-      "address": "0x628c5ba9b775dacecd14e237130c537f497d1cc7",
-      "name": "Jaderoll",
-      "symbol": "JADE",
+      "address": "0xaa6cccdce193698d33deb9ffd4be74eaa74c4898",
+      "name": "ElonRWA",
+      "symbol": "ELONRWA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38926/thumb/Asset_2_3x.png?1719542614"
+      "logoURI": "https://assets.coingecko.com/coins/images/36970/thumb/elonrwa.png?1712910039"
     },
     {
       "chainId": 8453,
-      "address": "0x6e2c81b6c2c0e02360f00a0da694e489acb0b05e",
-      "name": "Reflect",
-      "symbol": "RFL",
+      "address": "0x99b2b1a2adb02b38222adcd057783d7e5d1fcc7d",
+      "name": "Common Wealth",
+      "symbol": "WLTH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39189/thumb/Reflect.png?1720855854"
+      "logoURI": "https://assets.coingecko.com/coins/images/37858/thumb/WLTH_TICKER_200x200.png?1730241264"
     },
     {
       "chainId": 8453,
-      "address": "0x28e29ec91db66733a94ee8e3b86a6199117baf99",
-      "name": "Basedmilio",
-      "symbol": "BASED",
+      "address": "0x98d59767cd1335071a4e9b9d3482685c915131e8",
+      "name": "DREAM",
+      "symbol": "DREAM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37685/thumb/tokenicon.png?1715224333"
+      "logoURI": "https://assets.coingecko.com/coins/images/52029/thumb/dream-logo.png?1732358413"
     },
     {
       "chainId": 8453,
-      "address": "0x33d13d537609841ce6c42d6fd775dc33e3833411",
-      "name": "OAKS",
-      "symbol": "OAKS",
+      "address": "0xac12f930318be4f9d37f602cbf89cd33e99aa9d4",
+      "name": "Wexo",
+      "symbol": "WEXO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51920/thumb/Screenshot_2024-11-19_at_4.43.57%E2%80%AFPM.png?1732185930"
+      "logoURI": "https://assets.coingecko.com/coins/images/33801/thumb/wexo_token_200x200.png?1702991908"
     },
     {
       "chainId": 8453,
-      "address": "0x4a506181f07da5ddfda4ca4c2fa4c67001db94b4",
-      "name": "Dyl",
-      "symbol": "DYL",
+      "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
+      "name": "Aura Finance",
+      "symbol": "AURA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32550/thumb/Dyl-pfp-200x.png?1698479973"
+      "logoURI": "https://assets.coingecko.com/coins/images/25942/thumb/logo.png?1696525021"
     },
     {
       "chainId": 8453,
-      "address": "0xf578ad8809f13dabf921bdd3fcfbe194d0ab5628",
-      "name": "Virtue Poker Points",
-      "symbol": "VPP",
+      "address": "0x36912b5cf63e509f18e53ac98b3012fa79e77bf5",
+      "name": "FUEGO",
+      "symbol": "FUEGO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3386/thumb/vp-logo-200x200.png?1696504084"
+      "logoURI": "https://assets.coingecko.com/coins/images/51345/thumb/FUEGO_200x200.jpg?1730825086"
     },
     {
       "chainId": 8453,
-      "address": "0x38029c62dfa30d9fd3cadf4c64e9b2ab21dbda17",
-      "name": "Dubbz",
-      "symbol": "DUBBZ",
+      "address": "0x554bba833518793056cf105e66abea330672c0de",
+      "name": "Maha",
+      "symbol": "MAHA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28665/thumb/D8EACA06-18ED-4999-8B3A-6339F9E021CE.jpeg?1696527650"
+      "logoURI": "https://assets.coingecko.com/coins/images/13404/thumb/black.png?1724679606"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xae2bddbcc932c2d2cf286bad0028c6f5074c77b5",
+      "name": "Falcons",
+      "symbol": "FAH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50297/thumb/Falcons.png?1726935509"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7d27187eb33a7b1d99258ff222633670f84fa342",
+      "name": "IntentX",
+      "symbol": "INTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38241/thumb/PFP_IX_2.png?1716881240"
     },
     {
       "chainId": 8453,
@@ -3965,51 +2228,1788 @@
     },
     {
       "chainId": 8453,
-      "address": "0xdce704a0622a8437200cb6076ee69b2cf573827c",
-      "name": "Speculate",
-      "symbol": "SPEC",
+      "address": "0x717d31a60a9e811469673429c9f8ea24358990f1",
+      "name": "Everyworld",
+      "symbol": "EVERY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37214/thumb/Speculate_Coingecko_Logo.png?1713773507"
+      "logoURI": "https://assets.coingecko.com/coins/images/36799/thumb/coin_gecko.png?1714459237"
     },
     {
       "chainId": 8453,
-      "address": "0x48de4b1826e83b77bcf62cb25bc30bd216d27745",
-      "name": "YUKO",
-      "symbol": "YUKO",
+      "address": "0xdcf5130274753c8050ab061b1a1dcbf583f5bfd0",
+      "name": "ViciCoin",
+      "symbol": "VCNT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51889/thumb/photo_2024-11-20_16-19-14.jpg?1732122162"
+      "logoURI": "https://assets.coingecko.com/coins/images/31305/thumb/ViciCoin_-_small.png?1696530124"
     },
     {
       "chainId": 8453,
-      "address": "0x8b52f46a52d86c131222ee14167da6a847bdb84a",
-      "name": "Etho Protocol",
-      "symbol": "ETHO",
+      "address": "0x82b0e1a2374ea0198f62a48b14ffab53db6c1e36",
+      "name": "PokPok Golden Egg",
+      "symbol": "PEGG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5194/thumb/IconOnly_Transparent_NoBuffer_resized.png?1713297055"
+      "logoURI": "https://assets.coingecko.com/coins/images/40102/thumb/golden_eggs_%281%29.png?1725694597"
     },
     {
       "chainId": 8453,
-      "address": "0xd7d919ea0c33a97ad6e7bd4f510498e2ec98cb78",
-      "name": "Penjamin Blinkerton",
-      "symbol": "PEN",
+      "address": "0x0c41f1fc9022feb69af6dc666abfe73c9ffda7ce",
+      "name": "Bitcoin on Base",
+      "symbol": "BTCB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37269/thumb/PEN_COIN_LOGO.png?1713887481"
+      "logoURI": "https://assets.coingecko.com/coins/images/38868/thumb/BTCB_Official_Logo_July_2024.png?1721753012"
     },
     {
       "chainId": 8453,
-      "address": "0x2816a491dd0b7a88d84cbded842a618e59016888",
-      "name": "LONG",
-      "symbol": "LONG",
+      "address": "0xecaf81eb42cd30014eb44130b89bcd6d4ad98b92",
+      "name": "Based Chad",
+      "symbol": "CHAD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36888/thumb/coin9.png?1712652624"
+      "logoURI": "https://assets.coingecko.com/coins/images/36285/thumb/logo_200_200_square.jpg?1712167823"
     },
     {
       "chainId": 8453,
-      "address": "0xd5046b976188eb40f6de40fb527f89c05b323385",
-      "name": "BaseX",
-      "symbol": "BSX",
+      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
+      "name": "Seedworld",
+      "symbol": "SWORLD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31419/thumb/bsxlogo.png?1696530234"
+      "logoURI": "https://assets.coingecko.com/coins/images/51000/thumb/IMG_2798.PNG?1729685531"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x25e1c298f100d7c600e9e44d46788c1ebbd4f69b",
+      "name": "Pike Finance",
+      "symbol": "P",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50771/thumb/image.png?1729132574"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf56b3b3972f2f154555a0b62ff5a22b7b2a3c90b",
+      "name": "ZAP",
+      "symbol": "ZAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50515/thumb/zap.jpg?1728033535"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd652c5425aea2afd5fb142e120fecf79e18fafc3",
+      "name": "PoolTogether",
+      "symbol": "POOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14003/thumb/PoolTogether.png?1696513732"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfd1013c72cbb0ffb920d347c5836bf88965d0d5e",
+      "name": "STIX",
+      "symbol": "STIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52015/thumb/STIX_Logo_Transparent_200x200.png?1732346967"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x52e0d3c27cc9e3607c1ca7914b9049be3d5e9c41",
+      "name": "Blu",
+      "symbol": "BLU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51922/thumb/Blu.jpg?1732190348"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe8aae6251c6cf39927b0ff31399030c60bec798f",
+      "name": "SUMI",
+      "symbol": "SUMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51253/thumb/SUMI.jpg?1730477794"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb4e1b230dd0476238fc64c99ff9d6ccdfdb2258d",
+      "name": "Florence Finance Medici",
+      "symbol": "FFM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34382/thumb/M_PNG_200x200_copy.png?1704779326"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb4e017223fd3d639d0264de4da1b9e080325cb5e",
+      "name": "SyncVault",
+      "symbol": "SVTS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50447/thumb/White_SV_logo_200x200.png?1727771615"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb38266e0e9d9681b77aeb0a280e98131b953f865",
+      "name": "DOVU",
+      "symbol": "DOVU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/31930/thumb/Dovu_Icon_Black_%281%29.png?1696530738"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x99298c6be0e8ec9e56b7a2be5850abe1fc109d94",
+      "name": "Degen Capital by Virtuals",
+      "symbol": "DEGENC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52246/thumb/Degen_Capital_DEGENC.png?1732824263"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c4b6cd7874edc945797123fce2d9a871818524b",
+      "name": "PARADOX",
+      "symbol": "PARADOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51590/thumb/IMG_1408.jpeg?1731570502"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "name": "Hop Protocol",
+      "symbol": "HOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25445/thumb/hop.png?1696524577"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2dad3a13ef0c6366220f989157009e501e7938f8",
+      "name": "Extra Finance",
+      "symbol": "EXTRA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30973/thumb/Ex_logo-white-blue_ring_288x.png?1696529812"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xff0c532fdb8cd566ae169c1cb157ff2bdc83e105",
+      "name": "Fren Pet",
+      "symbol": "FP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33022/thumb/token.png?1700274697"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x78a087d713be963bf307b18f2ff8122ef9a63ae9",
+      "name": "BaseSwap",
+      "symbol": "BSWAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31245/thumb/Baseswap_LogoNew.jpg?1696530070"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6009e7cd237087e6d7570990e8bdac09c3e182b0",
+      "name": "TaskBunny",
+      "symbol": "BNY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51478/thumb/Bunny_coin_200x200.png?1731404290"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3816dd4bd44c8830c2fa020a5605bac72fa3de7a",
+      "name": "Presearch",
+      "symbol": "PRE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1299/thumb/presearch.png?1696502369"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x262a9f4e84efa2816d87a68606bb4c1ea3874bf1",
+      "name": "Bangkit",
+      "symbol": "BKIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52416/thumb/logo.png?1733309160"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7431ada8a591c955a994a21710752ef9b882b8e3",
+      "name": "MorpheusAI",
+      "symbol": "MOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37969/thumb/MOR200X200.png?1716327119"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7a8a5012022bccbf3ea4b03cd2bb5583d915fb1a",
+      "name": "Chuck",
+      "symbol": "CHUCK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37468/thumb/1000030138.jpg?1714457112"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x01aac2b594f7bdbec740f0f1aa22910ebb4b74ab",
+      "name": "Unio Coin",
+      "symbol": "UNIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50191/thumb/uniocoin-200x200.png?1726206790"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x76734b57dfe834f102fb61e1ebf844adf8dd931e",
+      "name": "Weirdo",
+      "symbol": "WEIRDO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/37847/thumb/New_Project_%2823%29.png?1726539603"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x41e0fe1317bd6e8944b037cd59b22d428c1434c2",
+      "name": "Virtu by Virtuals",
+      "symbol": "VIRTU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51827/thumb/_removal.ai__24fd4161-77b5-412f-b553-a99e9012f575_photo_2024-11-07_08-05-59.png?1732042711"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9de16c805a3227b9b92e39a446f9d56cf59fe640",
+      "name": "Bento",
+      "symbol": "BENTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37138/thumb/logo-bento-200-200.png?1713419221"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5b5dee44552546ecea05edea01dcd7be7aa6144a",
+      "name": "TN100x",
+      "symbol": "TN100X",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35729/thumb/patch-transparent-blue.png?1729878068"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x42069de48741db40aef864f8764432bbccbd0b69",
+      "name": "All Street Bets",
+      "symbol": "BETS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36906/thumb/Screenshot_2024-03-17_034831_no_background.png?1712728634"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x252d223d0550bc6c137b003d90bc74f5341a2818",
+      "name": "Bitbot",
+      "symbol": "BITBOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52512/thumb/Bitbot_Logo.png?1733493165"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe095780ba2a64a4efa7a74830f0b71656f0b0ad4",
+      "name": "Byte",
+      "symbol": "BYTE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/33527/thumb/Byte200.jpeg?1702138460"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x70737489dfdf1a29b7584d40500d3561bd4fe196",
+      "name": "BORED",
+      "symbol": "BORED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37050/thumb/bored.jpeg?1713340233"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x689644b86075ed61c647596862c7403e1c474dbf",
+      "name": "Bamboo on Base",
+      "symbol": "BAMBOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39126/thumb/Bamboo_Logo_800x800.png?1720656497"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4da78059d97f155e18b37765e2e042270f4e0fc4",
+      "name": "WUFFI",
+      "symbol": "WUF",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/36933/thumb/WUFFI.jpg?1720613603"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfaa4f3bcfc87d791e9305951275e0f62a98bcb10",
+      "name": "Super Best Friends",
+      "symbol": "SUBF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36368/thumb/1000017215.jpg?1711338058"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x120edc8e391ba4c94cb98bb65d8856ae6ec1525f",
+      "name": "LOUDER",
+      "symbol": "LOUDER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39495/thumb/louder_icon_200x200.png?1722539190"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x54b659832f59c24cec0e4a2cd193377f1bcefc3c",
+      "name": "Akashalife",
+      "symbol": "AK1111",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50533/thumb/Akasha-CoinIcon_%283%29.png?1728206155"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8a638ea79f71f3b91bdc96bbdf9fb27c93013d60",
+      "name": "Baby Tiger",
+      "symbol": "BBT",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/51933/thumb/BBT_%282%29_%281%29.png?1732205350"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc48e605c7b722a57277e087a6170b9e227e5ac0a",
+      "name": "OmniCat",
+      "symbol": "OMNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33917/thumb/omnicatlogo.png?1717544778"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf5f2a79eeccf6e7f4c570c803f529930e29cc96b",
+      "name": "CertaiK by Virtuals",
+      "symbol": "CERTAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52488/thumb/download.jpeg?1733432223"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8fbd0648971d56f1f2c35fa075ff5bc75fb0e39d",
+      "name": "UNKJD",
+      "symbol": "MBS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20841/thumb/monkeyball.png?1696520233"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x60222751504796934bddee8218f9725f0c95d2c1",
+      "name": "Simps",
+      "symbol": "SIMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51994/thumb/200.png?1732296595"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9e53e88dcff56d3062510a745952dec4cefdff9e",
+      "name": "Basic Dog Meme",
+      "symbol": "DOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33749/thumb/Round_Logo.png?1703245893"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x52c2b317eb0bb61e650683d2f287f56c413e4cf6",
+      "name": "Tree",
+      "symbol": "TREE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33727/thumb/circle_green.png?1709894067"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x39fed555ff57cb1154bfa6b1a2492bb914ce2d9b",
+      "name": "EchoLeaks by Virtuals",
+      "symbol": "ECHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52172/thumb/echoleaks.jpg?1732683705"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9f235d23354857efe6c541db92a9ef1877689bcb",
+      "name": "Goodle",
+      "symbol": "GOODLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39688/thumb/Screenshot_2024-07-26_at_5.38.55_PM-removebg-preview.png?1723660779"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1b6a569dd61edce3c383f6d565e2f79ec3a12980",
+      "name": "Young Peezy AKA Pepe",
+      "symbol": "PEEZY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36649/thumb/PFP_CG_200x200.jpeg?1719953176"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8853f0c059c27527d33d02378e5e4f6d5afb574a",
+      "name": "AI INU",
+      "symbol": "AIINU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36902/thumb/aiinu.png?1712699681"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3fbde9864362ce4abb244ebef2ef0482aba8ea39",
+      "name": "Baklava",
+      "symbol": "BAVA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23780/thumb/200x200_BAVA_LOGO_%282%29.png?1696522980"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd33c7b753ecaa85e5d5f5b5fd99dec59f26a087e",
+      "name": "Defactor",
+      "symbol": "FACTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19201/thumb/jFLSu4U9_400x400.png?1696518648"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8c9037d1ef5c6d1f6816278c7aaf5491d24cd527",
+      "name": "Moxie",
+      "symbol": "MOXIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39451/thumb/favicon_-_200_x_200.png?1722311978"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7f05a7a9af2f5a07d1e64877c8dc37a64a22508e",
+      "name": "Ajna Protocol",
+      "symbol": "AJNA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30187/thumb/AJNA-Icon-200.png?1696529105"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x09579452bc3872727a5d105f342645792bb8a82b",
+      "name": "Aardvark",
+      "symbol": "VARK",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32678/thumb/VARK.jpg?1698929830"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
+      "name": "Nya",
+      "symbol": "NYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40082/thumb/nya.jpg?1725523655"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1b5ce2a593a840e3ad3549a34d7b3dec697c114d",
+      "name": "Altcoinist Token",
+      "symbol": "ALTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39455/thumb/Altcoinist_logo_png_%282%29.png?1733342642"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8c1851488f2daceae46d815dd204d5f6d946666a",
+      "name": "Besa Gaming Company",
+      "symbol": "BESA",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/33283/thumb/Besa_Gaming_Company_BESA_200.png?1701363231"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf3708859c178709d5319ad5405bc81511b72b9e9",
+      "name": "Aethernet",
+      "symbol": "AETHER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51065/thumb/Aether_Farcaster_frame.png?1729943869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd91d07e4949a858d29005d339610db2402ef5b73",
+      "name": "DataGold",
+      "symbol": "DGOLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52431/thumb/dGOLD-square-navy.png?1733436522"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8c81b4c816d66d36c4bf348bdec01dbcbc70e987",
+      "name": "Briun Armstrung",
+      "symbol": "BRIUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36183/thumb/200x200.png?1710758416"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd1917629b3e6a72e6772aab5dbe58eb7fa3c2f33",
+      "name": "Settled EthXY Token",
+      "symbol": "SEXY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33032/thumb/logo-circle.png?1700348518"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x88faea256f789f8dd50de54f9c807eef24f71b16",
+      "name": "Landwolf",
+      "symbol": "WOLF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36803/thumb/IMG_8678.jpeg?1712469842"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xefb97aaf77993922ac4be4da8fbc9a2425322677",
+      "name": "Web 3 Dollar",
+      "symbol": "USD3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38073/thumb/usd3%28200_x_200_px%29.png?1716449060"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1ccb4b14a11e0f2994a7ecbbd4cc69632f4c7c76",
+      "name": "Cute Cat Candle",
+      "symbol": "CCC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36930/thumb/1000017879.jpg?1712803401"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f2e6758c4d6570344bd5007dec6301cd57590a0",
+      "name": "Spot",
+      "symbol": "SPOT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28426/thumb/SPOT_Logo_200x200_sq_small_centered.png?1696527423"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe642657e4f43e6dcf0bd73ef24008394574dee28",
+      "name": "Music Protocol",
+      "symbol": "RECORD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39243/thumb/MP-mark-color.png?1724879503"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3203856eac03d343f9d5245ba2f39861838a7b36",
+      "name": "Aviator",
+      "symbol": "AVI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31024/thumb/avi-200x200png.png?1711119363"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8a9430e92153c026092544444cbb38077e6688d1",
+      "name": "KeptChain",
+      "symbol": "KEPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38406/thumb/Kept_200_200.png?1717463539"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe13e40e8fdb815fbc4a1e2133ab5588c33bac45d",
+      "name": "TRIBAL",
+      "symbol": "TRIBAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38531/thumb/7pc8ov67182ddpbqjnff20ik4oye.png?1733194448"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
+      "name": "Glo Dollar",
+      "symbol": "USDGLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29319/thumb/GLO_logo_pine_on_cyan_1_3.png?1716971065"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f019931375454fe4ee353427eb94e2e0c9e0a8c",
+      "name": "KOMPETE",
+      "symbol": "KOMPETE",
+      "decimals": 10,
+      "logoURI": "https://assets.coingecko.com/coins/images/24298/thumb/200x200.png?1732826917"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfea9dcdc9e23a9068bf557ad5b186675c61d33ea",
+      "name": "Based Shiba Inu",
+      "symbol": "BSHIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36092/thumb/logocg.png?1710478223"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x511ef9ad5e645e533d15df605b4628e3d0d0ff53",
+      "name": "Velvet Unicorn by Virtuals",
+      "symbol": "VU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52175/thumb/velvet_unicorn.jpg?1732684869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x13741c5df9ab03e7aa9fb3bf1f714551dd5a5f8a",
+      "name": "Noggles",
+      "symbol": "NOGS",
+      "decimals": 15,
+      "logoURI": "https://assets.coingecko.com/coins/images/37238/thumb/nogs.jpeg?1713851209"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7d9ce55d54ff3feddb611fc63ff63ec01f26d15f",
+      "name": "Fungi",
+      "symbol": "FUNGI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/36690/thumb/image_2024-03-29_20-10-19_%282%29_%283%29.png?1712091884"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x681a09a902d9c7445b3b1ab282c38d60c72f1f09",
+      "name": "AlphaKEK AI",
+      "symbol": "AIKEK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35445/thumb/alphakek_-_Copy.png?1708620097"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8fe815417913a93ea99049fc0718ee1647a2a07c",
+      "name": "XSwap",
+      "symbol": "XSWAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36000/thumb/XSwap_Icon_%282%29.png?1710320467"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xaec9e50e3397f9ddc635c6c429c8c7eca418a143",
+      "name": "Arcana arcUSD",
+      "symbol": "ARCUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38490/thumb/USDa.png?1717688209"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb488fcb23333e7baa28d1dfd7b69a5d3a8bfeb3a",
+      "name": "Terminal",
+      "symbol": "TERMINAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51477/thumb/terminalLogo.png?1731403786"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8bfac1b375bf2894d6f12fb2eb48b1c1a7916789",
+      "name": "Mey Network",
+      "symbol": "MEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52249/thumb/logo_mey_200.png?1732828172"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfafb7581a65a1f554616bf780fc8a8acd2ab8c9b",
+      "name": "Squid Game",
+      "symbol": "SQUID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20506/thumb/squid.png?1696519912"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbf1aea8670d2528e08334083616dd9c5f3b087ae",
+      "name": "MAI  Base ",
+      "symbol": "MIMATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35466/thumb/mimatic-red.png?1708687857"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x29e39327b5b1e500b87fc0fcae3856cd8f96ed2a",
+      "name": "Bark Ruffalo by Virtuals",
+      "symbol": "PAWSY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52205/thumb/00_Avatar_200x200.png?1732736729"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x623cd3a3edf080057892aaf8d773bbb7a5c9b6e9",
+      "name": "Sekuya Multiverse",
+      "symbol": "SKYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38096/thumb/SKYA_Logo_200x200.png?1731909478"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf34e0cff046e154cafcae502c7541b9e5fd8c249",
+      "name": "Thales",
+      "symbol": "THALES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18388/thumb/CLVZJN_C_400x400.png?1696517879"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x37f24b26bcefbfac7f261b97f8036da98f81a299",
+      "name": "Brish",
+      "symbol": "BRISH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38700/thumb/brishlogoupdate.png?1718480842"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe0023e73aab4fe9a22f059a9d27e857e027ee3dc",
+      "name": "RWAX",
+      "symbol": "RWAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38266/thumb/Rwax_Token_Symbol_logo-200.png?1716949733"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x777b2839832982b35213063d850848369390ee16",
+      "name": "Jarvis",
+      "symbol": "JARVIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35812/thumb/jarvis.png?1709873633"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x59f680f431f5280e7662b96f2dfa195d1693852d",
+      "name": "Magnify Cash",
+      "symbol": "MAG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38992/thumb/magnifyt.jpg?1719808409"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1287a235474e0331c0975e373bdd066444d1bd35",
+      "name": "TAIKAI",
+      "symbol": "TKAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34827/thumb/TKAI.jpg?1706191900"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4dd9077269dd08899f2a9e73507125962b5bc87f",
+      "name": "Crash On Base",
+      "symbol": "CRASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38817/thumb/_iNshlUA.png?1722185418"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x63228048121877a9e0f52020834a135074e8207c",
+      "name": "Moonsama",
+      "symbol": "SAMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28308/thumb/Small.png?1696527312"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x004aa1586011f3454f487eac8d0d5c647d646c69",
+      "name": "DogeVerse",
+      "symbol": "DOGEVERSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38495/thumb/DogeVerse_200x200.png?1717692269"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd88611a629265c9af294ffdd2e7fa4546612273e",
+      "name": "Metapro",
+      "symbol": "MPRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35128/thumb/mpro.jpeg?1707440015"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x28e29ec91db66733a94ee8e3b86a6199117baf99",
+      "name": "Basedmilio",
+      "symbol": "BASED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37685/thumb/tokenicon.png?1715224333"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x645c7aa841087e2e7f741c749ab27422ff5bba8e",
+      "name": "Iona by Virtuals",
+      "symbol": "IONA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52166/thumb/iona.jpg?1732682259"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfc60aa1ffca50ce08b3cdec9626c0bb9e9b09bec",
+      "name": "Envision Labs",
+      "symbol": "VIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37142/thumb/Envision_Logo.png?1713421742"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf578ad8809f13dabf921bdd3fcfbe194d0ab5628",
+      "name": "Virtue Poker Points",
+      "symbol": "VPP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3386/thumb/vp-logo-200x200.png?1696504084"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7f62ac1e974d65fab4a81821ca6af659a5f46298",
+      "name": "Ethlas",
+      "symbol": "ELS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30331/thumb/ELS_Logo_200x200.png?1696529232"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfdc944fb59201fb163596ee5e209ebc8fa4dcdc5",
+      "name": "AMC",
+      "symbol": "AMC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37977/thumb/amc.jpeg?1716196916"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5cc5e64ab764a0f1e97f23984e20fd4528356a6a",
+      "name": "XRGB",
+      "symbol": "XRGB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35447/thumb/log2.png?1708620430"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
+      "name": "Lava Network",
+      "symbol": "LAVA",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37354/thumb/lava_logo.png?1714098423"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x613ce28076289de255f1a6487437f03e37e4a71d",
+      "name": "Dackie USD",
+      "symbol": "DCKUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39966/thumb/Dackie_USD_Stablecoin.png?1724957262"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdbe125089d0752ef458c0685436ace93a7f1f8ca",
+      "name": "Aqualibre",
+      "symbol": "AQLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35026/thumb/aq1.png?1707147950"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x97b959385dfdcaf252223838746beb232ac601aa",
+      "name": "AI Market Compass",
+      "symbol": "AIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39363/thumb/AIM_%282%29.jpg?1723415448"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8931ee05ec111325c1700b68e5ef7b887e00661d",
+      "name": "The Big Guy",
+      "symbol": "BGUY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/38875/thumb/download.png?1719336441"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+      "name": "Equalizer  BASE ",
+      "symbol": "SCALE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32221/thumb/SCALE_icon_200x200.png?1696835640"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x45d9c101a3870ca5024582fd788f4e1e8f7971c3",
+      "name": "MASQ",
+      "symbol": "MASQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13699/thumb/masq.png?1696513446"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x28a730de97dc62a8c88363e0b1049056f1274a70",
+      "name": "Chinese Toshi",
+      "symbol": "CTOSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38635/thumb/231_%28Custom%29_%283%29.png?1718173956"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xebb78043e29f4af24e6266a7d142f5a08443969e",
+      "name": "Derp",
+      "symbol": "DERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33069/thumb/derpdex_%281%29.png?1700793428"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x22a2488fe295047ba13bd8cccdbc8361dbd8cf7c",
+      "name": "Sonne Finance",
+      "symbol": "SONNE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27540/thumb/Token1.png?1696526577"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb0e87796380172f911214208df966a84cceaaf82",
+      "name": "DOM",
+      "symbol": "DOM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51723/thumb/463fac78-dcc9-49cf-879f-b0b1af658295.png?1731903839"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8216e8143902a8fe0b676006bc25eb23829c123d",
+      "name": "Wow",
+      "symbol": "WOW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51527/thumb/23bafybeialew5mz6o2d6abynkd7kafunbgcgxcatyjdr5s2mgr4ae4zeltwe_%281%29.jpg?1731497334"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6a27cd26a373530835b9fe7ac472b3e080070f64",
+      "name": "BlockAI",
+      "symbol": "BAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39638/thumb/logo-200x200-transparent-bg.png?1723278224"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xde7a416ac821c77478340eebaa21b68297025ef3",
+      "name": "Beni",
+      "symbol": "BENI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36691/thumb/Logo_Image_Beni_Uodate.png?1732385556"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x698b49063c14d2753d23064ff891a876cffa6fb5",
+      "name": "NIKITA by Virtuals",
+      "symbol": "NIKITA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52146/thumb/Nikita_Pic.png?1732652736"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3054e8f8fba3055a42e5f5228a2a4e2ab1326933",
+      "name": "zuzalu",
+      "symbol": "ZUZALU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36909/thumb/ZUZALA.jpg?1712732086"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa0a2e84f6f19c09a095d4a83ac8de5a32d303a13",
+      "name": "Lil Brett",
+      "symbol": "LILB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51813/thumb/%28100_x_100_px%29.png?1732029374"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c3860d89b81c91974fc1f8a41aeeef604c17058",
+      "name": "Kinetix Finance Token",
+      "symbol": "KAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34031/thumb/KFI_Token_1.png?1703675672"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4b6f82a4ed0b9e3767f53309b87819a78d041a7f",
+      "name": "Juicybet",
+      "symbol": "JSP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38262/thumb/JB_token.png?1717686707"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xed899bfdb28c8ad65307fa40f4acab113ae2e14c",
+      "name": "Roost",
+      "symbol": "ROOST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36458/thumb/roost.jpeg?1711493580"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x31b28012f61fc3600e1c076bafc9fd997fb2da90",
+      "name": "Mrs Miggles",
+      "symbol": "MRSMIGGLES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39282/thumb/token.png?1722045136"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
+      "name": "Overnight Finance",
+      "symbol": "OVN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31970/thumb/OVN.png?1696959174"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066",
+      "name": "Rug World Assets",
+      "symbol": "RWA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37119/thumb/0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066.jpg?1713356569"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc73dc7ae7a4fa40517aafa941ae1ee436b91a12c",
+      "name": "Buz Economy",
+      "symbol": "BUZ",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/39793/thumb/buz-economy-logo-dark.png?1724117134"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa8c2e771288585229eea8dbe072edfa7bcb388bb",
+      "name": "Apollo Name Service",
+      "symbol": "ANS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40040/thumb/star_logo8305.png?1725392202"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0028e1e60167b48a938b785aa5292917e7eaca8b",
+      "name": "Coinye West",
+      "symbol": "COINYE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36403/thumb/Coinye_West.png?1711369153"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc2bc7a73613b9bd5f373fe10b55c59a69f4d617b",
+      "name": "DackieSwap",
+      "symbol": "DACKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30752/thumb/dackieswap_large.png?1707290196"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x55027a5b06f4340cc4c82dcc74c90ca93dcb173e",
+      "name": "Tadpole",
+      "symbol": "TAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39783/thumb/IMG_7927.PNG?1724101375"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xde5ed76e7c05ec5e4572cfc88d1acea165109e44",
+      "name": "DEUS Finance",
+      "symbol": "DEUS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18778/thumb/Black_Background_200x200.png?1696518242"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x76e7447bafa3f0acafc9692629b1d1bc937ca15d",
+      "name": "Pola On Base",
+      "symbol": "POLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37314/thumb/pola.jpg?1713971028"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcba6fabf7df8ada1995d1f57acaf520198289ca9",
+      "name": "BeromesButt",
+      "symbol": "BUTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52419/thumb/BUTT_Logo.jpg?1733326535"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf1143f3a8d76f1ca740d29d5671d365f66c44ed1",
+      "name": "Wrapped Bitcoin  Universal ",
+      "symbol": "UBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50252/thumb/UA-BTC_1.png?1726721793"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xff62ddfa80e513114c3a0bf4d6ffff1c1d17aadf",
+      "name": "Boe",
+      "symbol": "BOE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36712/thumb/79jlrE4M_400x400_%282%29.jpg?1712127456"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xebf7d4d84372f5df1b5d0e3ddd889e5bc286b1c3",
+      "name": "Ali for fx protocol by Virtuals",
+      "symbol": "FX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52319/thumb/imresizer-1732989192834.jpg?1733077790"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x92dc4ab92eb16e781559e612f349916988013d5a",
+      "name": "Agent Zero",
+      "symbol": "WSB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51310/thumb/photo_2024-11-03_07-33-29.jpg?1730643955"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x78b3c724a2f663d11373c4a1978689271895256f",
+      "name": "Token Name Service",
+      "symbol": "TKN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39886/thumb/Tri-gradient_Group_5135_2x.png?1724682287"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa067436db77ab18b1a315095e4b816791609897c",
+      "name": "WASSIE",
+      "symbol": "WASSIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30144/thumb/logo-coingecko.png?1696529065"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x57bd5c33c8002a634b389ab4de5e09ec1c31dce7",
+      "name": "Silo Finance",
+      "symbol": "SILO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21454/thumb/y0iYKZOv_400x400.png?1696520816"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x474f4cb764df9da079d94052fed39625c147c12c",
+      "name": "Bonsai Token",
+      "symbol": "BONSAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35884/thumb/Bonsai_BW_Coingecko-200x200.jpg?1710071621"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x24cb2b89844604c57350776d81e14765d03b91de",
+      "name": "Zunami ETH",
+      "symbol": "ZUNETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37835/thumb/zunETH_200x200.png?1715741123"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2075f6e2147d4ac26036c9b4084f8e28b324397d",
+      "name": "BaseCTO",
+      "symbol": "CTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50716/thumb/IMG_1480.jpeg?1728792869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb34457736aa191ff423f84f5d669f68b231e6c4e",
+      "name": "AGENT DOGE by Virtuals",
+      "symbol": "AIDOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52187/thumb/Screenshot_2024-11-23_at_4.09.40%E2%80%AFPM.png?1732723139"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x75e6b648c91d222b2f6318e8ceeed4b691d5323f",
+      "name": "AnonFi",
+      "symbol": "ANON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50446/thumb/IMG_20240928_164632_277.png?1727771357"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x315b8c9a1123c10228d469551033440441b41f0b",
+      "name": "BEATS on BASE",
+      "symbol": "BEATS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52396/thumb/200x200_transparent.png?1733293803"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x698dc45e4f10966f6d1d98e3bfd7071d8144c233",
+      "name": "PEPE 0x69 ON BASE",
+      "symbol": "PEPE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37400/thumb/lOGO.jpg?1714352456"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc2fe011c3885277c7f0e7ffd45ff90cadc8ecd12",
+      "name": "Poncho",
+      "symbol": "PONCHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36160/thumb/ponchologo.PNG?1710744293"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb8e564b206032bbcda2c3978bc371da52152f72e",
+      "name": "Base Terminal",
+      "symbol": "BASEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50300/thumb/Base_Terminal_Logo_200x200.png?1727021406"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd85eff20288ca72ea9eecffb428f89ee5066ca5c",
+      "name": "ISKRA Token",
+      "symbol": "ISK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27428/thumb/ISKRA_logo.png?1696526469"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x49c86046903807d0a3193a221c1a3e1b1b6c9ba3",
+      "name": "CYI by Virtuals",
+      "symbol": "CYI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52125/thumb/Cryptoyieldinfo.jpg?1732611368"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x72e72193ea14ac3b469f881989d18a2ba021b4c6",
+      "name": "Dollar",
+      "symbol": "DOLLAR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39312/thumb/pfp_200x200.png?1721706165"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5d9c2457a10d455e0ad8e28e40cc28eacf27a06a",
+      "name": "GM Everyday",
+      "symbol": "GM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52139/thumb/sRavZnte_.png?1732642259"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc9b6ef062fab19d3f1eabc36b1f2e852af1acd18",
+      "name": "Brett s cat",
+      "symbol": "BALT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38428/thumb/IMG_4717.PNG?1717627270"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6112b8714221bbd96ae0a0032a683e38b475d06c",
+      "name": "WAI Combinator by Virtuals",
+      "symbol": "WAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52181/thumb/wai.jpg?1732689732"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x26f1bb40ea88b46ceb21557dc0ffac7b7c0ad40f",
+      "name": "ALF",
+      "symbol": "ALF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38867/thumb/alf200.png?1719283344"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2dc90fa3a0f178ba4bee16cac5d6c9a5a7b4c6cb",
+      "name": "DRINK",
+      "symbol": "DRINK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50167/thumb/2N1fxgBw_400x400.jpg?1726136925"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc227717ef4ae4d982e14789eb33ba942243c3fee",
+      "name": "Mozaic",
+      "symbol": "MOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30100/thumb/Main_Logo_1-200x200jpg.jpg?1696529024"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb8d98a102b0079b69ffbc760c8d857a31653e56e",
+      "name": "Toby ToadGod",
+      "symbol": "TOBY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36615/thumb/toby1.png?1711976453"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f4e4221ba88d4e9bb76ecfb91d7c5ce08d7d5b9",
+      "name": "FU Money",
+      "symbol": "FU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38629/thumb/FU_logo_black.png?1718170125"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbd4e5c2f8de5065993d29a9794e2b7cefc41437a",
+      "name": "IPOR",
+      "symbol": "IPOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28373/thumb/IPOR-token-200x200.png?1696527376"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb755506531786c8ac63b756bab1ac387bacb0c04",
+      "name": "ZARP Stablecoin",
+      "symbol": "ZARP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27333/thumb/zarp_coin.png?1696526381"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x72499bddb67f4ca150e1f522ca82c87bc9fb18c8",
+      "name": "Bonk On Base",
+      "symbol": "BONK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37123/thumb/200x200.png?1713367524"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc19669a405067927865b40ea045a2baabbbe57f5",
+      "name": "Star",
+      "symbol": "STAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31277/thumb/coin-icon_Star-200x200.png?1732742256"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1a43287cbfcc5f35082e6e2aa98e5b474fe7bd4e",
+      "name": "Athena by Virtuals",
+      "symbol": "ATHENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52006/thumb/athenalogo.png?1732304469"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6c7ebb64e258f5712eeec83ceaf41c3dcbb534b1",
+      "name": "Vainguard",
+      "symbol": "VAIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52365/thumb/Vain_CG.png?1733210740"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac86f3556cbd2b4d800d17adc3a266b500fcb9f5",
+      "name": "Etherisc DIP",
+      "symbol": "DIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4586/thumb/dip.png?1696505164"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x506beb7965fc7053059006c7ab4c62c02c2d989f",
+      "name": "Brain Worms",
+      "symbol": "BWORM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39192/thumb/black_square_transparent_200px.png?1720990715"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7cf7132ede0ca592a236b6198a681bb7b42dd5ae",
+      "name": "BOLT on Base",
+      "symbol": "BOLT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38449/thumb/wwwww.png?1717557162"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfb18511f1590a494360069f3640c27d55c2b5290",
+      "name": "Wild Goat Coin",
+      "symbol": "WGC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37966/thumb/COIN_200x200.png?1716778831"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x10a7a84c91988138f8dbbc82a23b02c8639e2552",
+      "name": "ROXY FROG",
+      "symbol": "ROXY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38170/thumb/ROXY.jpg?1716703909"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6bc40d4099f9057b23af309c08d935b890d7adc0",
+      "name": "SnailBrook",
+      "symbol": "SNAIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29922/thumb/snail.jpeg?1713754058"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcc7ff230365bd730ee4b352cc2492cedac49383e",
+      "name": "High Yield USD  Base ",
+      "symbol": "HYUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33636/thumb/hyusdlogo.png?1702536133"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7ed613ab8b2b4c6a781ddc97ea98a666c6437511",
+      "name": "All Your Base",
+      "symbol": "AYB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35777/thumb/AYB-Coingecko.png?1718634946"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1db0fc8933f545648b54a9ee4326209a9a259643",
+      "name": "Zunami Governance Token",
+      "symbol": "ZUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38298/thumb/ZUN_200x200.png?1717194404"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x91f45aa2bde7393e0af1cc674ffe75d746b93567",
+      "name": "Frame Token",
+      "symbol": "FRAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35034/thumb/Artboard_1_copyd.png?1707189782"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac27fa800955849d6d17cc8952ba9dd6eaa66187",
+      "name": "UnlockProtocolToken",
+      "symbol": "UP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51457/thumb/up2.png?1731318758"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0a14ef61afb32e5ca672e021784f71705ac14908",
+      "name": "NULL MATRIX",
+      "symbol": "NULL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51086/thumb/dark.png?1732460149"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xba71cb8ef2d59de7399745793657838829e0b147",
+      "name": "Siamese",
+      "symbol": "SIAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36489/thumb/transparant-200x200.png?1728005931"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xeff2a458e464b07088bdb441c21a42ab4b61e07e",
+      "name": "ParagonsDAO",
+      "symbol": "PDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22642/thumb/pdt_token_image.png?1727376481"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8d3419b9a18651f3926a205ee0b1acea1e7192de",
+      "name": "Law of Attraction",
+      "symbol": "LOA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38008/thumb/1.png?1716270777"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb3a9bd4861454ba94931ebff410c3d828525dce2",
+      "name": "WoofWork io",
+      "symbol": "WOOF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28903/thumb/WWlogoTransparent_200x200.png?1696527879"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4b61e2f1bbdee6d746209a693156952936f1702c",
+      "name": "Based Lambow",
+      "symbol": "LAMBOW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38690/thumb/new-logo.jpg?1731187032"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x968d6a288d7b024d5012c0b25d67a889e4e3ec19",
+      "name": "Internet Token",
+      "symbol": "INT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36593/thumb/internettoken_logo.png?1711949672"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6b9bb36519538e0c073894e964e90172e1c0b41f",
+      "name": "WEWECOIN",
+      "symbol": "WEWE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39135/thumb/wewe_logo.png?1720857800"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0dd7913197bfb6d2b1f03f9772ced06298f1a644",
+      "name": "Moonboots DAO",
+      "symbol": "MBDAO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38066/thumb/MBDAO_Token_icon.png?1716441877"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1a475d06d967aeb686c98de80d079d72097aeacf",
+      "name": "Brett 2 0",
+      "symbol": "BRETT20",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37121/thumb/brett200-modified.png?1713366621"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd27c288fd69f228e0c02f79e5ecadff962e05a2b",
+      "name": "Fire",
+      "symbol": "FIRE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50835/thumb/fire-coin-200.png?1729242121"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdaf3c78f165d26f821d3d39d6598a96e962b1508",
+      "name": "The Css God by Virtuals",
+      "symbol": "WEBSIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52173/thumb/the_css_god.jpg?1732684452"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1f1aa4d239002bb818536c95e9b762a1fc8484c1",
+      "name": "Precipitate ai",
+      "symbol": "RAIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32405/thumb/RAIN_200-removebg-preview.png?1711371589"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x524d524b4c9366be706d3a90dcf70076ca037ae3",
+      "name": "RMRK",
+      "symbol": "RMRK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18656/thumb/download_%281%29_%281%29.png?1696518126"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9124577428c5bd73ad7636cbc5014081384f29d6",
+      "name": "Monky",
+      "symbol": "MONKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38522/thumb/1000084004.jpg?1717759092"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf95e1c0a67492720ca22842122fe7fa63d5519e5",
+      "name": "Lunarlens",
+      "symbol": "LUNARLENS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39304/thumb/%E6%9C%88%E4%BA%AE%E5%B8%8164.png?1721633565"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x41a22eb30df65d6ab0ce0b4cfe8f4e0eb306d471",
+      "name": "BaseBearCute",
+      "symbol": "BBQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40006/thumb/logo.jpg?1725221317"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7480527815ccae421400da01e052b120cc4255e9",
+      "name": "Workie",
+      "symbol": "WORKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38774/thumb/Pfp2_%281%29.png?1724903016"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4d58608eff50b691a3b76189af2a7a123df1e9ba",
+      "name": "Boysclubbase",
+      "symbol": "BOYS",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37825/thumb/IMG_20240507_221140_398.jpg?1715668247"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x420b0fa3de2efcf2b2fd04152eb1df36a09717cd",
+      "name": "King Of Memes",
+      "symbol": "KING",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38261/thumb/kingofmemes.png?1716929140"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4d25e94291fe8dcfbfa572cbb2aaa7b755087c91",
+      "name": "High",
+      "symbol": "HIGH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36318/thumb/high200x200.png?1711092521"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbf4db8b7a679f89ef38125d5f84dd1446af2ea3b",
+      "name": "Le Bleu Elefant",
+      "symbol": "BLEU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37811/thumb/b.png?1715597915"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x38d513ec43dda20f323f26c7bef74c5cf80b6477",
+      "name": "Carlo",
+      "symbol": "CARLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37553/thumb/CARLO_200x200.png?1714752141"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x33ad778e6c76237d843c52d7cafc972bb7cf8729",
+      "name": "Boshi",
+      "symbol": "BOSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37222/thumb/boshi.jpeg?1713775901"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd064c53f043d5aee2ac9503b13ee012bf2def1d0",
+      "name": "DeFido",
+      "symbol": "DEFIDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18861/thumb/coingecko.png?1712043959"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6b82297c6f1f9c3b1f501450d2ee7c37667ab70d",
+      "name": "goatwifhat",
+      "symbol": "GIF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37776/thumb/GIF_logo_200x200.png?1715581191"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xed1978d01d4a8a9d6a43ac79403d5b8dfbed739b",
+      "name": "Sandwich Cat",
+      "symbol": "SACA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36876/thumb/200x200_%281%29.png?1712646447"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcc6ce98579ba909344bb765f0c4f45964d5ce1d2",
+      "name": "DUDEGEN",
+      "symbol": "DUDEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39323/thumb/Untitled_Artwork_5-enhanced_copy_2.png?1721711203"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x87c211144b1d9bdaa5a791b8099ea4123dc31d21",
+      "name": "BlockChainPeople",
+      "symbol": "BCP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38085/thumb/200x200.png?1716477512"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4c40454659c8ec1283355d8e3911ba1745ff6fd1",
+      "name": "Blue Chip",
+      "symbol": "CHIP",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/36433/thumb/BlueChip-200x200.png?1711435311"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x82aed68f1deaca2b2aa4c5f27276374228a9f923",
+      "name": "Based Beast Coin",
+      "symbol": "BEAST",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/51121/thumb/IMG_7914.png?1730164559"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3933012dcf9beb0d63778725345e04dcc0c69c7e",
+      "name": "UNLUCKY",
+      "symbol": "UNLUCKY",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/38691/thumb/unlucky.jpeg?1718346998"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x881ed0fcef78120a135ec6cc66cef2779fe95bba",
+      "name": "DogeGF",
+      "symbol": "DOGEGF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18651/thumb/dogegf_logo_200x200.png?1712082872"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x39d24405ca717ef841e4a782da97284cf2dc7628",
+      "name": "Agent Zeek by Virtuals",
+      "symbol": "ZEEK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52331/thumb/dwWGlf18_400x400.jpg?1733086398"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9a6d24c02ec35ad970287ee8296d4d6552a31dbe",
+      "name": "OPEN Ticketing Ecosystem",
+      "symbol": "OPN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36612/thumb/TOKEN.png?1711975511"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6ce7c23b917284e21d55cea20acaeb2bc58594be",
+      "name": "Rizz",
+      "symbol": "RIZZ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/50598/thumb/200x200px.png?1728446110"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfd008f937b4d73eeb00cf74ce90c392be5f07f96",
+      "name": "MOON INU",
+      "symbol": "MOON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36493/thumb/moon-200.png?1711612557"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4b556f3a476b58be7f35df77edd68fbe5076f706",
+      "name": "MintStakeShare",
+      "symbol": "MSS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39424/thumb/logo200x200.png?1729946358"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x599f07567656e6961e20fa6a90685d393808c192",
+      "name": "Department Of Government Efficiency",
+      "symbol": "DOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51896/thumb/coingecko_%282%29.png?1732124666"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5597ce42b315f29e42071d231dcd0158da35b77b",
+      "name": "Kendu Inu",
+      "symbol": "KENDU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51087/thumb/Based_Kendu_Logo_%281%29.png?1730019305"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x22222bd682745cf032006394750739684e45a5f8",
+      "name": "Jasse Polluk",
+      "symbol": "POLLUK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38510/thumb/Jasse_Polluk.png?1717754036"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1986cc18d8ec757447254310d2604f85741aa732",
+      "name": "Rewardable",
+      "symbol": "REWARD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52274/thumb/reward-token-icon-200x200.png?1732888312"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xed1779845520339693cdbffec49a74246e7d671b",
+      "name": "Samurai Starter",
+      "symbol": "SAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37552/thumb/samurai-coingecko-logo_2.png?1714751141"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x41ed891897117450adbd710006855b12f98cb86b",
+      "name": "LazyCat",
+      "symbol": "LAZYCAT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/40029/thumb/LAZYCAT.jpg?1725360523"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x628c5ba9b775dacecd14e237130c537f497d1cc7",
+      "name": "Jaderoll",
+      "symbol": "JADE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38926/thumb/Asset_2_3x.png?1719542614"
     }
-  ]
+  ],
+  "timestamp": "2024-12-06T16:10:22.708Z"
 }

--- a/src/public/CoinGecko.8453.json
+++ b/src/public/CoinGecko.8453.json
@@ -1,11 +1,11 @@
 {
-  "name": "Coingecko top 500 on base",
+  "name": "Coingecko top 500 on Base",
   "logoURI": "https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png",
   "keywords": [
     "defi"
   ],
   "version": {
-    "major": 2,
+    "major": 1,
     "minor": 0,
     "patch": 0
   },
@@ -28,11 +28,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
-      "name": "LayerZero",
-      "symbol": "ZRO",
+      "address": "0x7d49a065d17d6d4a55dc13649901fdbb98b2afba",
+      "name": "Sushi",
+      "symbol": "SUSHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/large/512x512_Logo_no_chop.png?1696512101"
     },
     {
       "chainId": 8453,
@@ -44,27 +44,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0xab36452dbac151be02b16ca17d8919826072f64a",
-      "name": "Reserve Rights",
-      "symbol": "RSR",
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "name": "LayerZero",
+      "symbol": "ZRO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
     },
     {
       "chainId": 8453,
-      "address": "0x2da56acb9ea78330f947bd57c54119debda7af71",
-      "name": "Mog Coin",
-      "symbol": "MOG",
+      "address": "0x3055913c90fcc1a6ce9a358911721eeb942013a1",
+      "name": "PancakeSwap",
+      "symbol": "CAKE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png?1696529893"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbaa5cc21fd487b8fcc2f632f3f4e8d37262a0842",
-      "name": "Morpho",
-      "symbol": "MORPHO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
+      "logoURI": "https://assets.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
     },
     {
       "chainId": 8453,
@@ -76,11 +68,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0x3055913c90fcc1a6ce9a358911721eeb942013a1",
-      "name": "PancakeSwap",
-      "symbol": "CAKE",
+      "address": "0xab36452dbac151be02b16ca17d8919826072f64a",
+      "name": "Reserve Rights",
+      "symbol": "RSR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
+      "logoURI": "https://assets.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3992b27da26848c2b19cea6fd25ad5568b68ab98",
+      "name": "MANTRA",
+      "symbol": "OM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12151/large/OM_Token.png?1696511991"
     },
     {
       "chainId": 8453,
@@ -100,19 +100,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0x7d49a065d17d6d4a55dc13649901fdbb98b2afba",
-      "name": "Sushi",
-      "symbol": "SUSHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12271/large/512x512_Logo_no_chop.png?1696512101"
-    },
-    {
-      "chainId": 8453,
       "address": "0x9eaf8c1e34f05a589eda6bafdf391cf6ad3cb239",
       "name": "yearn finance",
       "symbol": "YFI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/11849/large/yearn.jpg?1696511720"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x532f27101965dd16442e59d40670faf5ebb142e4",
+      "name": "Brett",
+      "symbol": "BRETT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35529/large/1000050750.png?1709031995"
     },
     {
       "chainId": 8453,
@@ -132,14 +132,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0x9c7beba8f6ef6643abd725e45a4e8387ef260649",
-      "name": "Gravity",
-      "symbol": "G",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39200/large/gravity.jpg?1721020647"
-    },
-    {
-      "chainId": 8453,
       "address": "0x22e6966b799c4d5b13be962e1d117b56327fda66",
       "name": "Synthetix Network",
       "symbol": "SNX",
@@ -148,19 +140,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x3992b27da26848c2b19cea6fd25ad5568b68ab98",
-      "name": "MANTRA",
-      "symbol": "OM",
+      "address": "0xbaa5cc21fd487b8fcc2f632f3f4e8d37262a0842",
+      "name": "Morpho",
+      "symbol": "MORPHO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12151/large/OM_Token.png?1696511991"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x532f27101965dd16442e59d40670faf5ebb142e4",
-      "name": "Brett",
-      "symbol": "BRETT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35529/large/1000050750.png?1709031995"
+      "logoURI": "https://assets.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
     },
     {
       "chainId": 8453,
@@ -180,11 +164,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xbcbaf311cec8a4eac0430193a528d9ff27ae38c1",
-      "name": "IoTeX",
-      "symbol": "IOTX",
+      "address": "0x2da56acb9ea78330f947bd57c54119debda7af71",
+      "name": "Mog Coin",
+      "symbol": "MOG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3334/large/Token_Icon_Token_Icon.png?1727899869"
+      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png?1696529893"
     },
     {
       "chainId": 8453,
@@ -196,19 +180,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
-      "name": "CARV",
-      "symbol": "CARV",
+      "address": "0xbcbaf311cec8a4eac0430193a528d9ff27ae38c1",
+      "name": "IoTeX",
+      "symbol": "IOTX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
+      "logoURI": "https://assets.coingecko.com/coins/images/3334/large/Token_Icon_Token_Icon.png?1727899869"
     },
     {
       "chainId": 8453,
-      "address": "0xfa980ced6895ac314e7de34ef1bfae90a5add21b",
-      "name": "Echelon Prime",
-      "symbol": "PRIME",
+      "address": "0x9c7beba8f6ef6643abd725e45a4e8387ef260649",
+      "name": "Gravity",
+      "symbol": "G",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/prime-logo-small-border_%282%29.png?1696528020"
+      "logoURI": "https://assets.coingecko.com/coins/images/39200/large/gravity.jpg?1721020647"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd722e55c1d9d9fa0021a5215cbb904b92b3dc5d4",
+      "name": "Radiant Capital",
+      "symbol": "RDNT",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x50da645f148798f68ef2d7db7c1cb22a6819bb2c",
+      "name": "SPX6900",
+      "symbol": "SPX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/31401/large/sticker_%281%29.jpg?1702371083"
     },
     {
       "chainId": 8453,
@@ -228,59 +228,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xd722e55c1d9d9fa0021a5215cbb904b92b3dc5d4",
-      "name": "Radiant Capital",
-      "symbol": "RDNT",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x96419929d7949d6a801a6909c145c8eef6a40431",
-      "name": "Spectral",
-      "symbol": "SPEC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36138/large/ls7wS7vf_400x400.jpg?1724975224"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca",
-      "name": "Bridged USDC  Base ",
-      "symbol": "USDBC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/31164/large/baseusdc.jpg?1696529993"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x99ac4484e8a1dbd6a185380b3a811913ac884d87",
-      "name": "Savings Dai",
-      "symbol": "SDAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32254/large/sdai.png?1697015278"
-    },
-    {
-      "chainId": 8453,
       "address": "0x24fcfc492c1393274b6bcd568ac9e225bec93584",
       "name": "Heroes of Mavia",
       "symbol": "MAVIA",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/33895/large/2023-12-20_21.21.41_%281%29.jpg?1703230771"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7002458b1df59eccb57387bc79ffc7c29e22e6f7",
-      "name": "Origin Token",
-      "symbol": "OGN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3296/large/op.jpg?1696504006"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x259fac10c5cbfefe3e710e1d9467f70a76138d45",
-      "name": "Cartesi",
-      "symbol": "CTSI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
     },
     {
       "chainId": 8453,
@@ -292,11 +244,107 @@
     },
     {
       "chainId": 8453,
-      "address": "0x4f9fd6be4a90f2620860d680c0d4d5fb53d1a825",
-      "name": "aixbt by Virtuals",
-      "symbol": "AIXBT",
+      "address": "0x259fac10c5cbfefe3e710e1d9467f70a76138d45",
+      "name": "Cartesi",
+      "symbol": "CTSI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51784/large/3.png?1731981138"
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfa980ced6895ac314e7de34ef1bfae90a5add21b",
+      "name": "Echelon Prime",
+      "symbol": "PRIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/prime-logo-small-border_%282%29.png?1696528020"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca",
+      "name": "Bridged USDC  Base ",
+      "symbol": "USDBC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31164/large/baseusdc.jpg?1696529993"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0db510e79909666d6dec7f5e49370838c16d950f",
+      "name": "Anon",
+      "symbol": "ANON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51871/large/_.png?1732095727"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+      "name": "CARV",
+      "symbol": "CARV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4158734d47fc9692176b5085e0f52ee0da5d47f1",
+      "name": "Balancer",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x96419929d7949d6a801a6909c145c8eef6a40431",
+      "name": "Spectral",
+      "symbol": "SPEC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36138/large/ls7wS7vf_400x400.jpg?1724975224"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x64b88c73a5dfa78d1713fe1b4c69a22d7e0faaa7",
+      "name": "Maverick Protocol",
+      "symbol": "MAV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30850/large/MAV_Logo.png?1696529701"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7002458b1df59eccb57387bc79ffc7c29e22e6f7",
+      "name": "Origin Token",
+      "symbol": "OGN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3296/large/op.jpg?1696504006"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376",
+      "name": "Overnight fi USD   Base ",
+      "symbol": "USD+",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39624/large/USD_.png?1723179227"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x99ac4484e8a1dbd6a185380b3a811913ac884d87",
+      "name": "Savings Dai",
+      "symbol": "SDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32254/large/sdai.png?1697015278"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",
+      "name": "L2 Standard Bridged USDT  Base ",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39963/large/usdt.png?1724952731"
     },
     {
       "chainId": 8453,
@@ -316,83 +364,27 @@
     },
     {
       "chainId": 8453,
+      "address": "0x4f9fd6be4a90f2620860d680c0d4d5fb53d1a825",
+      "name": "aixbt by Virtuals",
+      "symbol": "AIXBT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51784/large/3.png?1731981138"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3b86ad95859b6ab773f55f8d94b4b9d443ee931f",
+      "name": "Solv Protocol SolvBTC",
+      "symbol": "SOLVBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36800/large/solvBTC.png?1719810684"
+    },
+    {
+      "chainId": 8453,
       "address": "0xcd2f22236dd9dfe2356d7c543161d4d260fd9bcb",
       "name": "Aavegotchi",
       "symbol": "GHST",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/12467/large/GHST.png?1696512286"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x236aa50979d5f3de3bd1eeb40e81137f22ab794b",
-      "name": "tBTC",
-      "symbol": "TBTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4158734d47fc9692176b5085e0f52ee0da5d47f1",
-      "name": "Balancer",
-      "symbol": "BAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376",
-      "name": "Overnight fi USD   Base ",
-      "symbol": "USD+",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39624/large/USD_.png?1723179227"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x64b88c73a5dfa78d1713fe1b4c69a22d7e0faaa7",
-      "name": "Maverick Protocol",
-      "symbol": "MAV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30850/large/MAV_Logo.png?1696529701"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",
-      "name": "L2 Standard Bridged USDT  Base ",
-      "symbol": "USDT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39963/large/usdt.png?1724952731"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x50da645f148798f68ef2d7db7c1cb22a6819bb2c",
-      "name": "SPX6900",
-      "symbol": "SPX",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/31401/large/sticker_%281%29.jpg?1702371083"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0db510e79909666d6dec7f5e49370838c16d950f",
-      "name": "Anon",
-      "symbol": "ANON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51871/large/_.png?1732095727"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x768be13e1680b5ebe0024c42c896e3db59ec0149",
-      "name": "Ski Mask Dog",
-      "symbol": "SKI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37195/large/32992128-F52F-4346-84CA-8E0C48F43606.jpeg?1713676521"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb1a03eda10342529bbf8eb700a06c60441fef25d",
-      "name": "Mister Miggles",
-      "symbol": "MIGGLES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39251/large/photo_2024-11-14_16-50-08_%282%29.jpg?1731814015"
     },
     {
       "chainId": 8453,
@@ -404,11 +396,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0x67f0870bb897f5e1c369976b4a2962d527b9562c",
-      "name": "Department Of Government Efficiency",
-      "symbol": "DOGE",
+      "address": "0xd89d90d26b48940fa8f58385fe84625d468e057a",
+      "name": "Avail",
+      "symbol": "AVAIL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39841/large/IMG_9775.PNG?1729771739"
+      "logoURI": "https://assets.coingecko.com/coins/images/37372/large/avail-logo.png?1714145201"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x236aa50979d5f3de3bd1eeb40e81137f22ab794b",
+      "name": "tBTC",
+      "symbol": "TBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x768be13e1680b5ebe0024c42c896e3db59ec0149",
+      "name": "Ski Mask Dog",
+      "symbol": "SKI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37195/large/32992128-F52F-4346-84CA-8E0C48F43606.jpeg?1713676521"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c",
+      "name": "Rocket Pool ETH",
+      "symbol": "RETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20764/large/reth.png?1696520159"
     },
     {
       "chainId": 8453,
@@ -420,6 +436,14 @@
     },
     {
       "chainId": 8453,
+      "address": "0xb676f87a6e701f0de8de5ab91b56b66109766db1",
+      "name": "BLOCKLORDS",
+      "symbol": "LRDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34775/large/LRDS_PNG.png?1706001771"
+    },
+    {
+      "chainId": 8453,
       "address": "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22",
       "name": "Coinbase Wrapped Staked ETH",
       "symbol": "CBETH",
@@ -428,11 +452,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0x1bc0c42215582d5a085795f4badbac3ff36d1bcb",
-      "name": "tokenbot",
-      "symbol": "CLANKER",
+      "address": "0x2a06a17cbc6d0032cac2c6696da90f29d39a1a29",
+      "name": "HarryPotterObamaSonic10Inu  ETH ",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x91ad1b44913cd1b8241a4ff1e2eaa198da6bf4c9",
+      "name": "Altura",
+      "symbol": "ALU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51440/large/CLANKER.png?1731232869"
+      "logoURI": "https://assets.coingecko.com/coins/images/15127/large/logo-dark.png?1696514784"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb1a03eda10342529bbf8eb700a06c60441fef25d",
+      "name": "Mister Miggles",
+      "symbol": "MIGGLES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39251/large/photo_2024-11-14_16-50-08_%282%29.jpg?1731814015"
     },
     {
       "chainId": 8453,
@@ -452,235 +492,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x9c632e6aaa3ea73f91554f8a3cb2ed2f29605e0c",
-      "name": "Onyxcoin",
-      "symbol": "XCN",
+      "address": "0x67f0870bb897f5e1c369976b4a2962d527b9562c",
+      "name": "Department Of Government Efficiency",
+      "symbol": "DOGE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24210/large/onyxlogo.jpg?1696523397"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
-      "name": "Renzo Restaked ETH",
-      "symbol": "EZETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x91ad1b44913cd1b8241a4ff1e2eaa198da6bf4c9",
-      "name": "Altura",
-      "symbol": "ALU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15127/large/logo-dark.png?1696514784"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfb1aaba03c31ea98a3eec7591808acb1947ee7ac",
-      "name": "Gains Network",
-      "symbol": "GNS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19737/large/logo.png?1696519161"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd89d90d26b48940fa8f58385fe84625d468e057a",
-      "name": "Avail",
-      "symbol": "AVAIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37372/large/avail-logo.png?1714145201"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3b86ad95859b6ab773f55f8d94b4b9d443ee931f",
-      "name": "Solv Protocol SolvBTC",
-      "symbol": "SOLVBTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36800/large/solvBTC.png?1719810684"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe997017e0cb0ceb503565f181e9ea922cd979c35",
-      "name": "LimeWire",
-      "symbol": "LMWR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30356/large/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xecac9c5f704e954931349da37f60e39f515c11c1",
-      "name": "Lombard Staked BTC",
-      "symbol": "LBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39969/large/LBTC_Logo.png?1724959872"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2a06a17cbc6d0032cac2c6696da90f29d39a1a29",
-      "name": "HarryPotterObamaSonic10Inu  ETH ",
-      "symbol": "BITCOIN",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3792dbdd07e87413247df995e692806aa13d3299",
-      "name": "ECOMI",
-      "symbol": "OMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4428/large/ECOMI.png?1696505023"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb0505e5a99abd03d94a1169e638b78edfed26ea4",
-      "name": "Wrapped SUI  Universal ",
-      "symbol": "USUI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50482/large/UA-SUI-PAD.png?1727888681"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
-      "name": "Pocket Network",
-      "symbol": "POKT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf5bc3439f53a45607ccad667abc7daf5a583633f",
-      "name": "AgentLayer",
-      "symbol": "AGENT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50213/large/Logo-Mark-White_256.png?1726433757"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x619c4bbbd65f836b78b36cbe781513861d57f39d",
-      "name": "Bitget Wallet Token",
-      "symbol": "BWB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37767/large/bwb.png?1715480561"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x161e113b8e9bbaefb846f73f31624f6f9607bd44",
-      "name": "Simmi Token",
-      "symbol": "SIMMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52349/large/simmi.png?1733160996"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x04c0599ae5a44757c0af6f9ec3b93da8976c150a",
-      "name": "ether fi Bridged weETH  Base ",
-      "symbol": "WEETHBASE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39950/large/WETH.PNG?1724902237"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9a26f5433671751c3276a065f57e5a02d2817973",
-      "name": "Keyboard Cat  Base ",
-      "symbol": "KEYCAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36608/large/keyboard_cat.jpeg?1711965348"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x20d704099b62ada091028bcfc44445041ed16f09",
-      "name": "Chaos",
-      "symbol": "CHAOS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52444/large/chaos-2.jpg?1733365634"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3e31966d4f81c72d2a55310a6365a56a4393e98d",
-      "name": "World Mobile Token",
-      "symbol": "WMTX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x57f5fbd3de65dfc0bd3630f732969e5fb97e6d37",
-      "name": "MAGA",
-      "symbol": "TRUMP",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/31498/large/Maga-Trump-Logo-200px.png?1696530309"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc48823ec67720a04a9dfd8c7d109b2c3d6622094",
-      "name": "Metacade",
-      "symbol": "MCADE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29764/large/Square_Profile_Photo_1080_x_1080px.png?1699396445"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc0fbc4967259786c743361a5885ef49380473dcf",
-      "name": "Aleph im",
-      "symbol": "ALEPH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11676/large/Aleph-Logo-BW.png?1696511566"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x97c806e7665d3afd84a8fe1837921403d59f3dcc",
-      "name": "Artificial Liquid Intelligence",
-      "symbol": "ALI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22062/large/ALI-v2.webp?1728501978"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x50c5725949a6f0c72e6c4a641f24049a917db0cb",
-      "name": "L2 Standard Bridged DAI  Base ",
-      "symbol": "DAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39807/large/dai.png?1724126571"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc43f3ae305a92043bd9b62ebd2fe14f7547ee485",
-      "name": "CHEX Token",
-      "symbol": "CHEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10349/large/logo-white-bg-dark.png?1733475849"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x18dd5b087bca9920562aff7a0199b96b9230438b",
-      "name": "Propy",
-      "symbol": "PRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/869/large/propy.png?1696502002"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x23a96680ccde03bd4bdd9a3e9a0cb56a5d27f7c9",
-      "name": "Henlo",
-      "symbol": "HENLO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52083/large/henlo.webp?1732532244"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c",
-      "name": "Rocket Pool ETH",
-      "symbol": "RETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20764/large/reth.png?1696520159"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
-      "name": "OX Coin",
-      "symbol": "OX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
+      "logoURI": "https://assets.coingecko.com/coins/images/39841/large/IMG_9775.PNG?1729771739"
     },
     {
       "chainId": 8453,
@@ -692,67 +508,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0xe2b1dc2d4a3b4e59fdf0c47b71a7a86391a8b35a",
-      "name": "RWA Inc ",
-      "symbol": "RWA",
+      "address": "0xfb1aaba03c31ea98a3eec7591808acb1947ee7ac",
+      "name": "Gains Network",
+      "symbol": "GNS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50975/large/logo_%281%29.png?1732594737"
+      "logoURI": "https://assets.coingecko.com/coins/images/19737/large/logo.png?1696519161"
     },
     {
       "chainId": 8453,
-      "address": "0x4621b7a9c75199271f773ebd9a499dbd165c3191",
-      "name": "DOLA",
-      "symbol": "DOLA",
+      "address": "0xe997017e0cb0ceb503565f181e9ea922cd979c35",
+      "name": "LimeWire",
+      "symbol": "LMWR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x029a3b0532871735809a51e8653d6017ef04b6fa",
-      "name": "TYBENG",
-      "symbol": "TYBENG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31022/large/NVoa_mZ6_400x400.jpg?1721805735"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x455234ab787665a219125235fb01b22b512dfcaa",
-      "name": "DOSE",
-      "symbol": "DOSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18847/large/dose.PNG?1696518308"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfad8cb754230dbfd249db0e8eccb5142dd675a0d",
-      "name": "AEROBUD",
-      "symbol": "AEROBUD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38210/large/Logo_Coingecko.png?1716798924"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb676f87a6e701f0de8de5ab91b56b66109766db1",
-      "name": "BLOCKLORDS",
-      "symbol": "LRDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34775/large/LRDS_PNG.png?1706001771"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf31e6d62bfc485857af2186eb3d8ee94b4379fed",
-      "name": "Chinese Doge Wow",
-      "symbol": "CHIDO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52054/large/1.png?1732449299"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x890a40bfae3bf25a5e7c50a31505774ee7a5d33b",
-      "name": "Worldwide USD",
-      "symbol": "WUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
+      "logoURI": "https://assets.coingecko.com/coins/images/30356/large/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
     },
     {
       "chainId": 8453,
@@ -764,11 +532,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0xbc45647ea894030a4e9801ec03479739fa2485f0",
-      "name": "Basenji",
-      "symbol": "BENJI",
+      "address": "0xe2b1dc2d4a3b4e59fdf0c47b71a7a86391a8b35a",
+      "name": "RWA Inc ",
+      "symbol": "RWA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36416/large/ben200x200.jpg?1711420807"
+      "logoURI": "https://assets.coingecko.com/coins/images/50975/large/logo_%281%29.png?1732594737"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3e31966d4f81c72d2a55310a6365a56a4393e98d",
+      "name": "World Mobile Token",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1bc0c42215582d5a085795f4badbac3ff36d1bcb",
+      "name": "tokenbot",
+      "symbol": "CLANKER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51440/large/CLANKER.png?1731232869"
     },
     {
       "chainId": 8453,
@@ -780,115 +564,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0xb33ff54b9f7242ef1593d2c9bcd8f9df46c77935",
-      "name": "Freysa AI",
-      "symbol": "FAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52315/large/FAI.png?1733076295"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3d2eba645c44bbd32a34b7c017667711eb5b173c",
-      "name": "Wrapped MistCoin",
-      "symbol": "WMC",
-      "decimals": 2,
-      "logoURI": "https://assets.coingecko.com/coins/images/32490/large/355966EE-F4AD-4023-A38E-59B9DEF1C6C3.jpeg?1732678326"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd6aaf4d477999fa50c5a1aa35f708862113a73cc",
-      "name": "Propbase",
-      "symbol": "PROPS",
+      "address": "0xecac9c5f704e954931349da37f60e39f515c11c1",
+      "name": "Lombard Staked BTC",
+      "symbol": "LBTC",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/32932/large/PROP_BASE_%286%29.png?1699870054"
+      "logoURI": "https://assets.coingecko.com/coins/images/39969/large/LBTC_Logo.png?1724959872"
     },
     {
       "chainId": 8453,
-      "address": "0x15ac90165f8b45a80534228bdcb124a011f62fee",
-      "name": "MOEW",
-      "symbol": "MOEW",
+      "address": "0x9c632e6aaa3ea73f91554f8a3cb2ed2f29605e0c",
+      "name": "Onyxcoin",
+      "symbol": "XCN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36737/large/img_v3_02h9_c36546da-c4b6-4636-bc50-5239ab5d78hu.png?1733472868"
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/large/onyxlogo.jpg?1696523397"
     },
     {
       "chainId": 8453,
-      "address": "0x9b8df6e244526ab5f6e6400d331db28c8fdddb55",
-      "name": "Wrapped Solana  Universal ",
-      "symbol": "USOL",
+      "address": "0x619c4bbbd65f836b78b36cbe781513861d57f39d",
+      "name": "Bitget Wallet Token",
+      "symbol": "BWB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39987/large/UA-SOL_1.png?1725027946"
+      "logoURI": "https://assets.coingecko.com/coins/images/37767/large/bwb.png?1715480561"
     },
     {
       "chainId": 8453,
-      "address": "0x0fd7a301b51d0a83fcaf6718628174d527b373b6",
-      "name": "Luminous",
-      "symbol": "LUM",
+      "address": "0xbc45647ea894030a4e9801ec03479739fa2485f0",
+      "name": "Basenji",
+      "symbol": "BENJI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51439/large/LUM.jpg?1731232511"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1dd2d631c92b1acdfcdd51a0f7145a50130050c4",
-      "name": "Alien Base",
-      "symbol": "ALB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31301/large/ALB.png?1720133373"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1185cb5122edad199bdbc0cbd7a0457e448f23c7",
-      "name": "sekoia by Virtuals",
-      "symbol": "SEKOIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51785/large/sekoia.jpg?1731982234"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa7d68d155d17cb30e311367c2ef1e82ab6022b67",
-      "name": "Braintrust",
-      "symbol": "BTRST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18100/large/braintrust.PNG?1696517605"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfb0c734fc3008683c5eff45bcf8128836c4d97d0",
-      "name": "Vertex",
-      "symbol": "VRTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27927/large/vrtx.png?1696526947"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0a953dd9fc813fefaf6015b804c9dfa0624690c0",
-      "name": "Cornucopias",
-      "symbol": "COPI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21452/large/g56WwJDA_400x400.jpg?1696520814"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9e81f6495ba29a6b4d48bddd042c0598fa8abc9f",
-      "name": "MATH",
-      "symbol": "MATH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11335/large/2020-05-19-token-200.png?1696511257"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xea651c035f52b644856cab1f59775369c36ecadd",
-      "name": "La ka",
-      "symbol": "LAIKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39364/large/logo_laika.jpg?1721895773"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfd4330b0312fdeec6d4225075b82e00493ff2e3f",
-      "name": "SmarDex",
-      "symbol": "SDEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29470/large/SDEX_logo_transparent_outside_240x240.png?1696930070"
+      "logoURI": "https://assets.coingecko.com/coins/images/36416/large/ben200x200.jpg?1711420807"
     },
     {
       "chainId": 8453,
@@ -900,51 +604,139 @@
     },
     {
       "chainId": 8453,
-      "address": "0x750cf88d9e0c2bcedeec31d5faad6ed6e3f1abc6",
-      "name": "XCAD Network",
-      "symbol": "XCAD",
+      "address": "0xc26c9099bd3789107888c35bb41178079b282561",
+      "name": "Solv Protocol SolvBTC BBN",
+      "symbol": "SOLVBTCBBN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15857/large/xcad_logo.jpg?1707832192"
+      "logoURI": "https://assets.coingecko.com/coins/images/39384/large/unnamed.png?1721961640"
     },
     {
       "chainId": 8453,
-      "address": "0x55cd6469f597452b5a7536e2cd98fde4c1247ee4",
-      "name": "Luna by Virtuals",
-      "symbol": "LUNA",
+      "address": "0xf5bc3439f53a45607ccad667abc7daf5a583633f",
+      "name": "AgentLayer",
+      "symbol": "AGENT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50880/large/luna.png?1729478763"
+      "logoURI": "https://assets.coingecko.com/coins/images/50213/large/Logo-Mark-White_256.png?1726433757"
     },
     {
       "chainId": 8453,
-      "address": "0x2c8c89c442436cc6c0a77943e09c8daf49da3161",
-      "name": "Zeebu",
-      "symbol": "ZBU",
+      "address": "0xb0505e5a99abd03d94a1169e638b78edfed26ea4",
+      "name": "Wrapped SUI  Universal ",
+      "symbol": "USUI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31145/large/200x200_Front_token.png?1696529974"
+      "logoURI": "https://assets.coingecko.com/coins/images/50482/large/UA-SUI-PAD.png?1727888681"
     },
     {
       "chainId": 8453,
-      "address": "0x0bbbead62f7647ae8323d2cb243a0db74b7c2b80",
-      "name": "Ambire Wallet",
-      "symbol": "WALLET",
+      "address": "0xc43f3ae305a92043bd9b62ebd2fe14f7547ee485",
+      "name": "CHEX Token",
+      "symbol": "CHEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23154/large/wallet.PNG?1696522445"
+      "logoURI": "https://assets.coingecko.com/coins/images/10349/large/logo-white-bg-dark.png?1733475849"
     },
     {
       "chainId": 8453,
-      "address": "0xafb89a09d82fbde58f18ac6437b3fc81724e4df6",
-      "name": "Own The Doge",
-      "symbol": "DOG",
+      "address": "0x029a3b0532871735809a51e8653d6017ef04b6fa",
+      "name": "TYBENG",
+      "symbol": "TYBENG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18111/large/Doge.png?1696517615"
+      "logoURI": "https://assets.coingecko.com/coins/images/31022/large/NVoa_mZ6_400x400.jpg?1721805735"
     },
     {
       "chainId": 8453,
-      "address": "0x08c81699f9a357a9f0d04a09b353576ca328d60d",
-      "name": "nftxbt by Virtuals",
-      "symbol": "NFTXBT",
+      "address": "0x57f5fbd3de65dfc0bd3630f732969e5fb97e6d37",
+      "name": "MAGA",
+      "symbol": "TRUMP",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/31498/large/Maga-Trump-Logo-200px.png?1696530309"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x50c5725949a6f0c72e6c4a641f24049a917db0cb",
+      "name": "L2 Standard Bridged DAI  Base ",
+      "symbol": "DAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52332/large/nftxbt_logo.jpg?1733087152"
+      "logoURI": "https://assets.coingecko.com/coins/images/39807/large/dai.png?1724126571"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc48823ec67720a04a9dfd8c7d109b2c3d6622094",
+      "name": "Metacade",
+      "symbol": "MCADE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29764/large/Square_Profile_Photo_1080_x_1080px.png?1699396445"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x18dd5b087bca9920562aff7a0199b96b9230438b",
+      "name": "Propy",
+      "symbol": "PRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/869/large/propy.png?1696502002"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x455234ab787665a219125235fb01b22b512dfcaa",
+      "name": "DOSE",
+      "symbol": "DOSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18847/large/dose.PNG?1696518308"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4621b7a9c75199271f773ebd9a499dbd165c3191",
+      "name": "DOLA",
+      "symbol": "DOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
+      "name": "Pocket Network",
+      "symbol": "POKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x97c806e7665d3afd84a8fe1837921403d59f3dcc",
+      "name": "Artificial Liquid Intelligence",
+      "symbol": "ALI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22062/large/ALI-v2.webp?1728501978"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x890a40bfae3bf25a5e7c50a31505774ee7a5d33b",
+      "name": "Worldwide USD",
+      "symbol": "WUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x161e113b8e9bbaefb846f73f31624f6f9607bd44",
+      "name": "Simmi Token",
+      "symbol": "SIMMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52349/large/simmi.png?1733160996"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0fd7a301b51d0a83fcaf6718628174d527b373b6",
+      "name": "Luminous",
+      "symbol": "LUM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51439/large/LUM.jpg?1731232511"
     },
     {
       "chainId": 8453,
@@ -956,11 +748,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4",
-      "name": "Electronic USD",
-      "symbol": "EUSD",
+      "address": "0x2c8c89c442436cc6c0a77943e09c8daf49da3161",
+      "name": "Zeebu",
+      "symbol": "ZBU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28445/large/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
+      "logoURI": "https://assets.coingecko.com/coins/images/31145/large/200x200_Front_token.png?1696529974"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x20d704099b62ada091028bcfc44445041ed16f09",
+      "name": "Chaos",
+      "symbol": "CHAOS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52444/large/chaos-2.jpg?1733365634"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfb0c734fc3008683c5eff45bcf8128836c4d97d0",
+      "name": "Vertex",
+      "symbol": "VRTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27927/large/vrtx.png?1696526947"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x52b492a33e447cdb854c7fc19f1e57e8bfa1777d",
+      "name": "Based Pepe",
+      "symbol": "PEPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39763/large/based_pepe_transparent.png?1724010222"
     },
     {
       "chainId": 8453,
@@ -972,6 +788,54 @@
     },
     {
       "chainId": 8453,
+      "address": "0xfd4330b0312fdeec6d4225075b82e00493ff2e3f",
+      "name": "SmarDex",
+      "symbol": "SDEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29470/large/SDEX_logo_transparent_outside_240x240.png?1696930070"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x15ac90165f8b45a80534228bdcb124a011f62fee",
+      "name": "MOEW",
+      "symbol": "MOEW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36737/large/img_v3_02h9_c36546da-c4b6-4636-bc50-5239ab5d78hu.png?1733472868"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd6aaf4d477999fa50c5a1aa35f708862113a73cc",
+      "name": "Propbase",
+      "symbol": "PROPS",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/32932/large/PROP_BASE_%286%29.png?1699870054"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9b8df6e244526ab5f6e6400d331db28c8fdddb55",
+      "name": "Wrapped Solana  Universal ",
+      "symbol": "USOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39987/large/UA-SOL_1.png?1725027946"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9a26f5433671751c3276a065f57e5a02d2817973",
+      "name": "Keyboard Cat  Base ",
+      "symbol": "KEYCAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36608/large/keyboard_cat.jpeg?1711965348"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3792dbdd07e87413247df995e692806aa13d3299",
+      "name": "ECOMI",
+      "symbol": "OMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4428/large/ECOMI.png?1696505023"
+    },
+    {
+      "chainId": 8453,
       "address": "0xd2012fc1b913ce50732ebcaa7e601fe37ac728c6",
       "name": "StakeStone ETH",
       "symbol": "STONE",
@@ -980,43 +844,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0x27e3bc3a66e24cad043ac3d93a12a8070e3897ba",
-      "name": "Ovr",
-      "symbol": "OVR",
+      "address": "0x9e81f6495ba29a6b4d48bddd042c0598fa8abc9f",
+      "name": "MATH",
+      "symbol": "MATH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13429/large/LOGO-OVER-ICON-200X200PX.png?1699396496"
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/large/2020-05-19-token-200.png?1696511257"
     },
     {
       "chainId": 8453,
-      "address": "0x6921b130d297cc43754afba22e5eac0fbf8db75b",
-      "name": "doginme",
-      "symbol": "DOGINME",
+      "address": "0x0bbbead62f7647ae8323d2cb243a0db74b7c2b80",
+      "name": "Ambire Wallet",
+      "symbol": "WALLET",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35123/large/doginme-logo1-transparent200.png?1710856784"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
-      "name": "Mountain Protocol USD",
-      "symbol": "USDM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31719/large/usdm.png?1696530540"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
-      "name": "Cookie DAO",
-      "symbol": "COOKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38450/large/cookie_token_logo_200x200.png?1733194528"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xedfa23602d0ec14714057867a78d01e94176bea0",
-      "name": "Wrapped rsETH",
-      "symbol": "WRSETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37919/large/rseth.png?1715936438"
+      "logoURI": "https://assets.coingecko.com/coins/images/23154/large/wallet.PNG?1696522445"
     },
     {
       "chainId": 8453,
@@ -1028,59 +868,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xc7dcca0a3e69bd762c8db257f868f76be36c8514",
-      "name": "KiboShib",
-      "symbol": "KIBSHI",
+      "address": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
+      "name": "Cookie DAO",
+      "symbol": "COOKIE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29335/large/foto_no_exif_%2811%29%282%29_%281%29.png?1696528285"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x50ce4129ca261ccde4eb100c170843c2936bc11b",
-      "name": "KOLZ",
-      "symbol": "KOLZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51235/large/KOLZ.png?1730447667"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc26c9099bd3789107888c35bb41178079b282561",
-      "name": "Solv Protocol SolvBTC BBN",
-      "symbol": "SOLVBTCBBN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39384/large/unnamed.png?1721961640"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
-      "name": "PAW",
-      "symbol": "PAW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28946/large/PawLogo.png?1699394612"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x32e0f9d26d1e33625742a52620cc76c1130efde6",
-      "name": "BASED",
-      "symbol": "BASED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39669/large/BASED.jpg?1723603780"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x489fe42c267fe0366b16b0c39e7aeef977e841ef",
-      "name": "Wrapped Ampleforth",
-      "symbol": "WAMPL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20825/large/photo_2021-11-25_02-05-11.jpg?1696520218"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd3c68968137317a57a9babeacc7707ec433548b4",
-      "name": "Phavercoin",
-      "symbol": "SOCIAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50304/large/Phavercoin-_Social-MAIN-purple-logo-square.png?1727024458"
+      "logoURI": "https://assets.coingecko.com/coins/images/38450/large/cookie_token_logo_200x200.png?1733194528"
     },
     {
       "chainId": 8453,
@@ -1092,14 +884,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0x01facc69ec7360640aa5898e852326752801674a",
-      "name": "Fuse",
-      "symbol": "FUSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
-    },
-    {
-      "chainId": 8453,
       "address": "0x1c4cca7c5db003824208adda61bd749e55f463a3",
       "name": "GAME by Virtuals",
       "symbol": "GAME",
@@ -1108,59 +892,99 @@
     },
     {
       "chainId": 8453,
-      "address": "0x4e73420dcc85702ea134d91a262c8ffc0a72aa70",
-      "name": "SKI MASK PUP",
-      "symbol": "SKIPUP",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/38093/large/SkiPup_Logo.png?1716486539"
+      "address": "0x55cd6469f597452b5a7536e2cd98fde4c1247ee4",
+      "name": "Luna by Virtuals",
+      "symbol": "LUNA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50880/large/luna.png?1729478763"
     },
     {
       "chainId": 8453,
-      "address": "0x731814e491571a2e9ee3c5b1f7f3b962ee8f4870",
-      "name": "VaderAI by Virtuals",
-      "symbol": "VADER",
+      "address": "0x717d31a60a9e811469673429c9f8ea24358990f1",
+      "name": "Everyworld",
+      "symbol": "EVERY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51910/large/kare_pepe.png?1733345833"
+      "logoURI": "https://assets.coingecko.com/coins/images/36799/large/coin_gecko.png?1714459237"
     },
     {
       "chainId": 8453,
-      "address": "0xcde172dc5ffc46d228838446c57c1227e0b82049",
-      "name": "Boomer",
-      "symbol": "BOOMER",
+      "address": "0x750cf88d9e0c2bcedeec31d5faad6ed6e3f1abc6",
+      "name": "XCAD Network",
+      "symbol": "XCAD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36477/large/Token_Image_200x200.png?1714757172"
+      "logoURI": "https://assets.coingecko.com/coins/images/15857/large/xcad_logo.jpg?1707832192"
     },
     {
       "chainId": 8453,
-      "address": "0x0578d8a44db98b23bf096a382e016e29a5ce0ffe",
-      "name": "higher",
-      "symbol": "HIGHER",
+      "address": "0xedfa23602d0ec14714057867a78d01e94176bea0",
+      "name": "Wrapped rsETH",
+      "symbol": "WRSETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36084/large/200x200logo.png?1710427814"
+      "logoURI": "https://assets.coingecko.com/coins/images/37919/large/rseth.png?1715936438"
     },
     {
       "chainId": 8453,
-      "address": "0xe161be4a74ab8fa8706a2d03e67c02318d0a0ad6",
-      "name": "Apetardio",
-      "symbol": "APETARDIO",
+      "address": "0x23a96680ccde03bd4bdd9a3e9a0cb56a5d27f7c9",
+      "name": "Henlo",
+      "symbol": "HENLO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38155/large/apetardio200x200.png?1716669062"
+      "logoURI": "https://assets.coingecko.com/coins/images/52083/large/henlo.webp?1732532244"
     },
     {
       "chainId": 8453,
-      "address": "0x4f81837c2f4a189a0b69370027cc2627d93785b4",
-      "name": "Seraph by Virtuals",
-      "symbol": "SERAPH",
+      "address": "0xc7dcca0a3e69bd762c8db257f868f76be36c8514",
+      "name": "KiboShib",
+      "symbol": "KIBSHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52442/large/fire_guy.png?1733351187"
+      "logoURI": "https://assets.coingecko.com/coins/images/29335/large/foto_no_exif_%2811%29%282%29_%281%29.png?1696528285"
     },
     {
       "chainId": 8453,
-      "address": "0xbb22ff867f8ca3d5f2251b4084f6ec86d4666e14",
-      "name": "Cryptex Finance",
-      "symbol": "CTX",
+      "address": "0x2615a94df961278dcbc41fb0a54fec5f10a693ae",
+      "name": "Wrapped XRP  Universal ",
+      "symbol": "UXRP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14932/large/CTX_Logo_200px.png?1723514786"
+      "logoURI": "https://assets.coingecko.com/coins/images/51658/large/UA-XRP_1.png?1731703523"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xeb6d78148f001f3aa2f588997c5e102e489ad341",
+      "name": "Super Champs",
+      "symbol": "CHAMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51900/large/CHAMP_Token_256x256.png?1732131989"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xeec468333ccc16d4bf1cef497a56cf8c0aae4ca3",
+      "name": "Anzen Finance",
+      "symbol": "ANZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52456/large/ANZ_symbol200w.png?1733391218"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc0fbc4967259786c743361a5885ef49380473dcf",
+      "name": "Aleph im",
+      "symbol": "ALEPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/large/Aleph-Logo-BW.png?1696511566"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x32e0f9d26d1e33625742a52620cc76c1130efde6",
+      "name": "BASED",
+      "symbol": "BASED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39669/large/BASED.jpg?1723603780"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x27e3bc3a66e24cad043ac3d93a12a8070e3897ba",
+      "name": "Ovr",
+      "symbol": "OVR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13429/large/LOGO-OVER-ICON-200X200PX.png?1699396496"
     },
     {
       "chainId": 8453,
@@ -1172,6 +996,110 @@
     },
     {
       "chainId": 8453,
+      "address": "0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4",
+      "name": "Electronic USD",
+      "symbol": "EUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28445/large/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x703d57164ca270b0b330a87fd159cfef1490c0a5",
+      "name": "RAI Finance",
+      "symbol": "SOFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14686/large/sofi.png?1696514359"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5b2124d427fac9c80c902cbdd74b03dd85d7d3fe",
+      "name": "Dypius",
+      "symbol": "DYP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33016/large/RS-zDhFE_400x400.jpg?1700157370"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x04c0599ae5a44757c0af6f9ec3b93da8976c150a",
+      "name": "ether fi Bridged weETH  Base ",
+      "symbol": "WEETHBASE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39950/large/WETH.PNG?1724902237"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd3c68968137317a57a9babeacc7707ec433548b4",
+      "name": "Phavercoin",
+      "symbol": "SOCIAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50304/large/Phavercoin-_Social-MAIN-purple-logo-square.png?1727024458"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8bfac1b375bf2894d6f12fb2eb48b1c1a7916789",
+      "name": "Mey Network",
+      "symbol": "MEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52249/large/logo_mey_200.png?1732828172"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7588880d9c78e81fade7b7e8dc0781e95995a792",
+      "name": "Satoshi AI agent by Virtuals",
+      "symbol": "SAINT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52336/large/saint.jpg?1733121865"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
+      "name": "Gyroscope GYD",
+      "symbol": "GYD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1dd2d631c92b1acdfcdd51a0f7145a50130050c4",
+      "name": "Alien Base",
+      "symbol": "ALB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31301/large/ALB.png?1720133373"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x12e96c2bfea6e835cf8dd38a5834fa61cf723736",
+      "name": "Wrapped DOGE  Universal ",
+      "symbol": "UDOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40099/large/UA-DOGE_1.png?1725632510"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf31e6d62bfc485857af2186eb3d8ee94b4379fed",
+      "name": "Chinese Doge Wow",
+      "symbol": "CHIDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52054/large/1.png?1732449299"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x01facc69ec7360640aa5898e852326752801674a",
+      "name": "Fuse",
+      "symbol": "FUSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x50ce4129ca261ccde4eb100c170843c2936bc11b",
+      "name": "KOLZ",
+      "symbol": "KOLZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51235/large/KOLZ.png?1730447667"
+    },
+    {
+      "chainId": 8453,
       "address": "0x4e719699e4197f4bf4370c49acd3e3b8de11974f",
       "name": "Lovely Inu Finance",
       "symbol": "LOVELY",
@@ -1180,11 +1108,43 @@
     },
     {
       "chainId": 8453,
-      "address": "0xdb6e0e5094a25a052ab6845a9f1e486b9a9b3dde",
-      "name": "Okayeg",
-      "symbol": "OKAYEG",
+      "address": "0x73e2a6320314883ff8cc08b53f1460a5f4c47f2c",
+      "name": "Hacken",
+      "symbol": "HAI",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/11081/large/hacken-symbol-with-bg.png?1696511022"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6797b6244fa75f2e78cdffc3a4eb169332b730cc",
+      "name": "Eagle AI",
+      "symbol": "EAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37748/large/Okayeg_200.png?1715442444"
+      "logoURI": "https://assets.coingecko.com/coins/images/38650/large/Eagle_AI.png?1718215736"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6921b130d297cc43754afba22e5eac0fbf8db75b",
+      "name": "doginme",
+      "symbol": "DOGINME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35123/large/doginme-logo1-transparent200.png?1710856784"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb33ff54b9f7242ef1593d2c9bcd8f9df46c77935",
+      "name": "Freysa AI",
+      "symbol": "FAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52315/large/FAI.png?1733076295"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdfd579dd6aeb232e95a15d964a135a61925b5c93",
+      "name": "Marso Tech",
+      "symbol": "MARSO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50292/large/QKbwAja.png?1726905588"
     },
     {
       "chainId": 8453,
@@ -1196,11 +1156,147 @@
     },
     {
       "chainId": 8453,
-      "address": "0x02454a97a8372f3a760a033dbb39e67d73bd6d87",
-      "name": "Katana Inu",
-      "symbol": "KATA",
+      "address": "0xcde172dc5ffc46d228838446c57c1227e0b82049",
+      "name": "Boomer",
+      "symbol": "BOOMER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21872/large/Katana_Inu512.png?1696521226"
+      "logoURI": "https://assets.coingecko.com/coins/images/36477/large/Token_Image_200x200.png?1714757172"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xafb89a09d82fbde58f18ac6437b3fc81724e4df6",
+      "name": "Own The Doge",
+      "symbol": "DOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18111/large/Doge.png?1696517615"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2f20cf3466f80a5f7f532fca553c8cbc9727fef6",
+      "name": "Akuma Inu",
+      "symbol": "AKUMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52182/large/IMG_7527.PNG?1732690402"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xea651c035f52b644856cab1f59775369c36ecadd",
+      "name": "La ka",
+      "symbol": "LAIKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39364/large/logo_laika.jpg?1721895773"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfad8cb754230dbfd249db0e8eccb5142dd675a0d",
+      "name": "AEROBUD",
+      "symbol": "AEROBUD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38210/large/Logo_Coingecko.png?1716798924"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfbb75a59193a3525a8825bebe7d4b56899e2f7e1",
+      "name": "ResearchCoin",
+      "symbol": "RSC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28146/large/RH_BOTTLE_CLEAN_Aug_2024_1.png?1732742001"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd98832e8a59156acbee4744b9a94a9989a728f36",
+      "name": "AgentAIgo",
+      "symbol": "AGENT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52294/large/agent_logo.jpg?1732966712"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc4d44c155f95fd4e94600d191a4a01bb571df7df",
+      "name": "GammaSwap",
+      "symbol": "GS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29222/large/newLogo2.png?1731702645"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe2dca969624795985f2f083bcd0b674337ba130a",
+      "name": "Saakuru",
+      "symbol": "SKR",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/37058/large/saakuru.jpeg?1713172376"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1185cb5122edad199bdbc0cbd7a0457e448f23c7",
+      "name": "sekoia by Virtuals",
+      "symbol": "SEKOIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51785/large/sekoia.jpg?1731982234"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2d189eabb667aa1ecfc01963a6a3a5d83960f558",
+      "name": "GALAXIS Token",
+      "symbol": "GALAXIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36221/large/500x500.png?1714755244"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa7d68d155d17cb30e311367c2ef1e82ab6022b67",
+      "name": "Braintrust",
+      "symbol": "BTRST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18100/large/braintrust.PNG?1696517605"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc0d3700000987c99b3c9009069e4f8413fd22330",
+      "name": "Cod3x USD",
+      "symbol": "CDXUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51438/large/logo-128x128.png?1731224236"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x70737489dfdf1a29b7584d40500d3561bd4fe196",
+      "name": "BORED",
+      "symbol": "BORED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37050/large/bored.jpeg?1713340233"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0a953dd9fc813fefaf6015b804c9dfa0624690c0",
+      "name": "Cornucopias",
+      "symbol": "COPI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21452/large/g56WwJDA_400x400.jpg?1696520814"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfe550bffb51eb645ea3b324d772a19ac449e92c5",
+      "name": "IX Swap",
+      "symbol": "IXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18069/large/ixswap.PNG?1696517577"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9a33406165f562e16c3abd82fd1185482e01b49a",
+      "name": "Talent Protocol",
+      "symbol": "TALENT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51120/large/Ticker-logo-200.png?1730128751"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa3a2cdd230f9b3ff6e01a01534a3ed3cbf049815",
+      "name": "zkRace",
+      "symbol": "ZERC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17438/large/zkRace-logomark-border.png?1716518566"
     },
     {
       "chainId": 8453,
@@ -1220,355 +1316,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x9a33406165f562e16c3abd82fd1185482e01b49a",
-      "name": "Talent Protocol",
-      "symbol": "TALENT",
+      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
+      "name": "Dexalot",
+      "symbol": "ALOT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51120/large/Ticker-logo-200.png?1730128751"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xeb6d78148f001f3aa2f588997c5e102e489ad341",
-      "name": "Super Champs",
-      "symbol": "CHAMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51900/large/CHAMP_Token_256x256.png?1732131989"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2615a94df961278dcbc41fb0a54fec5f10a693ae",
-      "name": "Wrapped XRP  Universal ",
-      "symbol": "UXRP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51658/large/UA-XRP_1.png?1731703523"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2676e4e0e2eb58d9bdb5078358ff8a3a964cedf5",
-      "name": "Polytrader by Virtuals",
-      "symbol": "POLY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52168/large/poly.jpg?1732682921"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6e51b3a19f114013e5dc09d0477a536c7e4e0207",
-      "name": "Media Network",
-      "symbol": "MEDIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15142/large/media50x50.png?1696514798"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x52b492a33e447cdb854c7fc19f1e57e8bfa1777d",
-      "name": "Based Pepe",
-      "symbol": "PEPE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39763/large/based_pepe_transparent.png?1724010222"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2d189eabb667aa1ecfc01963a6a3a5d83960f558",
-      "name": "GALAXIS Token",
-      "symbol": "GALAXIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36221/large/500x500.png?1714755244"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfbb75a59193a3525a8825bebe7d4b56899e2f7e1",
-      "name": "ResearchCoin",
-      "symbol": "RSC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28146/large/RH_BOTTLE_CLEAN_Aug_2024_1.png?1732742001"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc4d44c155f95fd4e94600d191a4a01bb571df7df",
-      "name": "GammaSwap",
-      "symbol": "GS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29222/large/newLogo2.png?1731702645"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa3a2cdd230f9b3ff6e01a01534a3ed3cbf049815",
-      "name": "zkRace",
-      "symbol": "ZERC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17438/large/zkRace-logomark-border.png?1716518566"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfe550bffb51eb645ea3b324d772a19ac449e92c5",
-      "name": "IX Swap",
-      "symbol": "IXS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18069/large/ixswap.PNG?1696517577"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x703d57164ca270b0b330a87fd159cfef1490c0a5",
-      "name": "RAI Finance",
-      "symbol": "SOFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14686/large/sofi.png?1696514359"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5ed25e305e08f58afd7995eac72563e6be65a617",
-      "name": "Wrapped NEAR  Universal ",
-      "symbol": "UNEAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50645/large/UA-NEAR_1.png?1728579564"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7588880d9c78e81fade7b7e8dc0781e95995a792",
-      "name": "Satoshi AI agent by Virtuals",
-      "symbol": "SAINT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52336/large/saint.jpg?1733121865"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x64cb1bafc59bf93aeb90676885c63540cf4f4106",
-      "name": "Coin6900",
-      "symbol": "COIN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51425/large/logo.jpg?1731186114"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x24569d33653c404f90af10a2b98d6e0030d3d267",
-      "name": "Unagi Token",
-      "symbol": "UNA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34733/large/unagi.png?1705922276"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd07379a755a8f11b57610154861d694b2a0f615a",
-      "name": "Base",
-      "symbol": "BASE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31199/large/59302ba8-022e-45a4-8d00-e29fe2ee768c-removebg-preview.png?1696530026"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x73e2a6320314883ff8cc08b53f1460a5f4c47f2c",
-      "name": "Hacken",
-      "symbol": "HAI",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/11081/large/hacken-symbol-with-bg.png?1696511022"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x85483696cc9970ad9edd786b2c5ef735f38d156f",
-      "name": "Overnight fi USDC ",
-      "symbol": "USDC+",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/34763/large/USDC_.png?1705990720"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9aaae745cf2830fb8ddc6248b17436dc3a5e701c",
-      "name": "Gochujangcoin",
-      "symbol": "GOCHU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39318/large/GochujangLogo_200_3x.png?1721709656"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcf67815cce72e682eb4429eca46843bed81ca739",
-      "name": "GAM3S GG",
-      "symbol": "G3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35662/large/G3_logo.jpg?1709454143"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xebff2db643cf955247339c8c6bcd8406308ca437",
-      "name": "ChompCoin",
-      "symbol": "CHOMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36942/large/chomplogo200.png?1712864472"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3c5fdf0ee37d62c774025599e3b692d027746e24",
-      "name": "Bonkey",
-      "symbol": "BONKEY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51629/large/nWKo5DZvrtkwwjtT7YXyYQeDstBhvwrqxdOmGmWvUNN6d_GSurf_TR1InJS8oLo2WYIJG2ZsX2Lffmr8z1bjqjygtVNcAKuMIX3TJPg65wPZepTpTQnXCXZrbA_oXuiIkzN2PU1vd1i6scKtGgJa4ffeecm1R7WzR7NX65j6JVu_ys42VMrpvNuNJ2ovRGM8sh9V-MovD8Mbs9NkaYQ_%281%29.jpg?1731664154"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe2dca969624795985f2f083bcd0b674337ba130a",
-      "name": "Saakuru",
-      "symbol": "SKR",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/37058/large/saakuru.jpeg?1713172376"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x478e03d45716dda94f6dbc15a633b0d90c237e2f",
-      "name": "Shaka",
-      "symbol": "SHAKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36850/large/sharetheshaka.png?1712585688"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3c281a39944a2319aa653d81cfd93ca10983d234",
-      "name": "Build",
-      "symbol": "BUILD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37836/large/buildlogo.png?1715741487"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8319767a7b602f88e376368dca1b92d38869b9b4",
-      "name": "Based Peaches",
-      "symbol": "PEACH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36762/large/Peaches-New-Logo-200x200.png?1719742607"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3ecced5b416e58664f04a39dd18935eb71d33b15",
-      "name": "Brian",
-      "symbol": "BRIAN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51099/large/Brian_Arm_Strong.png?1730083824"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x98f4779fccb177a6d856dd1dfd78cd15b7cd2af5",
-      "name": "MISATO",
-      "symbol": "MISATO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52231/large/misatocleanboost.png?1732802425"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xca4569949699d56e1834efe9f58747ca0f151b01",
-      "name": "Token Metrics AI",
-      "symbol": "TMAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37707/large/Mascot_200x200.png?1733173189"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6d3b8c76c5396642960243febf736c6be8b60562",
-      "name": "Skull of Pepe Token",
-      "symbol": "SKOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38342/large/skop.jpeg?1717141011"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdcefd8c8fcc492630b943abcab3429f12ea9fea2",
-      "name": "KlimaDAO",
-      "symbol": "KLIMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19169/large/Klima-Token.png?1696518618"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x85e90a5430af45776548adb82ee4cd9e33b08077",
-      "name": "Coding Dino",
-      "symbol": "DINO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36637/large/dino_icon_copy.png?1712029544"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3d1d651761d535df881740ab50ba4bd8a2ec2c00",
-      "name": "Synthesizer Dog",
-      "symbol": "SYNDOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51577/large/SYNDOG_LOGO.png?1731534533"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe2c86869216ac578bd62a4b8313770d9ee359a05",
-      "name": "EMAIL Token",
-      "symbol": "EMT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38631/large/EMT_square_LG%282%29.png?1718171885"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x47b464edb8dc9bc67b5cd4c9310bb87b773845bd",
-      "name": "NORMIE",
-      "symbol": "NORMIE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/35880/large/NORMIEsite.png?1709983341"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbdf5bafee1291eec45ae3aadac89be8152d4e673",
-      "name": "Catamoto",
-      "symbol": "CATA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37218/large/200x200.png?1713774219"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6b2504a03ca4d43d0d73776f6ad46dab2f2a4cfd",
-      "name": "Unit 00   Rei",
-      "symbol": "REI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52005/large/Unit_00_-_Rei.jpg?1732592775"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2974dc646e375e83bd1c0342625b49f288987fa4",
-      "name": "Swarm Markets",
-      "symbol": "SMT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17488/large/swarm-SMT-token-symbol_200x200.png?1696517029"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
-      "name": "Osaka Protocol",
-      "symbol": "OSAK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30911/large/OSAK_LOGO_200x200.png?1723662197"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf2d3d488626a117984fda70f8106abc0049018d3",
-      "name": "Miracle Play",
-      "symbol": "MPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32653/large/MPT.png?1698895300"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x10f434b3d1cc13a4a79b062dcc25706f64d10d47",
-      "name": "BEPE",
-      "symbol": "BEPE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/35989/large/NEW_LOGO200x200.png?1721595288"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9b700b043e9587dde9a0c29a9483e2f8fa450d54",
-      "name": "AxonDAO Governance Token",
-      "symbol": "AXGT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35290/large/AXGT-logo-7.png?1708076161"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x30121d81f4407474a6d93f5c3060f14aaa098a61",
-      "name": "Insane Labz  Base ",
-      "symbol": "LABZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51886/large/Photo_May_18_2024__6_11_22_PM.jpg?1732120518"
+      "logoURI": "https://assets.coingecko.com/coins/images/24188/large/logo_200x200.png?1696523376"
     },
     {
       "chainId": 8453,
@@ -1580,251 +1332,51 @@
     },
     {
       "chainId": 8453,
-      "address": "0x5b2124d427fac9c80c902cbdd74b03dd85d7d3fe",
-      "name": "Dypius",
-      "symbol": "DYP",
+      "address": "0x02454a97a8372f3a760a033dbb39e67d73bd6d87",
+      "name": "Katana Inu",
+      "symbol": "KATA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33016/large/RS-zDhFE_400x400.jpg?1700157370"
+      "logoURI": "https://assets.coingecko.com/coins/images/21872/large/Katana_Inu512.png?1696521226"
     },
     {
       "chainId": 8453,
-      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
-      "name": "Gyroscope GYD",
-      "symbol": "GYD",
+      "address": "0x642e993fa91ffe9fb24d39a8eb0e0663145f8e92",
+      "name": "BASED RABBIT",
+      "symbol": "RABBIT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
+      "logoURI": "https://assets.coingecko.com/coins/images/38843/large/BASED_RABBIT_200x200.png?1719202239"
     },
     {
       "chainId": 8453,
-      "address": "0x589864a9892b1a736ae70a91824ab4dc591fd8cd",
-      "name": "Gibape",
-      "symbol": "GIB",
+      "address": "0x0578d8a44db98b23bf096a382e016e29a5ce0ffe",
+      "name": "higher",
+      "symbol": "HIGHER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37691/large/gib_ape_logo.jpeg?1715650189"
+      "logoURI": "https://assets.coingecko.com/coins/images/36084/large/200x200logo.png?1710427814"
     },
     {
       "chainId": 8453,
-      "address": "0xcb327b99ff831bf8223cced12b1338ff3aa322ff",
-      "name": "Based ETH",
-      "symbol": "BSDETH",
+      "address": "0xf2d3d488626a117984fda70f8106abc0049018d3",
+      "name": "Miracle Play",
+      "symbol": "MPT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35774/large/Icon_White_on_Blue.png?1709793654"
+      "logoURI": "https://assets.coingecko.com/coins/images/32653/large/MPT.png?1698895300"
     },
     {
       "chainId": 8453,
-      "address": "0x9c0e042d65a2e1ff31ac83f404e5cb79f452c337",
-      "name": "Wrapped Aptos  Universal ",
-      "symbol": "UAPT",
+      "address": "0x85e90a5430af45776548adb82ee4cd9e33b08077",
+      "name": "Coding Dino",
+      "symbol": "DINO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50646/large/UA-APTOS-PAD_1.png?1728579627"
+      "logoURI": "https://assets.coingecko.com/coins/images/36637/large/dino_icon_copy.png?1712029544"
     },
     {
       "chainId": 8453,
-      "address": "0x0f1cfd0bb452db90a3bfc0848349463010419ab2",
-      "name": "Guru Network",
-      "symbol": "GURU",
+      "address": "0x4f81837c2f4a189a0b69370027cc2627d93785b4",
+      "name": "Seraph by Virtuals",
+      "symbol": "SERAPH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38583/large/tGURU_token_circle.png?1718087986"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdfbea88c4842d30c26669602888d746d30f9d60d",
-      "name": "crow with knife",
-      "symbol": "CAW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36067/large/200px.png?1710405601"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5a76a56ad937335168b30df3aa1327277421c6ae",
-      "name": "Vela Token",
-      "symbol": "VELA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28739/large/VELA_logo_-_no_background.png?1696527719"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2c002ffec41568d138acc36f5894d6156398d539",
-      "name": "Lucky Dog",
-      "symbol": "LUCKY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51334/large/LUCKYTokenSymbol.png?1730797716"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5a7a2bf9ffae199f088b25837dcd7e115cf8e1bb",
-      "name": "IMO",
-      "symbol": "IMO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14831/large/IMO_logo_rond_200.png?1729798616"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c5142bc58f9a61ab8c3d2085dd2f4e550c5ce0b",
-      "name": "RUSSELL",
-      "symbol": "RUSSELL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50690/large/russelllogo.png?1730010143"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc1ffaef4e7d553bbaf13926e258a1a555a363a07",
-      "name": "Human Intelligence Machin",
-      "symbol": "HIM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37898/large/Human_Intelligence_Machine.png?1715848133"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf0268c5f9aa95baf5c25d646aabb900ac12f0800",
-      "name": "RealGoat",
-      "symbol": "RGOAT",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/38923/large/IMG_20240625_033037_003.jpg?1719521003"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
-      "name": "Wagmi",
-      "symbol": "WAGMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31887/large/wagmi_token_logo.png?1696530698"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x051fb509e4a775fabd257611eea1efaed8f91359",
-      "name": "CateCoin",
-      "symbol": "CATE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/15364/large/logo.png?1696515013"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x12e96c2bfea6e835cf8dd38a5834fa61cf723736",
-      "name": "Wrapped DOGE  Universal ",
-      "symbol": "UDOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40099/large/UA-DOGE_1.png?1725632510"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x776aaef8d8760129a0398cf8674ee28cefc0eab9",
-      "name": "Floppa Cat",
-      "symbol": "FLOPPA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36969/large/floppa.jpg?1722771377"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x71a67215a2025f501f386a49858a9ced2fc0249d",
-      "name": "Wrapped SEI  Universal ",
-      "symbol": "USEI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51023/large/UA-SEI_1.png?1729770680"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
-      "name": "Truflation",
-      "symbol": "TRUF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36642/large/truflation.jpg?1733315818"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd98832e8a59156acbee4744b9a94a9989a728f36",
-      "name": "AgentAIgo",
-      "symbol": "AGENT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52294/large/agent_logo.jpg?1732966712"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xed2d13a70acbd61074fc56bd0d0845e35f793e5e",
-      "name": "Planet Mojo",
-      "symbol": "MOJO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36670/large/MOJOIcon.jpg?1712061269"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf8a99f2bf2ce5bb6ce4aafcf070d8723bc904aa2",
-      "name": "Chinese Brett",
-      "symbol": "CHRETT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38541/large/GNQP9A7WwAIcolJ_%282%29.png?1717926712"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf6e932ca12afa26665dc4dde7e27be02a7c02e50",
-      "name": "Mochi",
-      "symbol": "MOCHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33083/large/CIRCLE-200x200.png?1713297273"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x354d6890caa31a5e28b6059d46781f40880786a6",
-      "name": "ghffb47yii2rteeyy10op",
-      "symbol": "GHFFB47YII2RTEEYY10",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52104/large/0x354d6890caa31a5e28b6059d46781f40880786a6.png?1732591949"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x18a8bd1fe17a1bb9ffb39ecd83e9489cfd17a022",
-      "name": "Andy",
-      "symbol": "ANDY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36552/large/ANDY.jpg?1711896298"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x814fe70e85025bec87d4ad3f3b713bdcaac0579b",
-      "name": "Based Bario",
-      "symbol": "BARIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50719/large/bario.jpg?1728803763"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf5e89006cbeff2dabcfda0def5bf45ebe7f8429f",
-      "name": "Ragdoll",
-      "symbol": "RAGDOLL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51848/large/O0_Ds5Ad_400x400.jpg?1732060576"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
-      "name": "Any Inu",
-      "symbol": "AI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34126/large/anyinulogo200.png?1704174269"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x314d7f9e2f55b430ef656fbb98a7635d43a2261e",
-      "name": "Naym",
-      "symbol": "NAYM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50981/large/naym.jpg?1729651162"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0808bf94d57c905f1236212654268ef82e1e594e",
-      "name": "ritestream",
-      "symbol": "RITE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24130/large/rite.png?1696523321"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x65e570b560027f493f2b1907e8e8e3b9546053bd",
-      "name": "Tyler",
-      "symbol": "TYLER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50734/large/photo_2024-09-23_09-14-08.jpg?1728916087"
+      "logoURI": "https://assets.coingecko.com/coins/images/52442/large/fire_guy.png?1733351187"
     },
     {
       "chainId": 8453,
@@ -1836,27 +1388,211 @@
     },
     {
       "chainId": 8453,
-      "address": "0x3ee5e23eee121094f1cfc0ccc79d6c809ebd22e5",
-      "name": "Ionic Protocol",
-      "symbol": "ION",
+      "address": "0x6d3b8c76c5396642960243febf736c6be8b60562",
+      "name": "Skull of Pepe Token",
+      "symbol": "SKOP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36713/large/Ionic-icon-green.png?1712127547"
+      "logoURI": "https://assets.coingecko.com/coins/images/38342/large/skop.jpeg?1717141011"
     },
     {
       "chainId": 8453,
-      "address": "0x749e5334752466cda899b302ed4176b8573dc877",
-      "name": "Assimilate",
-      "symbol": "SIM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52377/large/SIM_LOGO.jpeg?1733253732"
+      "address": "0x051fb509e4a775fabd257611eea1efaed8f91359",
+      "name": "CateCoin",
+      "symbol": "CATE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/15364/large/logo.png?1696515013"
     },
     {
       "chainId": 8453,
-      "address": "0x1db0c569ebb4a8b57ac01833b9792f526305e062",
-      "name": "GenomesDAO GENOME",
-      "symbol": "GENOME",
+      "address": "0xbdf5bafee1291eec45ae3aadac89be8152d4e673",
+      "name": "Catamoto",
+      "symbol": "CATA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36763/large/images.jpg?1712282056"
+      "logoURI": "https://assets.coingecko.com/coins/images/37218/large/200x200.png?1713774219"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9b700b043e9587dde9a0c29a9483e2f8fa450d54",
+      "name": "AxonDAO Governance Token",
+      "symbol": "AXGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35290/large/AXGT-logo-7.png?1708076161"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
+      "name": "Any Inu",
+      "symbol": "AI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34126/large/anyinulogo200.png?1704174269"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcf67815cce72e682eb4429eca46843bed81ca739",
+      "name": "GAM3S GG",
+      "symbol": "G3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35662/large/G3_logo.jpg?1709454143"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x74ccbe53f77b08632ce0cb91d3a545bf6b8e0979",
+      "name": "Fantom Bomb",
+      "symbol": "BOMB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24109/large/logo-blue.png?1696523301"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xaa6cccdce193698d33deb9ffd4be74eaa74c4898",
+      "name": "ElonRWA",
+      "symbol": "ELONRWA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36970/large/elonrwa.png?1712910039"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x76734b57dfe834f102fb61e1ebf844adf8dd931e",
+      "name": "Weirdo",
+      "symbol": "WEIRDO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/37847/large/New_Project_%2823%29.png?1726539603"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdfbea88c4842d30c26669602888d746d30f9d60d",
+      "name": "crow with knife",
+      "symbol": "CAW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36067/large/200px.png?1710405601"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x731814e491571a2e9ee3c5b1f7f3b962ee8f4870",
+      "name": "VaderAI by Virtuals",
+      "symbol": "VADER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51910/large/kare_pepe.png?1733345833"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe2c86869216ac578bd62a4b8313770d9ee359a05",
+      "name": "EMAIL Token",
+      "symbol": "EMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38631/large/EMT_square_LG%282%29.png?1718171885"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x08c81699f9a357a9f0d04a09b353576ca328d60d",
+      "name": "nftxbt by Virtuals",
+      "symbol": "NFTXBT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52332/large/nftxbt_logo.jpg?1733087152"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2974dc646e375e83bd1c0342625b49f288987fa4",
+      "name": "Swarm Markets",
+      "symbol": "SMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17488/large/swarm-SMT-token-symbol_200x200.png?1696517029"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
+      "name": "PAW",
+      "symbol": "PAW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28946/large/PawLogo.png?1699394612"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3d1d651761d535df881740ab50ba4bd8a2ec2c00",
+      "name": "Synthesizer Dog",
+      "symbol": "SYNDOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51577/large/SYNDOG_LOGO.png?1731534533"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5a7a2bf9ffae199f088b25837dcd7e115cf8e1bb",
+      "name": "IMO",
+      "symbol": "IMO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14831/large/IMO_logo_rond_200.png?1729798616"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcb327b99ff831bf8223cced12b1338ff3aa322ff",
+      "name": "Based ETH",
+      "symbol": "BSDETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35774/large/Icon_White_on_Blue.png?1709793654"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf83759099dc88f75fc83de854c41e0d9e83ada9b",
+      "name": "Obortech",
+      "symbol": "OBOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14929/large/OBORTECH_200.png?1696514590"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
+      "name": "Truflation",
+      "symbol": "TRUF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36642/large/truflation.jpg?1733315818"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc734635cd30e882037c3f3de1ebccf9fa9d27d9f",
+      "name": "Lyvely",
+      "symbol": "LVLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50215/large/symbol_color.png?1726436150"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6b2504a03ca4d43d0d73776f6ad46dab2f2a4cfd",
+      "name": "Unit 00   Rei",
+      "symbol": "REI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52005/large/Unit_00_-_Rei.jpg?1732592775"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9aaae745cf2830fb8ddc6248b17436dc3a5e701c",
+      "name": "Gochujangcoin",
+      "symbol": "GOCHU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39318/large/GochujangLogo_200_3x.png?1721709656"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2c002ffec41568d138acc36f5894d6156398d539",
+      "name": "Lucky Dog",
+      "symbol": "LUCKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51334/large/LUCKYTokenSymbol.png?1730797716"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x74aa9bb52b36a378a6e641b86d7acb76dc9b3940",
+      "name": "Dtravel",
+      "symbol": "TRVL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20911/large/trvl.jpeg?1696520301"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf0268c5f9aa95baf5c25d646aabb900ac12f0800",
+      "name": "RealGoat",
+      "symbol": "RGOAT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/38923/large/IMG_20240625_033037_003.jpg?1719521003"
     },
     {
       "chainId": 8453,
@@ -1876,1011 +1612,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0xf7c1cefcf7e1dd8161e00099facd3e1db9e528ee",
-      "name": "Tower",
-      "symbol": "TOWER",
+      "address": "0x5ed25e305e08f58afd7995eac72563e6be65a617",
+      "name": "Wrapped NEAR  Universal ",
+      "symbol": "UNEAR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14134/large/tower-circular-1000.png?1696513854"
+      "logoURI": "https://assets.coingecko.com/coins/images/50645/large/UA-NEAR_1.png?1728579564"
     },
     {
       "chainId": 8453,
-      "address": "0x614577036f0a024dbc1c88ba616b394dd65d105a",
-      "name": "GENIUS AI",
-      "symbol": "GNUS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36914/large/IMG_5346.png?1712769235"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5babfc2f240bc5de90eb7e19d789412db1dec402",
-      "name": "Burning Circle",
-      "symbol": "CIRCLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35274/large/circle.png?1708048159"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf3c7cecf8cbc3066f9a87b310cebe198d00479ac",
-      "name": "FEED EVERY GORILLA",
-      "symbol": "FEG",
-      "decimals": 11,
-      "logoURI": "https://assets.coingecko.com/coins/images/29643/large/IMG_3919.jpeg?1721352213"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa3a34a0d9a08ccddb6ed422ac0a28a06731335aa",
-      "name": "Wrapped ADA  Universal ",
-      "symbol": "UADA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51868/large/UA-ADA.png?1732095196"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x63cb9a22cbc00bf9159429e9dede4b88c3dba8ce",
-      "name": "LaunchTokenBot",
-      "symbol": "CAPO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52234/large/f22a0bcbbfa4da6930bf8c1d37c2e0a0.jpeg?1732804814"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf04d220b8136e2d3d4be08081dbb565c3c302ffd",
-      "name": "Freya by Virtuals",
-      "symbol": "FREYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52325/large/FREYA_%281%29.png?1733079799"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x74ccbe53f77b08632ce0cb91d3a545bf6b8e0979",
-      "name": "Fantom Bomb",
-      "symbol": "BOMB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24109/large/logo-blue.png?1696523301"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdfd579dd6aeb232e95a15d964a135a61925b5c93",
-      "name": "Marso Tech",
-      "symbol": "MARSO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50292/large/QKbwAja.png?1726905588"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9f95e17b2668afe01f8fbd157068b0a4405cc08d",
-      "name": "Bullieverse",
-      "symbol": "BULL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24174/large/KR3qVAQe_400x400.jpg?1696523362"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbeb0fd48c2ba0f1aacad2814605f09e08a96b94e",
-      "name": "GME  Base ",
-      "symbol": "GME",
+      "address": "0x47b464edb8dc9bc67b5cd4c9310bb87b773845bd",
+      "name": "NORMIE",
+      "symbol": "NORMIE",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37229/large/gamestop.jpeg?1713780481"
+      "logoURI": "https://assets.coingecko.com/coins/images/35880/large/NORMIEsite.png?1709983341"
     },
     {
       "chainId": 8453,
-      "address": "0xac743b05f5e590d9db6a4192e02457838e4af61e",
-      "name": "OnlyCalls by Virtuals",
-      "symbol": "CALLS",
+      "address": "0x5a76a56ad937335168b30df3aa1327277421c6ae",
+      "name": "Vela Token",
+      "symbol": "VELA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52481/large/onlyCalls_%281%29.jpg?1733425816"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x06a63c498ef95ad1fa4fff841955e512b4b2198a",
-      "name": "Gluteus Maximus by Virtuals",
-      "symbol": "GLUTEU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52177/large/gluteu.jpg?1732685854"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x655a51e6803faf50d4ace80fa501af2f29c856cf",
-      "name": "PAID",
-      "symbol": "PAID",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13761/large/PAID_Logo_new.png?1730798431"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcc0adb6c436eb1f65b2f27733bf926691b94c5f1",
-      "name": "Guanciale by Virtuals",
-      "symbol": "GUAN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51865/large/guanciale.jpeg?1732173396"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x548f93779fbc992010c07467cbaf329dd5f059b7",
-      "name": "BMX",
-      "symbol": "BMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31699/large/bmx_white.png?1696530517"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
-      "name": "Dexalot",
-      "symbol": "ALOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24188/large/logo_200x200.png?1696523376"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9beec80e62aa257ced8b0edd8692f79ee8783777",
-      "name": "This Is My Iguana",
-      "symbol": "TIMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39361/large/200x200.png?1722464115"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x076bf099c7aabd0bc9bc37930113428906f51d89",
-      "name": "DEFLI",
-      "symbol": "FLI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50582/large/defli_lgo_2_%28200_x_200_px%29.png?1728415750"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbfefd7a0eda8a0feb06d0f52cf431afd0f9b2dd0",
-      "name": "Wokie Plumpkin by Virtuals",
-      "symbol": "WOKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52176/large/wokie.jpg?1732685106"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x56a38e7216304108e841579041249feb236c887b",
-      "name": "Libertum",
-      "symbol": "LBM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37147/large/wmGmpgSW_400x400.jpg?1713469301"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x74aa9bb52b36a378a6e641b86d7acb76dc9b3940",
-      "name": "Dtravel",
-      "symbol": "TRVL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20911/large/trvl.jpeg?1696520301"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc734635cd30e882037c3f3de1ebccf9fa9d27d9f",
-      "name": "Lyvely",
-      "symbol": "LVLY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50215/large/symbol_color.png?1726436150"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcde90558fc317c69580deeaf3efc509428df9080",
-      "name": "Normilio",
-      "symbol": "NORMILIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36915/large/vm2byD93.jpg?1733436102"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf9569cfb8fd265e91aa478d86ae8c78b8af55df4",
-      "name": "AUKI",
-      "symbol": "AUKI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39811/large/COINGECKO-200-x-200_%281%29.png?1724166209"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa9f5031b54c44c3603b4300fde9b8f5cd18ad06f",
-      "name": "Mars Battle",
-      "symbol": "SHOOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36553/large/icon.png?1711896644"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xeb9e49fb4c33d9f6aefb1b03f9133435e24c0ec6",
-      "name": "Newton On Base",
-      "symbol": "NEWB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38475/large/IMG_1092.JPG?1724476844"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb56d0839998fd79efcd15c27cf966250aa58d6d3",
-      "name": "Based USA",
-      "symbol": "USA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37981/large/BASE_USA_200px.png?1716203776"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcacf1ca03983ce6c7e235fb20c70acc70ed13509",
-      "name": "AstroPepeX",
-      "symbol": "APX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31839/large/astropepexcoingecko.png?1731814766"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xaa6cccdce193698d33deb9ffd4be74eaa74c4898",
-      "name": "ElonRWA",
-      "symbol": "ELONRWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36970/large/elonrwa.png?1712910039"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x30d19fb77c3ee5cfa97f73d72c6a1e509fa06aef",
-      "name": "CONDO",
-      "symbol": "CONDO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37174/large/1000012387.jpg?1724589415"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2f20cf3466f80a5f7f532fca553c8cbc9727fef6",
-      "name": "Akuma Inu",
-      "symbol": "AKUMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52182/large/IMG_7527.PNG?1732690402"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c03ce270b4826ec62e7dd007f0b716068639f7b",
-      "name": "The Innovation Game",
-      "symbol": "TIG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50669/large/TIG_Logo_200x200.png?1729604604"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6797b6244fa75f2e78cdffc3a4eb169332b730cc",
-      "name": "Eagle AI",
-      "symbol": "EAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38650/large/Eagle_AI.png?1718215736"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x98d59767cd1335071a4e9b9d3482685c915131e8",
-      "name": "DREAM",
-      "symbol": "DREAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52029/large/dream-logo.png?1732358413"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x99b2b1a2adb02b38222adcd057783d7e5d1fcc7d",
-      "name": "Common Wealth",
-      "symbol": "WLTH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37858/large/WLTH_TICKER_200x200.png?1730241264"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x717d31a60a9e811469673429c9f8ea24358990f1",
-      "name": "Everyworld",
-      "symbol": "EVERY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36799/large/coin_gecko.png?1714459237"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8761155c814c807cd3ccd15b256d69d3c10f198c",
-      "name": "Joystream",
-      "symbol": "JOY",
-      "decimals": 10,
-      "logoURI": "https://assets.coingecko.com/coins/images/24785/large/joy.png?1696523945"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
-      "name": "Aura Finance",
-      "symbol": "AURA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25942/large/logo.png?1696525021"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xac12f930318be4f9d37f602cbf89cd33e99aa9d4",
-      "name": "Wexo",
-      "symbol": "WEXO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33801/large/wexo_token_200x200.png?1702991908"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x36912b5cf63e509f18e53ac98b3012fa79e77bf5",
-      "name": "FUEGO",
-      "symbol": "FUEGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51345/large/FUEGO_200x200.jpg?1730825086"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x554bba833518793056cf105e66abea330672c0de",
-      "name": "Maha",
-      "symbol": "MAHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13404/large/black.png?1724679606"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xae2bddbcc932c2d2cf286bad0028c6f5074c77b5",
-      "name": "Falcons",
-      "symbol": "FAH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50297/large/Falcons.png?1726935509"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdcf5130274753c8050ab061b1a1dcbf583f5bfd0",
-      "name": "ViciCoin",
-      "symbol": "VCNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31305/large/ViciCoin_-_small.png?1696530124"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7d27187eb33a7b1d99258ff222633670f84fa342",
-      "name": "IntentX",
-      "symbol": "INTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38241/large/PFP_IX_2.png?1716881240"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xda761a290e01c69325d12d82ac402e5a73d62e81",
-      "name": "Base Pro Shops",
-      "symbol": "BPS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36855/large/BPS_2.png?1712634757"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c41f1fc9022feb69af6dc666abfe73c9ffda7ce",
-      "name": "Bitcoin on Base",
-      "symbol": "BTCB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38868/large/BTCB_Official_Logo_July_2024.png?1721753012"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xecaf81eb42cd30014eb44130b89bcd6d4ad98b92",
-      "name": "Based Chad",
-      "symbol": "CHAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36285/large/logo_200_200_square.jpg?1712167823"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb4e1b230dd0476238fc64c99ff9d6ccdfdb2258d",
-      "name": "Florence Finance Medici",
-      "symbol": "FFM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34382/large/M_PNG_200x200_copy.png?1704779326"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
-      "name": "Seedworld",
-      "symbol": "SWORLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51000/large/IMG_2798.PNG?1729685531"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x25e1c298f100d7c600e9e44d46788c1ebbd4f69b",
-      "name": "Pike Finance",
-      "symbol": "P",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50771/large/image.png?1729132574"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf56b3b3972f2f154555a0b62ff5a22b7b2a3c90b",
-      "name": "ZAP",
-      "symbol": "ZAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50515/large/zap.jpg?1728033535"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfd1013c72cbb0ffb920d347c5836bf88965d0d5e",
-      "name": "STIX",
-      "symbol": "STIX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52015/large/STIX_Logo_Transparent_200x200.png?1732346967"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xff0c532fdb8cd566ae169c1cb157ff2bdc83e105",
-      "name": "Fren Pet",
-      "symbol": "FP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33022/large/token.png?1700274697"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd652c5425aea2afd5fb142e120fecf79e18fafc3",
-      "name": "PoolTogether",
-      "symbol": "POOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14003/large/PoolTogether.png?1696513732"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x52e0d3c27cc9e3607c1ca7914b9049be3d5e9c41",
-      "name": "Blu",
-      "symbol": "BLU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51922/large/Blu.jpg?1732190348"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe8aae6251c6cf39927b0ff31399030c60bec798f",
-      "name": "SUMI",
-      "symbol": "SUMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51253/large/SUMI.jpg?1730477794"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb4e017223fd3d639d0264de4da1b9e080325cb5e",
-      "name": "SyncVault",
-      "symbol": "SVTS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50447/large/White_SV_logo_200x200.png?1727771615"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb38266e0e9d9681b77aeb0a280e98131b953f865",
-      "name": "DOVU",
-      "symbol": "DOVU",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/31930/large/Dovu_Icon_Black_%281%29.png?1696530738"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3c4b6cd7874edc945797123fce2d9a871818524b",
-      "name": "PARADOX",
-      "symbol": "PARADOX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51590/large/IMG_1408.jpeg?1731570502"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2dad3a13ef0c6366220f989157009e501e7938f8",
-      "name": "Extra Finance",
-      "symbol": "EXTRA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30973/large/Ex_logo-white-blue_ring_288x.png?1696529812"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x99298c6be0e8ec9e56b7a2be5850abe1fc109d94",
-      "name": "Degen Capital by Virtuals",
-      "symbol": "DEGENC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52246/large/Degen_Capital_DEGENC.png?1732824263"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7431ada8a591c955a994a21710752ef9b882b8e3",
-      "name": "MorpheusAI",
-      "symbol": "MOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37969/large/MOR200X200.png?1716327119"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-      "name": "Hop Protocol",
-      "symbol": "HOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25445/large/hop.png?1696524577"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x78a087d713be963bf307b18f2ff8122ef9a63ae9",
-      "name": "BaseSwap",
-      "symbol": "BSWAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31245/large/Baseswap_LogoNew.jpg?1696530070"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6009e7cd237087e6d7570990e8bdac09c3e182b0",
-      "name": "TaskBunny",
-      "symbol": "BNY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51478/large/Bunny_coin_200x200.png?1731404290"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3816dd4bd44c8830c2fa020a5605bac72fa3de7a",
-      "name": "Presearch",
-      "symbol": "PRE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1299/large/presearch.png?1696502369"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x76734b57dfe834f102fb61e1ebf844adf8dd931e",
-      "name": "Weirdo",
-      "symbol": "WEIRDO",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/37847/large/New_Project_%2823%29.png?1726539603"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x01aac2b594f7bdbec740f0f1aa22910ebb4b74ab",
-      "name": "Unio Coin",
-      "symbol": "UNIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50191/large/uniocoin-200x200.png?1726206790"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x262a9f4e84efa2816d87a68606bb4c1ea3874bf1",
-      "name": "Bangkit",
-      "symbol": "BKIT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52416/large/logo.png?1733309160"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7a8a5012022bccbf3ea4b03cd2bb5583d915fb1a",
-      "name": "Chuck",
-      "symbol": "CHUCK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37468/large/1000030138.jpg?1714457112"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x41e0fe1317bd6e8944b037cd59b22d428c1434c2",
-      "name": "Virtu by Virtuals",
-      "symbol": "VIRTU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51827/large/_removal.ai__24fd4161-77b5-412f-b553-a99e9012f575_photo_2024-11-07_08-05-59.png?1732042711"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9de16c805a3227b9b92e39a446f9d56cf59fe640",
-      "name": "Bento",
-      "symbol": "BENTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37138/large/logo-bento-200-200.png?1713419221"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5b5dee44552546ecea05edea01dcd7be7aa6144a",
-      "name": "TN100x",
-      "symbol": "TN100X",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35729/large/patch-transparent-blue.png?1729878068"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x63228048121877a9e0f52020834a135074e8207c",
-      "name": "Moonsama",
-      "symbol": "SAMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28308/large/Small.png?1696527312"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x42069de48741db40aef864f8764432bbccbd0b69",
-      "name": "All Street Bets",
-      "symbol": "BETS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36906/large/Screenshot_2024-03-17_034831_no_background.png?1712728634"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x252d223d0550bc6c137b003d90bc74f5341a2818",
-      "name": "Bitbot",
-      "symbol": "BITBOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52512/large/Bitbot_Logo.png?1733493165"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x70737489dfdf1a29b7584d40500d3561bd4fe196",
-      "name": "BORED",
-      "symbol": "BORED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37050/large/bored.jpeg?1713340233"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe095780ba2a64a4efa7a74830f0b71656f0b0ad4",
-      "name": "Byte",
-      "symbol": "BYTE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/33527/large/Byte200.jpeg?1702138460"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x689644b86075ed61c647596862c7403e1c474dbf",
-      "name": "Bamboo on Base",
-      "symbol": "BAMBOO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39126/large/Bamboo_Logo_800x800.png?1720656497"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
-      "name": "Nya",
-      "symbol": "NYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40082/large/nya.jpg?1725523655"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4da78059d97f155e18b37765e2e042270f4e0fc4",
-      "name": "WUFFI",
-      "symbol": "WUF",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/36933/large/WUFFI.jpg?1720613603"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfaa4f3bcfc87d791e9305951275e0f62a98bcb10",
-      "name": "Super Best Friends",
-      "symbol": "SUBF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36368/large/1000017215.jpg?1711338058"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x120edc8e391ba4c94cb98bb65d8856ae6ec1525f",
-      "name": "LOUDER",
-      "symbol": "LOUDER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39495/large/louder_icon_200x200.png?1722539190"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x54b659832f59c24cec0e4a2cd193377f1bcefc3c",
-      "name": "Akashalife",
-      "symbol": "AK1111",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50533/large/Akasha-CoinIcon_%283%29.png?1728206155"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8a638ea79f71f3b91bdc96bbdf9fb27c93013d60",
-      "name": "Baby Tiger",
-      "symbol": "BBT",
-      "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/51933/large/BBT_%282%29_%281%29.png?1732205350"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc48e605c7b722a57277e087a6170b9e227e5ac0a",
-      "name": "OmniCat",
-      "symbol": "OMNI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33917/large/omnicatlogo.png?1717544778"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8fbd0648971d56f1f2c35fa075ff5bc75fb0e39d",
-      "name": "UNKJD",
-      "symbol": "MBS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20841/large/monkeyball.png?1696520233"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf5f2a79eeccf6e7f4c570c803f529930e29cc96b",
-      "name": "CertaiK by Virtuals",
-      "symbol": "CERTAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52488/large/download.jpeg?1733432223"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe13e40e8fdb815fbc4a1e2133ab5588c33bac45d",
-      "name": "TRIBAL",
-      "symbol": "TRIBAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38531/large/7pc8ov67182ddpbqjnff20ik4oye.png?1733194448"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x60222751504796934bddee8218f9725f0c95d2c1",
-      "name": "Simps",
-      "symbol": "SIMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51994/large/200.png?1732296595"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x52c2b317eb0bb61e650683d2f287f56c413e4cf6",
-      "name": "Tree",
-      "symbol": "TREE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33727/large/circle_green.png?1709894067"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x82b0e1a2374ea0198f62a48b14ffab53db6c1e36",
-      "name": "PokPok Golden Egg",
-      "symbol": "PEGG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40102/large/golden_eggs_%281%29.png?1725694597"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x39fed555ff57cb1154bfa6b1a2492bb914ce2d9b",
-      "name": "EchoLeaks by Virtuals",
-      "symbol": "ECHO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52172/large/echoleaks.jpg?1732683705"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9f235d23354857efe6c541db92a9ef1877689bcb",
-      "name": "Goodle",
-      "symbol": "GOODLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39688/large/Screenshot_2024-07-26_at_5.38.55_PM-removebg-preview.png?1723660779"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9e53e88dcff56d3062510a745952dec4cefdff9e",
-      "name": "Basic Dog Meme",
-      "symbol": "DOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33749/large/Round_Logo.png?1703245893"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1b6a569dd61edce3c383f6d565e2f79ec3a12980",
-      "name": "Young Peezy AKA Pepe",
-      "symbol": "PEEZY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36649/large/PFP_CG_200x200.jpeg?1719953176"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3fbde9864362ce4abb244ebef2ef0482aba8ea39",
-      "name": "Baklava",
-      "symbol": "BAVA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23780/large/200x200_BAVA_LOGO_%282%29.png?1696522980"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd33c7b753ecaa85e5d5f5b5fd99dec59f26a087e",
-      "name": "Defactor",
-      "symbol": "FACTR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19201/large/jFLSu4U9_400x400.png?1696518648"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7f05a7a9af2f5a07d1e64877c8dc37a64a22508e",
-      "name": "Ajna Protocol",
-      "symbol": "AJNA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30187/large/AJNA-Icon-200.png?1696529105"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8c9037d1ef5c6d1f6816278c7aaf5491d24cd527",
-      "name": "Moxie",
-      "symbol": "MOXIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39451/large/favicon_-_200_x_200.png?1722311978"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x09579452bc3872727a5d105f342645792bb8a82b",
-      "name": "Aardvark",
-      "symbol": "VARK",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/32678/large/VARK.jpg?1698929830"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1b5ce2a593a840e3ad3549a34d7b3dec697c114d",
-      "name": "Altcoinist Token",
-      "symbol": "ALTT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39455/large/Altcoinist_logo_png_%282%29.png?1733342642"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf3708859c178709d5319ad5405bc81511b72b9e9",
-      "name": "Aethernet",
-      "symbol": "AETHER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51065/large/Aether_Farcaster_frame.png?1729943869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8c1851488f2daceae46d815dd204d5f6d946666a",
-      "name": "Besa Gaming Company",
-      "symbol": "BESA",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/33283/large/Besa_Gaming_Company_BESA_200.png?1701363231"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd91d07e4949a858d29005d339610db2402ef5b73",
-      "name": "DataGold",
-      "symbol": "DGOLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52431/large/dGOLD-square-navy.png?1733436522"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8c81b4c816d66d36c4bf348bdec01dbcbc70e987",
-      "name": "Briun Armstrung",
-      "symbol": "BRIUN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36183/large/200x200.png?1710758416"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd1917629b3e6a72e6772aab5dbe58eb7fa3c2f33",
-      "name": "Settled EthXY Token",
-      "symbol": "SEXY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33032/large/logo-circle.png?1700348518"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x88faea256f789f8dd50de54f9c807eef24f71b16",
-      "name": "Landwolf",
-      "symbol": "WOLF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36803/large/IMG_8678.jpeg?1712469842"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xefb97aaf77993922ac4be4da8fbc9a2425322677",
-      "name": "Web 3 Dollar",
-      "symbol": "USD3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38073/large/usd3%28200_x_200_px%29.png?1716449060"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1ccb4b14a11e0f2994a7ecbbd4cc69632f4c7c76",
-      "name": "Cute Cat Candle",
-      "symbol": "CCC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36930/large/1000017879.jpg?1712803401"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8f2e6758c4d6570344bd5007dec6301cd57590a0",
-      "name": "Spot",
-      "symbol": "SPOT",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/28426/large/SPOT_Logo_200x200_sq_small_centered.png?1696527423"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfea9dcdc9e23a9068bf557ad5b186675c61d33ea",
-      "name": "Based Shiba Inu",
-      "symbol": "BSHIB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36092/large/logocg.png?1710478223"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe642657e4f43e6dcf0bd73ef24008394574dee28",
-      "name": "Music Protocol",
-      "symbol": "RECORD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39243/large/MP-mark-color.png?1724879503"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3203856eac03d343f9d5245ba2f39861838a7b36",
-      "name": "Aviator",
-      "symbol": "AVI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31024/large/avi-200x200png.png?1711119363"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8a9430e92153c026092544444cbb38077e6688d1",
-      "name": "KeptChain",
-      "symbol": "KEPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38406/large/Kept_200_200.png?1717463539"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8f019931375454fe4ee353427eb94e2e0c9e0a8c",
-      "name": "KOMPETE",
-      "symbol": "KOMPETE",
-      "decimals": 10,
-      "logoURI": "https://assets.coingecko.com/coins/images/24298/large/200x200.png?1732826917"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
-      "name": "Glo Dollar",
-      "symbol": "USDGLO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29319/large/GLO_logo_pine_on_cyan_1_3.png?1716971065"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x511ef9ad5e645e533d15df605b4628e3d0d0ff53",
-      "name": "Velvet Unicorn by Virtuals",
-      "symbol": "VU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52175/large/velvet_unicorn.jpg?1732684869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x13741c5df9ab03e7aa9fb3bf1f714551dd5a5f8a",
-      "name": "Noggles",
-      "symbol": "NOGS",
-      "decimals": 15,
-      "logoURI": "https://assets.coingecko.com/coins/images/37238/large/nogs.jpeg?1713851209"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7d9ce55d54ff3feddb611fc63ff63ec01f26d15f",
-      "name": "Fungi",
-      "symbol": "FUNGI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/36690/large/image_2024-03-29_20-10-19_%282%29_%283%29.png?1712091884"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x681a09a902d9c7445b3b1ab282c38d60c72f1f09",
-      "name": "AlphaKEK AI",
-      "symbol": "AIKEK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35445/large/alphakek_-_Copy.png?1708620097"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xaec9e50e3397f9ddc635c6c429c8c7eca418a143",
-      "name": "Arcana arcUSD",
-      "symbol": "ARCUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38490/large/USDa.png?1717688209"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb488fcb23333e7baa28d1dfd7b69a5d3a8bfeb3a",
-      "name": "Terminal",
-      "symbol": "TERMINAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51477/large/terminalLogo.png?1731403786"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfafb7581a65a1f554616bf780fc8a8acd2ab8c9b",
-      "name": "Squid Game",
-      "symbol": "SQUID",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20506/large/squid.png?1696519912"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8bfac1b375bf2894d6f12fb2eb48b1c1a7916789",
-      "name": "Mey Network",
-      "symbol": "MEY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52249/large/logo_mey_200.png?1732828172"
+      "logoURI": "https://assets.coingecko.com/coins/images/28739/large/VELA_logo_-_no_background.png?1696527719"
     },
     {
       "chainId": 8453,
@@ -2892,123 +1644,179 @@
     },
     {
       "chainId": 8453,
-      "address": "0x29e39327b5b1e500b87fc0fcae3856cd8f96ed2a",
-      "name": "Bark Ruffalo by Virtuals",
-      "symbol": "PAWSY",
+      "address": "0x2676e4e0e2eb58d9bdb5078358ff8a3a964cedf5",
+      "name": "Polytrader by Virtuals",
+      "symbol": "POLY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52205/large/00_Avatar_200x200.png?1732736729"
+      "logoURI": "https://assets.coingecko.com/coins/images/52168/large/poly.jpg?1732682921"
     },
     {
       "chainId": 8453,
-      "address": "0xbf1aea8670d2528e08334083616dd9c5f3b087ae",
-      "name": "MAI  Base ",
-      "symbol": "MIMATIC",
+      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
+      "name": "Seedworld",
+      "symbol": "SWORLD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35466/large/mimatic-red.png?1708687857"
+      "logoURI": "https://assets.coingecko.com/coins/images/51000/large/IMG_2798.PNG?1729685531"
     },
     {
       "chainId": 8453,
-      "address": "0x623cd3a3edf080057892aaf8d773bbb7a5c9b6e9",
-      "name": "Sekuya Multiverse",
-      "symbol": "SKYA",
+      "address": "0xa3a34a0d9a08ccddb6ed422ac0a28a06731335aa",
+      "name": "Wrapped ADA  Universal ",
+      "symbol": "UADA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38096/large/SKYA_Logo_200x200.png?1731909478"
+      "logoURI": "https://assets.coingecko.com/coins/images/51868/large/UA-ADA.png?1732095196"
     },
     {
       "chainId": 8453,
-      "address": "0xf34e0cff046e154cafcae502c7541b9e5fd8c249",
-      "name": "Thales",
-      "symbol": "THALES",
+      "address": "0x06a63c498ef95ad1fa4fff841955e512b4b2198a",
+      "name": "Gluteus Maximus by Virtuals",
+      "symbol": "GLUTEU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18388/large/CLVZJN_C_400x400.png?1696517879"
+      "logoURI": "https://assets.coingecko.com/coins/images/52177/large/gluteu.jpg?1732685854"
     },
     {
       "chainId": 8453,
-      "address": "0x37f24b26bcefbfac7f261b97f8036da98f81a299",
-      "name": "Brish",
-      "symbol": "BRISH",
+      "address": "0x262a9f4e84efa2816d87a68606bb4c1ea3874bf1",
+      "name": "Bangkit",
+      "symbol": "BKIT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38700/large/brishlogoupdate.png?1718480842"
+      "logoURI": "https://assets.coingecko.com/coins/images/52416/large/logo.png?1733309160"
     },
     {
       "chainId": 8453,
-      "address": "0x59f680f431f5280e7662b96f2dfa195d1693852d",
-      "name": "Magnify Cash",
-      "symbol": "MAG",
+      "address": "0xdcefd8c8fcc492630b943abcab3429f12ea9fea2",
+      "name": "KlimaDAO",
+      "symbol": "KLIMA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38992/large/magnifyt.jpg?1719808409"
+      "logoURI": "https://assets.coingecko.com/coins/images/19169/large/Klima-Token.png?1696518618"
     },
     {
       "chainId": 8453,
-      "address": "0xe0023e73aab4fe9a22f059a9d27e857e027ee3dc",
-      "name": "RWAX",
-      "symbol": "RWAX",
+      "address": "0xac743b05f5e590d9db6a4192e02457838e4af61e",
+      "name": "OnlyCalls by Virtuals",
+      "symbol": "CALLS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38266/large/Rwax_Token_Symbol_logo-200.png?1716949733"
+      "logoURI": "https://assets.coingecko.com/coins/images/52481/large/onlyCalls_%281%29.jpg?1733425816"
     },
     {
       "chainId": 8453,
-      "address": "0x777b2839832982b35213063d850848369390ee16",
-      "name": "Jarvis",
-      "symbol": "JARVIS",
+      "address": "0xf6e932ca12afa26665dc4dde7e27be02a7c02e50",
+      "name": "Mochi",
+      "symbol": "MOCHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35812/large/jarvis.png?1709873633"
+      "logoURI": "https://assets.coingecko.com/coins/images/33083/large/CIRCLE-200x200.png?1713297273"
     },
     {
       "chainId": 8453,
-      "address": "0x1287a235474e0331c0975e373bdd066444d1bd35",
-      "name": "TAIKAI",
-      "symbol": "TKAI",
+      "address": "0x52c2b317eb0bb61e650683d2f287f56c413e4cf6",
+      "name": "Tree",
+      "symbol": "TREE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34827/large/TKAI.jpg?1706191900"
+      "logoURI": "https://assets.coingecko.com/coins/images/33727/large/circle_green.png?1709894067"
     },
     {
       "chainId": 8453,
-      "address": "0x4dd9077269dd08899f2a9e73507125962b5bc87f",
-      "name": "Crash On Base",
-      "symbol": "CRASH",
+      "address": "0x614577036f0a024dbc1c88ba616b394dd65d105a",
+      "name": "GENIUS AI",
+      "symbol": "GNUS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38817/large/_iNshlUA.png?1722185418"
+      "logoURI": "https://assets.coingecko.com/coins/images/36914/large/IMG_5346.png?1712769235"
     },
     {
       "chainId": 8453,
-      "address": "0x004aa1586011f3454f487eac8d0d5c647d646c69",
-      "name": "DogeVerse",
-      "symbol": "DOGEVERSE",
+      "address": "0x489fe42c267fe0366b16b0c39e7aeef977e841ef",
+      "name": "Wrapped Ampleforth",
+      "symbol": "WAMPL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38495/large/DogeVerse_200x200.png?1717692269"
+      "logoURI": "https://assets.coingecko.com/coins/images/20825/large/photo_2021-11-25_02-05-11.jpg?1696520218"
     },
     {
       "chainId": 8453,
-      "address": "0xd88611a629265c9af294ffdd2e7fa4546612273e",
-      "name": "Metapro",
-      "symbol": "MPRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35128/large/mpro.jpeg?1707440015"
+      "address": "0xf3c7cecf8cbc3066f9a87b310cebe198d00479ac",
+      "name": "FEED EVERY GORILLA",
+      "symbol": "FEG",
+      "decimals": 11,
+      "logoURI": "https://assets.coingecko.com/coins/images/29643/large/IMG_3919.jpeg?1721352213"
     },
     {
       "chainId": 8453,
-      "address": "0x28e29ec91db66733a94ee8e3b86a6199117baf99",
-      "name": "Basedmilio",
-      "symbol": "BASED",
+      "address": "0x64cb1bafc59bf93aeb90676885c63540cf4f4106",
+      "name": "Coin6900",
+      "symbol": "COIN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37685/large/tokenicon.png?1715224333"
+      "logoURI": "https://assets.coingecko.com/coins/images/51425/large/logo.jpg?1731186114"
     },
     {
       "chainId": 8453,
-      "address": "0x8853f0c059c27527d33d02378e5e4f6d5afb574a",
-      "name": "AI INU",
-      "symbol": "AIINU",
+      "address": "0xf9569cfb8fd265e91aa478d86ae8c78b8af55df4",
+      "name": "AUKI",
+      "symbol": "AUKI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36902/large/aiinu.png?1712699681"
+      "logoURI": "https://assets.coingecko.com/coins/images/39811/large/COINGECKO-200-x-200_%281%29.png?1724166209"
     },
     {
       "chainId": 8453,
-      "address": "0x7f62ac1e974d65fab4a81821ca6af659a5f46298",
-      "name": "Ethlas",
-      "symbol": "ELS",
+      "address": "0x0f1cfd0bb452db90a3bfc0848349463010419ab2",
+      "name": "Guru Network",
+      "symbol": "GURU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30331/large/ELS_Logo_200x200.png?1696529232"
+      "logoURI": "https://assets.coingecko.com/coins/images/38583/large/tGURU_token_circle.png?1718087986"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6e51b3a19f114013e5dc09d0477a536c7e4e0207",
+      "name": "Media Network",
+      "symbol": "MEDIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15142/large/media50x50.png?1696514798"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8761155c814c807cd3ccd15b256d69d3c10f198c",
+      "name": "Joystream",
+      "symbol": "JOY",
+      "decimals": 10,
+      "logoURI": "https://assets.coingecko.com/coins/images/24785/large/joy.png?1696523945"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbb22ff867f8ca3d5f2251b4084f6ec86d4666e14",
+      "name": "Cryptex Finance",
+      "symbol": "CTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14932/large/CTX_Logo_200px.png?1723514786"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac12f930318be4f9d37f602cbf89cd33e99aa9d4",
+      "name": "Wexo",
+      "symbol": "WEXO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33801/large/wexo_token_200x200.png?1702991908"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0808bf94d57c905f1236212654268ef82e1e594e",
+      "name": "ritestream",
+      "symbol": "RITE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24130/large/rite.png?1696523321"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xed2d13a70acbd61074fc56bd0d0845e35f793e5e",
+      "name": "Planet Mojo",
+      "symbol": "MOJO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36670/large/MOJOIcon.jpg?1712061269"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1db0c569ebb4a8b57ac01833b9792f526305e062",
+      "name": "GenomesDAO GENOME",
+      "symbol": "GENOME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36763/large/images.jpg?1712282056"
     },
     {
       "chainId": 8453,
@@ -3020,475 +1828,59 @@
     },
     {
       "chainId": 8453,
-      "address": "0x645c7aa841087e2e7f741c749ab27422ff5bba8e",
-      "name": "Iona by Virtuals",
-      "symbol": "IONA",
+      "address": "0xcacf1ca03983ce6c7e235fb20c70acc70ed13509",
+      "name": "AstroPepeX",
+      "symbol": "APX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52166/large/iona.jpg?1732682259"
+      "logoURI": "https://assets.coingecko.com/coins/images/31839/large/astropepexcoingecko.png?1731814766"
     },
     {
       "chainId": 8453,
-      "address": "0xfdc944fb59201fb163596ee5e209ebc8fa4dcdc5",
-      "name": "AMC",
-      "symbol": "AMC",
+      "address": "0xcc0adb6c436eb1f65b2f27733bf926691b94c5f1",
+      "name": "Guanciale by Virtuals",
+      "symbol": "GUAN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37977/large/amc.jpeg?1716196916"
+      "logoURI": "https://assets.coingecko.com/coins/images/51865/large/guanciale.jpeg?1732173396"
     },
     {
       "chainId": 8453,
-      "address": "0xf578ad8809f13dabf921bdd3fcfbe194d0ab5628",
-      "name": "Virtue Poker Points",
-      "symbol": "VPP",
+      "address": "0x9c0e042d65a2e1ff31ac83f404e5cb79f452c337",
+      "name": "Wrapped Aptos  Universal ",
+      "symbol": "UAPT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3386/large/vp-logo-200x200.png?1696504084"
+      "logoURI": "https://assets.coingecko.com/coins/images/50646/large/UA-APTOS-PAD_1.png?1728579627"
     },
     {
       "chainId": 8453,
-      "address": "0x5cc5e64ab764a0f1e97f23984e20fd4528356a6a",
-      "name": "XRGB",
-      "symbol": "XRGB",
+      "address": "0xf56b3b3972f2f154555a0b62ff5a22b7b2a3c90b",
+      "name": "ZAP",
+      "symbol": "ZAP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35447/large/log2.png?1708620430"
+      "logoURI": "https://assets.coingecko.com/coins/images/50515/large/zap.jpg?1728033535"
     },
     {
       "chainId": 8453,
-      "address": "0x613ce28076289de255f1a6487437f03e37e4a71d",
-      "name": "Dackie USD",
-      "symbol": "DCKUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39966/large/Dackie_USD_Stablecoin.png?1724957262"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
-      "name": "Lava Network",
-      "symbol": "LAVA",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37354/large/lava_logo.png?1714098423"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdbe125089d0752ef458c0685436ace93a7f1f8ca",
-      "name": "Aqualibre",
-      "symbol": "AQLA",
+      "address": "0x814fe70e85025bec87d4ad3f3b713bdcaac0579b",
+      "name": "Based Bario",
+      "symbol": "BARIO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35026/large/aq1.png?1707147950"
+      "logoURI": "https://assets.coingecko.com/coins/images/50719/large/bario.jpg?1728803763"
     },
     {
       "chainId": 8453,
-      "address": "0x97b959385dfdcaf252223838746beb232ac601aa",
-      "name": "AI Market Compass",
-      "symbol": "AIM",
+      "address": "0xf5e89006cbeff2dabcfda0def5bf45ebe7f8429f",
+      "name": "Ragdoll",
+      "symbol": "RAGDOLL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39363/large/AIM_%282%29.jpg?1723415448"
+      "logoURI": "https://assets.coingecko.com/coins/images/51848/large/O0_Ds5Ad_400x400.jpg?1732060576"
     },
     {
       "chainId": 8453,
-      "address": "0x45d9c101a3870ca5024582fd788f4e1e8f7971c3",
-      "name": "MASQ",
-      "symbol": "MASQ",
+      "address": "0xa9f5031b54c44c3603b4300fde9b8f5cd18ad06f",
+      "name": "Mars Battle",
+      "symbol": "SHOOT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13699/large/masq.png?1696513446"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8931ee05ec111325c1700b68e5ef7b887e00661d",
-      "name": "The Big Guy",
-      "symbol": "BGUY",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/38875/large/download.png?1719336441"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
-      "name": "Equalizer  BASE ",
-      "symbol": "SCALE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32221/large/SCALE_icon_200x200.png?1696835640"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8216e8143902a8fe0b676006bc25eb23829c123d",
-      "name": "Wow",
-      "symbol": "WOW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51527/large/23bafybeialew5mz6o2d6abynkd7kafunbgcgxcatyjdr5s2mgr4ae4zeltwe_%281%29.jpg?1731497334"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x28a730de97dc62a8c88363e0b1049056f1274a70",
-      "name": "Chinese Toshi",
-      "symbol": "CTOSHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38635/large/231_%28Custom%29_%283%29.png?1718173956"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xebb78043e29f4af24e6266a7d142f5a08443969e",
-      "name": "Derp",
-      "symbol": "DERP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33069/large/derpdex_%281%29.png?1700793428"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x22a2488fe295047ba13bd8cccdbc8361dbd8cf7c",
-      "name": "Sonne Finance",
-      "symbol": "SONNE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27540/large/Token1.png?1696526577"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb0e87796380172f911214208df966a84cceaaf82",
-      "name": "DOM",
-      "symbol": "DOM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51723/large/463fac78-dcc9-49cf-879f-b0b1af658295.png?1731903839"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6a27cd26a373530835b9fe7ac472b3e080070f64",
-      "name": "BlockAI",
-      "symbol": "BAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39638/large/logo-200x200-transparent-bg.png?1723278224"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xde7a416ac821c77478340eebaa21b68297025ef3",
-      "name": "Beni",
-      "symbol": "BENI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36691/large/Logo_Image_Beni_Uodate.png?1732385556"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3c3860d89b81c91974fc1f8a41aeeef604c17058",
-      "name": "Kinetix Finance Token",
-      "symbol": "KAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34031/large/KFI_Token_1.png?1703675672"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x698b49063c14d2753d23064ff891a876cffa6fb5",
-      "name": "NIKITA by Virtuals",
-      "symbol": "NIKITA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52146/large/Nikita_Pic.png?1732652736"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3054e8f8fba3055a42e5f5228a2a4e2ab1326933",
-      "name": "zuzalu",
-      "symbol": "ZUZALU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36909/large/ZUZALA.jpg?1712732086"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa0a2e84f6f19c09a095d4a83ac8de5a32d303a13",
-      "name": "Lil Brett",
-      "symbol": "LILB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51813/large/%28100_x_100_px%29.png?1732029374"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4b6f82a4ed0b9e3767f53309b87819a78d041a7f",
-      "name": "Juicybet",
-      "symbol": "JSP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38262/large/JB_token.png?1717686707"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xed899bfdb28c8ad65307fa40f4acab113ae2e14c",
-      "name": "Roost",
-      "symbol": "ROOST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36458/large/roost.jpeg?1711493580"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x31b28012f61fc3600e1c076bafc9fd997fb2da90",
-      "name": "Mrs Miggles",
-      "symbol": "MRSMIGGLES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39282/large/token.png?1722045136"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
-      "name": "Overnight Finance",
-      "symbol": "OVN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31970/large/OVN.png?1696959174"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc73dc7ae7a4fa40517aafa941ae1ee436b91a12c",
-      "name": "Buz Economy",
-      "symbol": "BUZ",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/39793/large/buz-economy-logo-dark.png?1724117134"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066",
-      "name": "Rug World Assets",
-      "symbol": "RWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37119/large/0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066.jpg?1713356569"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0028e1e60167b48a938b785aa5292917e7eaca8b",
-      "name": "Coinye West",
-      "symbol": "COINYE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36403/large/Coinye_West.png?1711369153"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa8c2e771288585229eea8dbe072edfa7bcb388bb",
-      "name": "Apollo Name Service",
-      "symbol": "ANS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40040/large/star_logo8305.png?1725392202"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc2bc7a73613b9bd5f373fe10b55c59a69f4d617b",
-      "name": "DackieSwap",
-      "symbol": "DACKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30752/large/dackieswap_large.png?1707290196"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x55027a5b06f4340cc4c82dcc74c90ca93dcb173e",
-      "name": "Tadpole",
-      "symbol": "TAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39783/large/IMG_7927.PNG?1724101375"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xde5ed76e7c05ec5e4572cfc88d1acea165109e44",
-      "name": "DEUS Finance",
-      "symbol": "DEUS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18778/large/Black_Background_200x200.png?1696518242"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x76e7447bafa3f0acafc9692629b1d1bc937ca15d",
-      "name": "Pola On Base",
-      "symbol": "POLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37314/large/pola.jpg?1713971028"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcc7ff230365bd730ee4b352cc2492cedac49383e",
-      "name": "High Yield USD  Base ",
-      "symbol": "HYUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33636/large/hyusdlogo.png?1702536133"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcba6fabf7df8ada1995d1f57acaf520198289ca9",
-      "name": "BeromesButt",
-      "symbol": "BUTT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52419/large/BUTT_Logo.jpg?1733326535"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf1143f3a8d76f1ca740d29d5671d365f66c44ed1",
-      "name": "Wrapped Bitcoin  Universal ",
-      "symbol": "UBTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50252/large/UA-BTC_1.png?1726721793"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xff62ddfa80e513114c3a0bf4d6ffff1c1d17aadf",
-      "name": "Boe",
-      "symbol": "BOE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36712/large/79jlrE4M_400x400_%282%29.jpg?1712127456"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xebf7d4d84372f5df1b5d0e3ddd889e5bc286b1c3",
-      "name": "Ali for fx protocol by Virtuals",
-      "symbol": "FX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52319/large/imresizer-1732989192834.jpg?1733077790"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x474f4cb764df9da079d94052fed39625c147c12c",
-      "name": "Bonsai Token",
-      "symbol": "BONSAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35884/large/Bonsai_BW_Coingecko-200x200.jpg?1710071621"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x92dc4ab92eb16e781559e612f349916988013d5a",
-      "name": "Agent Zero",
-      "symbol": "WSB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51310/large/photo_2024-11-03_07-33-29.jpg?1730643955"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa067436db77ab18b1a315095e4b816791609897c",
-      "name": "WASSIE",
-      "symbol": "WASSIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30144/large/logo-coingecko.png?1696529065"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x57bd5c33c8002a634b389ab4de5e09ec1c31dce7",
-      "name": "Silo Finance",
-      "symbol": "SILO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21454/large/y0iYKZOv_400x400.png?1696520816"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x78b3c724a2f663d11373c4a1978689271895256f",
-      "name": "Token Name Service",
-      "symbol": "TKN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39886/large/Tri-gradient_Group_5135_2x.png?1724682287"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x24cb2b89844604c57350776d81e14765d03b91de",
-      "name": "Zunami ETH",
-      "symbol": "ZUNETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37835/large/zunETH_200x200.png?1715741123"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2075f6e2147d4ac26036c9b4084f8e28b324397d",
-      "name": "BaseCTO",
-      "symbol": "CTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50716/large/IMG_1480.jpeg?1728792869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc19669a405067927865b40ea045a2baabbbe57f5",
-      "name": "Star",
-      "symbol": "STAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31277/large/coin-icon_Star-200x200.png?1732742256"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb34457736aa191ff423f84f5d669f68b231e6c4e",
-      "name": "AGENT DOGE by Virtuals",
-      "symbol": "AIDOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52187/large/Screenshot_2024-11-23_at_4.09.40%E2%80%AFPM.png?1732723139"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x75e6b648c91d222b2f6318e8ceeed4b691d5323f",
-      "name": "AnonFi",
-      "symbol": "ANON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50446/large/IMG_20240928_164632_277.png?1727771357"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x315b8c9a1123c10228d469551033440441b41f0b",
-      "name": "BEATS on BASE",
-      "symbol": "BEATS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52396/large/200x200_transparent.png?1733293803"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x698dc45e4f10966f6d1d98e3bfd7071d8144c233",
-      "name": "PEPE 0x69 ON BASE",
-      "symbol": "PEPE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37400/large/lOGO.jpg?1714352456"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb8e564b206032bbcda2c3978bc371da52152f72e",
-      "name": "Base Terminal",
-      "symbol": "BASEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50300/large/Base_Terminal_Logo_200x200.png?1727021406"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x72e72193ea14ac3b469f881989d18a2ba021b4c6",
-      "name": "Dollar",
-      "symbol": "DOLLAR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39312/large/pfp_200x200.png?1721706165"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x49c86046903807d0a3193a221c1a3e1b1b6c9ba3",
-      "name": "CYI by Virtuals",
-      "symbol": "CYI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52125/large/Cryptoyieldinfo.jpg?1732611368"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5d9c2457a10d455e0ad8e28e40cc28eacf27a06a",
-      "name": "GM Everyday",
-      "symbol": "GM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52139/large/sRavZnte_.png?1732642259"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc2fe011c3885277c7f0e7ffd45ff90cadc8ecd12",
-      "name": "Poncho",
-      "symbol": "PONCHO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36160/large/ponchologo.PNG?1710744293"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbd4e5c2f8de5065993d29a9794e2b7cefc41437a",
-      "name": "IPOR",
-      "symbol": "IPOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png?1696527376"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc9b6ef062fab19d3f1eabc36b1f2e852af1acd18",
-      "name": "Brett s cat",
-      "symbol": "BALT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38428/large/IMG_4717.PNG?1717627270"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6112b8714221bbd96ae0a0032a683e38b475d06c",
-      "name": "WAI Combinator by Virtuals",
-      "symbol": "WAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52181/large/wai.jpg?1732689732"
+      "logoURI": "https://assets.coingecko.com/coins/images/36553/large/icon.png?1711896644"
     },
     {
       "chainId": 8453,
@@ -3500,83 +1892,51 @@
     },
     {
       "chainId": 8453,
-      "address": "0x2dc90fa3a0f178ba4bee16cac5d6c9a5a7b4c6cb",
-      "name": "DRINK",
-      "symbol": "DRINK",
+      "address": "0xd33c7b753ecaa85e5d5f5b5fd99dec59f26a087e",
+      "name": "Defactor",
+      "symbol": "FACTR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50167/large/2N1fxgBw_400x400.jpg?1726136925"
+      "logoURI": "https://assets.coingecko.com/coins/images/19201/large/jFLSu4U9_400x400.png?1696518648"
     },
     {
       "chainId": 8453,
-      "address": "0xc227717ef4ae4d982e14789eb33ba942243c3fee",
-      "name": "Mozaic",
-      "symbol": "MOZ",
+      "address": "0x7431ada8a591c955a994a21710752ef9b882b8e3",
+      "name": "MorpheusAI",
+      "symbol": "MOR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30100/large/Main_Logo_1-200x200jpg.jpg?1696529024"
+      "logoURI": "https://assets.coingecko.com/coins/images/37969/large/MOR200X200.png?1716327119"
     },
     {
       "chainId": 8453,
-      "address": "0xb8d98a102b0079b69ffbc760c8d857a31653e56e",
-      "name": "Toby ToadGod",
-      "symbol": "TOBY",
+      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
+      "name": "Glo Dollar",
+      "symbol": "USDGLO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36615/large/toby1.png?1711976453"
+      "logoURI": "https://assets.coingecko.com/coins/images/29319/large/GLO_logo_pine_on_cyan_1_3.png?1716971065"
     },
     {
       "chainId": 8453,
-      "address": "0xd85eff20288ca72ea9eecffb428f89ee5066ca5c",
-      "name": "ISKRA Token",
-      "symbol": "ISK",
+      "address": "0x56a38e7216304108e841579041249feb236c887b",
+      "name": "Libertum",
+      "symbol": "LBM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27428/large/ISKRA_logo.png?1696526469"
+      "logoURI": "https://assets.coingecko.com/coins/images/37147/large/wmGmpgSW_400x400.jpg?1713469301"
     },
     {
       "chainId": 8453,
-      "address": "0x8f4e4221ba88d4e9bb76ecfb91d7c5ce08d7d5b9",
-      "name": "FU Money",
-      "symbol": "FU",
+      "address": "0x548f93779fbc992010c07467cbaf329dd5f059b7",
+      "name": "BMX",
+      "symbol": "BMX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38629/large/FU_logo_black.png?1718170125"
+      "logoURI": "https://assets.coingecko.com/coins/images/31699/large/bmx_white.png?1696530517"
     },
     {
       "chainId": 8453,
-      "address": "0xb755506531786c8ac63b756bab1ac387bacb0c04",
-      "name": "ZARP Stablecoin",
-      "symbol": "ZARP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27333/large/zarp_coin.png?1696526381"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x72499bddb67f4ca150e1f522ca82c87bc9fb18c8",
-      "name": "Bonk On Base",
-      "symbol": "BONK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37123/large/200x200.png?1713367524"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1a43287cbfcc5f35082e6e2aa98e5b474fe7bd4e",
-      "name": "Athena by Virtuals",
-      "symbol": "ATHENA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52006/large/athenalogo.png?1732304469"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6c7ebb64e258f5712eeec83ceaf41c3dcbb534b1",
-      "name": "Vainguard",
-      "symbol": "VAIN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52365/large/Vain_CG.png?1733210740"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xac86f3556cbd2b4d800d17adc3a266b500fcb9f5",
-      "name": "Etherisc DIP",
-      "symbol": "DIP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4586/large/dip.png?1696505164"
+      "address": "0x4e73420dcc85702ea134d91a262c8ffc0a72aa70",
+      "name": "SKI MASK PUP",
+      "symbol": "SKIPUP",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/38093/large/SkiPup_Logo.png?1716486539"
     },
     {
       "chainId": 8453,
@@ -3588,6 +1948,678 @@
     },
     {
       "chainId": 8453,
+      "address": "0xca4569949699d56e1834efe9f58747ca0f151b01",
+      "name": "Token Metrics AI",
+      "symbol": "TMAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37707/large/Mascot_200x200.png?1733173189"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8c9037d1ef5c6d1f6816278c7aaf5491d24cd527",
+      "name": "Moxie",
+      "symbol": "MOXIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39451/large/favicon_-_200_x_200.png?1722311978"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6009e7cd237087e6d7570990e8bdac09c3e182b0",
+      "name": "TaskBunny",
+      "symbol": "BNY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51478/large/Bunny_coin_200x200.png?1731404290"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x30121d81f4407474a6d93f5c3060f14aaa098a61",
+      "name": "Insane Labz  Base ",
+      "symbol": "LABZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51886/large/Photo_May_18_2024__6_11_22_PM.jpg?1732120518"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x554bba833518793056cf105e66abea330672c0de",
+      "name": "Maha",
+      "symbol": "MAHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13404/large/black.png?1724679606"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0c03ce270b4826ec62e7dd007f0b716068639f7b",
+      "name": "The Innovation Game",
+      "symbol": "TIG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50669/large/TIG_Logo_200x200.png?1729604604"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xebff2db643cf955247339c8c6bcd8406308ca437",
+      "name": "ChompCoin",
+      "symbol": "CHOMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36942/large/chomplogo200.png?1712864472"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x99b2b1a2adb02b38222adcd057783d7e5d1fcc7d",
+      "name": "Common Wealth",
+      "symbol": "WLTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37858/large/WLTH_TICKER_200x200.png?1730241264"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb38266e0e9d9681b77aeb0a280e98131b953f865",
+      "name": "DOVU",
+      "symbol": "DOVU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/31930/large/Dovu_Icon_Black_%281%29.png?1696530738"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
+      "name": "Wagmi",
+      "symbol": "WAGMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31887/large/wagmi_token_logo.png?1696530698"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
+      "name": "Nya",
+      "symbol": "NYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40082/large/nya.jpg?1725523655"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+      "name": "Mountain Protocol USD",
+      "symbol": "USDM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31719/large/usdm.png?1696530540"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x82b0e1a2374ea0198f62a48b14ffab53db6c1e36",
+      "name": "PokPok Golden Egg",
+      "symbol": "PEGG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40102/large/golden_eggs_%281%29.png?1725694597"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xae2bddbcc932c2d2cf286bad0028c6f5074c77b5",
+      "name": "Falcons",
+      "symbol": "FAH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50297/large/Falcons.png?1726935509"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x18a8bd1fe17a1bb9ffb39ecd83e9489cfd17a022",
+      "name": "Andy",
+      "symbol": "ANDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36552/large/ANDY.jpg?1711896298"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x71a67215a2025f501f386a49858a9ced2fc0249d",
+      "name": "Wrapped SEI  Universal ",
+      "symbol": "USEI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51023/large/UA-SEI_1.png?1729770680"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c5fdf0ee37d62c774025599e3b692d027746e24",
+      "name": "Bonkey",
+      "symbol": "BONKEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51629/large/nWKo5DZvrtkwwjtT7YXyYQeDstBhvwrqxdOmGmWvUNN6d_GSurf_TR1InJS8oLo2WYIJG2ZsX2Lffmr8z1bjqjygtVNcAKuMIX3TJPg65wPZepTpTQnXCXZrbA_oXuiIkzN2PU1vd1i6scKtGgJa4ffeecm1R7WzR7NX65j6JVu_ys42VMrpvNuNJ2ovRGM8sh9V-MovD8Mbs9NkaYQ_%281%29.jpg?1731664154"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4da78059d97f155e18b37765e2e042270f4e0fc4",
+      "name": "WUFFI",
+      "symbol": "WUF",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/36933/large/WUFFI.jpg?1720613603"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x36912b5cf63e509f18e53ac98b3012fa79e77bf5",
+      "name": "FUEGO",
+      "symbol": "FUEGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51345/large/FUEGO_200x200.jpg?1730825086"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9f95e17b2668afe01f8fbd157068b0a4405cc08d",
+      "name": "Bullieverse",
+      "symbol": "BULL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24174/large/KR3qVAQe_400x400.jpg?1696523362"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5babfc2f240bc5de90eb7e19d789412db1dec402",
+      "name": "Burning Circle",
+      "symbol": "CIRCLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35274/large/circle.png?1708048159"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0c5142bc58f9a61ab8c3d2085dd2f4e550c5ce0b",
+      "name": "RUSSELL",
+      "symbol": "RUSSELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50690/large/russelllogo.png?1730010143"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
+      "name": "Osaka Protocol",
+      "symbol": "OSAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30911/large/OSAK_LOGO_200x200.png?1723662197"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb4e017223fd3d639d0264de4da1b9e080325cb5e",
+      "name": "SyncVault",
+      "symbol": "SVTS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50447/large/White_SV_logo_200x200.png?1727771615"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x10f434b3d1cc13a4a79b062dcc25706f64d10d47",
+      "name": "BEPE",
+      "symbol": "BEPE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/35989/large/NEW_LOGO200x200.png?1721595288"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x354d6890caa31a5e28b6059d46781f40880786a6",
+      "name": "ghffb47yii2rteeyy10op",
+      "symbol": "GHFFB47YII2RTEEYY10",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52104/large/0x354d6890caa31a5e28b6059d46781f40880786a6.png?1732591949"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3d2eba645c44bbd32a34b7c017667711eb5b173c",
+      "name": "Wrapped MistCoin",
+      "symbol": "WMC",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/32490/large/355966EE-F4AD-4023-A38E-59B9DEF1C6C3.jpeg?1732678326"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x314d7f9e2f55b430ef656fbb98a7635d43a2261e",
+      "name": "Naym",
+      "symbol": "NAYM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50981/large/naym.jpg?1729651162"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x689644b86075ed61c647596862c7403e1c474dbf",
+      "name": "Bamboo on Base",
+      "symbol": "BAMBOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39126/large/Bamboo_Logo_800x800.png?1720656497"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdb6e0e5094a25a052ab6845a9f1e486b9a9b3dde",
+      "name": "Okayeg",
+      "symbol": "OKAYEG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37748/large/Okayeg_200.png?1715442444"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x98d59767cd1335071a4e9b9d3482685c915131e8",
+      "name": "DREAM",
+      "symbol": "DREAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52029/large/dream-logo.png?1732358413"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x60222751504796934bddee8218f9725f0c95d2c1",
+      "name": "Simps",
+      "symbol": "SIMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51994/large/200.png?1732296595"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe095780ba2a64a4efa7a74830f0b71656f0b0ad4",
+      "name": "Byte",
+      "symbol": "BYTE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/33527/large/Byte200.jpeg?1702138460"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x54b659832f59c24cec0e4a2cd193377f1bcefc3c",
+      "name": "Akashalife",
+      "symbol": "AK1111",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50533/large/Akasha-CoinIcon_%283%29.png?1728206155"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x252d223d0550bc6c137b003d90bc74f5341a2818",
+      "name": "Bitbot",
+      "symbol": "BITBOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52512/large/Bitbot_Logo.png?1733493165"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x52e0d3c27cc9e3607c1ca7914b9049be3d5e9c41",
+      "name": "Blu",
+      "symbol": "BLU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51922/large/Blu.jpg?1732190348"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3ecced5b416e58664f04a39dd18935eb71d33b15",
+      "name": "Brian",
+      "symbol": "BRIAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51099/large/Brian_Arm_Strong.png?1730083824"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc48e605c7b722a57277e087a6170b9e227e5ac0a",
+      "name": "OmniCat",
+      "symbol": "OMNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33917/large/omnicatlogo.png?1717544778"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3ee5e23eee121094f1cfc0ccc79d6c809ebd22e5",
+      "name": "Ionic Protocol",
+      "symbol": "ION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36713/large/Ionic-icon-green.png?1712127547"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x63228048121877a9e0f52020834a135074e8207c",
+      "name": "Moonsama",
+      "symbol": "SAMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28308/large/Small.png?1696527312"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7a8a5012022bccbf3ea4b03cd2bb5583d915fb1a",
+      "name": "Chuck",
+      "symbol": "CHUCK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37468/large/1000030138.jpg?1714457112"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x315b8c9a1123c10228d469551033440441b41f0b",
+      "name": "BEATS on BASE",
+      "symbol": "BEATS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52396/large/200x200_transparent.png?1733293803"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf34e0cff046e154cafcae502c7541b9e5fd8c249",
+      "name": "Thales",
+      "symbol": "THALES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18388/large/CLVZJN_C_400x400.png?1696517879"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x63cb9a22cbc00bf9159429e9dede4b88c3dba8ce",
+      "name": "LaunchTokenBot",
+      "symbol": "CAPO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52234/large/f22a0bcbbfa4da6930bf8c1d37c2e0a0.jpeg?1732804814"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2dad3a13ef0c6366220f989157009e501e7938f8",
+      "name": "Extra Finance",
+      "symbol": "EXTRA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30973/large/Ex_logo-white-blue_ring_288x.png?1696529812"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x72499bddb67f4ca150e1f522ca82c87bc9fb18c8",
+      "name": "Bonk On Base",
+      "symbol": "BONK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37123/large/200x200.png?1713367524"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x655a51e6803faf50d4ace80fa501af2f29c856cf",
+      "name": "PAID",
+      "symbol": "PAID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13761/large/PAID_Logo_new.png?1730798431"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbd4e5c2f8de5065993d29a9794e2b7cefc41437a",
+      "name": "IPOR",
+      "symbol": "IPOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png?1696527376"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbf1aea8670d2528e08334083616dd9c5f3b087ae",
+      "name": "MAI  Base ",
+      "symbol": "MIMATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35466/large/mimatic-red.png?1708687857"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfaa4f3bcfc87d791e9305951275e0f62a98bcb10",
+      "name": "Super Best Friends",
+      "symbol": "SUBF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36368/large/1000017215.jpg?1711338058"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe0023e73aab4fe9a22f059a9d27e857e027ee3dc",
+      "name": "RWAX",
+      "symbol": "RWAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38266/large/Rwax_Token_Symbol_logo-200.png?1716949733"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x41e0fe1317bd6e8944b037cd59b22d428c1434c2",
+      "name": "Virtu by Virtuals",
+      "symbol": "VIRTU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51827/large/_removal.ai__24fd4161-77b5-412f-b553-a99e9012f575_photo_2024-11-07_08-05-59.png?1732042711"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8fbd0648971d56f1f2c35fa075ff5bc75fb0e39d",
+      "name": "UNKJD",
+      "symbol": "MBS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20841/large/monkeyball.png?1696520233"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x698dc45e4f10966f6d1d98e3bfd7071d8144c233",
+      "name": "PEPE 0x69 ON BASE",
+      "symbol": "PEPE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37400/large/lOGO.jpg?1714352456"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xff0c532fdb8cd566ae169c1cb157ff2bdc83e105",
+      "name": "Fren Pet",
+      "symbol": "FP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33022/large/token.png?1700274697"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x42069de48741db40aef864f8764432bbccbd0b69",
+      "name": "All Street Bets",
+      "symbol": "BETS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36906/large/Screenshot_2024-03-17_034831_no_background.png?1712728634"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c3860d89b81c91974fc1f8a41aeeef604c17058",
+      "name": "Kinetix Finance Token",
+      "symbol": "KAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34031/large/KFI_Token_1.png?1703675672"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7f05a7a9af2f5a07d1e64877c8dc37a64a22508e",
+      "name": "Ajna Protocol",
+      "symbol": "AJNA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30187/large/AJNA-Icon-200.png?1696529105"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9f235d23354857efe6c541db92a9ef1877689bcb",
+      "name": "Goodle",
+      "symbol": "GOODLE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39688/large/Screenshot_2024-07-26_at_5.38.55_PM-removebg-preview.png?1723660779"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3816dd4bd44c8830c2fa020a5605bac72fa3de7a",
+      "name": "Presearch",
+      "symbol": "PRE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1299/large/presearch.png?1696502369"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x749e5334752466cda899b302ed4176b8573dc877",
+      "name": "Assimilate",
+      "symbol": "SIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52377/large/SIM_LOGO.jpeg?1733253732"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x613ce28076289de255f1a6487437f03e37e4a71d",
+      "name": "Dackie USD",
+      "symbol": "DCKUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39966/large/Dackie_USD_Stablecoin.png?1724957262"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc227717ef4ae4d982e14789eb33ba942243c3fee",
+      "name": "Mozaic",
+      "symbol": "MOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30100/large/Main_Logo_1-200x200jpg.jpg?1696529024"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x120edc8e391ba4c94cb98bb65d8856ae6ec1525f",
+      "name": "LOUDER",
+      "symbol": "LOUDER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39495/large/louder_icon_200x200.png?1722539190"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3203856eac03d343f9d5245ba2f39861838a7b36",
+      "name": "Aviator",
+      "symbol": "AVI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31024/large/avi-200x200png.png?1711119363"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f2e6758c4d6570344bd5007dec6301cd57590a0",
+      "name": "Spot",
+      "symbol": "SPOT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28426/large/SPOT_Logo_200x200_sq_small_centered.png?1696527423"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4dd9077269dd08899f2a9e73507125962b5bc87f",
+      "name": "Crash On Base",
+      "symbol": "CRASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38817/large/_iNshlUA.png?1722185418"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7d27187eb33a7b1d99258ff222633670f84fa342",
+      "name": "IntentX",
+      "symbol": "INTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38241/large/PFP_IX_2.png?1716881240"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0c41f1fc9022feb69af6dc666abfe73c9ffda7ce",
+      "name": "Bitcoin on Base",
+      "symbol": "BTCB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38868/large/BTCB_Official_Logo_July_2024.png?1721753012"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x98f4779fccb177a6d856dd1dfd78cd15b7cd2af5",
+      "name": "MISATO",
+      "symbol": "MISATO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52231/large/misatocleanboost.png?1732802425"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb4e1b230dd0476238fc64c99ff9d6ccdfdb2258d",
+      "name": "Florence Finance Medici",
+      "symbol": "FFM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34382/large/M_PNG_200x200_copy.png?1704779326"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x01aac2b594f7bdbec740f0f1aa22910ebb4b74ab",
+      "name": "Unio Coin",
+      "symbol": "UNIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50191/large/uniocoin-200x200.png?1726206790"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xecaf81eb42cd30014eb44130b89bcd6d4ad98b92",
+      "name": "Based Chad",
+      "symbol": "CHAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36285/large/logo_200_200_square.jpg?1712167823"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x74ff3cbf86f95fea386f79633d7bc4460d415f34",
+      "name": "BabyCrash",
+      "symbol": "BABYCRASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38966/large/BABY_CRASH_TPB_200px.png?1727976620"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe13e40e8fdb815fbc4a1e2133ab5588c33bac45d",
+      "name": "TRIBAL",
+      "symbol": "TRIBAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38531/large/7pc8ov67182ddpbqjnff20ik4oye.png?1733194448"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf5f2a79eeccf6e7f4c570c803f529930e29cc96b",
+      "name": "CertaiK by Virtuals",
+      "symbol": "CERTAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52488/large/download.jpeg?1733432223"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfd1013c72cbb0ffb920d347c5836bf88965d0d5e",
+      "name": "STIX",
+      "symbol": "STIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52015/large/STIX_Logo_Transparent_200x200.png?1732346967"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x698b49063c14d2753d23064ff891a876cffa6fb5",
+      "name": "NIKITA by Virtuals",
+      "symbol": "NIKITA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52146/large/Nikita_Pic.png?1732652736"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x57bd5c33c8002a634b389ab4de5e09ec1c31dce7",
+      "name": "Silo Finance",
+      "symbol": "SILO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21454/large/y0iYKZOv_400x400.png?1696520816"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc2bc7a73613b9bd5f373fe10b55c59a69f4d617b",
+      "name": "DackieSwap",
+      "symbol": "DACKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30752/large/dackieswap_large.png?1707290196"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x478e03d45716dda94f6dbc15a633b0d90c237e2f",
+      "name": "Shaka",
+      "symbol": "SHAKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36850/large/sharetheshaka.png?1712585688"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
+      "name": "Aura Finance",
+      "symbol": "AURA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25942/large/logo.png?1696525021"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x24569d33653c404f90af10a2b98d6e0030d3d267",
+      "name": "Unagi Token",
+      "symbol": "UNA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34733/large/unagi.png?1705922276"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "name": "Hop Protocol",
+      "symbol": "HOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25445/large/hop.png?1696524577"
+    },
+    {
+      "chainId": 8453,
       "address": "0xfb18511f1590a494360069f3640c27d55c2b5290",
       "name": "Wild Goat Coin",
       "symbol": "WGC",
@@ -3596,107 +2628,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x7cf7132ede0ca592a236b6198a681bb7b42dd5ae",
-      "name": "BOLT on Base",
-      "symbol": "BOLT",
+      "address": "0x39fed555ff57cb1154bfa6b1a2492bb914ce2d9b",
+      "name": "EchoLeaks by Virtuals",
+      "symbol": "ECHO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38449/large/wwwww.png?1717557162"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x10a7a84c91988138f8dbbc82a23b02c8639e2552",
-      "name": "ROXY FROG",
-      "symbol": "ROXY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38170/large/ROXY.jpg?1716703909"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6bc40d4099f9057b23af309c08d935b890d7adc0",
-      "name": "SnailBrook",
-      "symbol": "SNAIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29922/large/snail.jpeg?1713754058"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7ed613ab8b2b4c6a781ddc97ea98a666c6437511",
-      "name": "All Your Base",
-      "symbol": "AYB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35777/large/AYB-Coingecko.png?1718634946"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x91f45aa2bde7393e0af1cc674ffe75d746b93567",
-      "name": "Frame Token",
-      "symbol": "FRAME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35034/large/Artboard_1_copyd.png?1707189782"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1db0fc8933f545648b54a9ee4326209a9a259643",
-      "name": "Zunami Governance Token",
-      "symbol": "ZUN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38298/large/ZUN_200x200.png?1717194404"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xac27fa800955849d6d17cc8952ba9dd6eaa66187",
-      "name": "UnlockProtocolToken",
-      "symbol": "UP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51457/large/up2.png?1731318758"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xba71cb8ef2d59de7399745793657838829e0b147",
-      "name": "Siamese",
-      "symbol": "SIAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36489/large/transparant-200x200.png?1728005931"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0a14ef61afb32e5ca672e021784f71705ac14908",
-      "name": "NULL MATRIX",
-      "symbol": "NULL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51086/large/dark.png?1732460149"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xeff2a458e464b07088bdb441c21a42ab4b61e07e",
-      "name": "ParagonsDAO",
-      "symbol": "PDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22642/large/pdt_token_image.png?1727376481"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8d3419b9a18651f3926a205ee0b1acea1e7192de",
-      "name": "Law of Attraction",
-      "symbol": "LOA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38008/large/1.png?1716270777"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb3a9bd4861454ba94931ebff410c3d828525dce2",
-      "name": "WoofWork io",
-      "symbol": "WOOF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28903/large/WWlogoTransparent_200x200.png?1696527879"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4b61e2f1bbdee6d746209a693156952936f1702c",
-      "name": "Based Lambow",
-      "symbol": "LAMBOW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38690/large/new-logo.jpg?1731187032"
+      "logoURI": "https://assets.coingecko.com/coins/images/52172/large/echoleaks.jpg?1732683705"
     },
     {
       "chainId": 8453,
@@ -3708,259 +2644,59 @@
     },
     {
       "chainId": 8453,
-      "address": "0x6b9bb36519538e0c073894e964e90172e1c0b41f",
-      "name": "WEWECOIN",
-      "symbol": "WEWE",
+      "address": "0xeb9e49fb4c33d9f6aefb1b03f9133435e24c0ec6",
+      "name": "Newton On Base",
+      "symbol": "NEWB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39135/large/wewe_logo.png?1720857800"
+      "logoURI": "https://assets.coingecko.com/coins/images/38475/large/IMG_1092.JPG?1724476844"
     },
     {
       "chainId": 8453,
-      "address": "0x0dd7913197bfb6d2b1f03f9772ced06298f1a644",
-      "name": "Moonboots DAO",
-      "symbol": "MBDAO",
+      "address": "0x0718f45bbf4781ce891e4e18182f025725f0fc95",
+      "name": "Misser",
+      "symbol": "MISSER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38066/large/MBDAO_Token_icon.png?1716441877"
+      "logoURI": "https://assets.coingecko.com/coins/images/39315/large/misser_pic.png?1721707572"
     },
     {
       "chainId": 8453,
-      "address": "0x1a475d06d967aeb686c98de80d079d72097aeacf",
-      "name": "Brett 2 0",
-      "symbol": "BRETT20",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37121/large/brett200-modified.png?1713366621"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd27c288fd69f228e0c02f79e5ecadff962e05a2b",
-      "name": "Fire",
-      "symbol": "FIRE",
+      "address": "0xcde90558fc317c69580deeaf3efc509428df9080",
+      "name": "Normilio",
+      "symbol": "NORMILIO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50835/large/fire-coin-200.png?1729242121"
+      "logoURI": "https://assets.coingecko.com/coins/images/36915/large/vm2byD93.jpg?1733436102"
     },
     {
       "chainId": 8453,
-      "address": "0xdaf3c78f165d26f821d3d39d6598a96e962b1508",
-      "name": "The Css God by Virtuals",
-      "symbol": "WEBSIM",
+      "address": "0xf7c1cefcf7e1dd8161e00099facd3e1db9e528ee",
+      "name": "Tower",
+      "symbol": "TOWER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52173/large/the_css_god.jpg?1732684452"
+      "logoURI": "https://assets.coingecko.com/coins/images/14134/large/tower-circular-1000.png?1696513854"
     },
     {
       "chainId": 8453,
-      "address": "0x1f1aa4d239002bb818536c95e9b762a1fc8484c1",
-      "name": "Precipitate ai",
-      "symbol": "RAIN",
+      "address": "0xe642657e4f43e6dcf0bd73ef24008394574dee28",
+      "name": "Music Protocol",
+      "symbol": "RECORD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32405/large/RAIN_200-removebg-preview.png?1711371589"
+      "logoURI": "https://assets.coingecko.com/coins/images/39243/large/MP-mark-color.png?1724879503"
     },
     {
       "chainId": 8453,
-      "address": "0x524d524b4c9366be706d3a90dcf70076ca037ae3",
-      "name": "RMRK",
-      "symbol": "RMRK",
+      "address": "0xd1917629b3e6a72e6772aab5dbe58eb7fa3c2f33",
+      "name": "Settled EthXY Token",
+      "symbol": "SEXY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18656/large/download_%281%29_%281%29.png?1696518126"
+      "logoURI": "https://assets.coingecko.com/coins/images/33032/large/logo-circle.png?1700348518"
     },
     {
       "chainId": 8453,
-      "address": "0x7480527815ccae421400da01e052b120cc4255e9",
-      "name": "Workie",
-      "symbol": "WORKIE",
+      "address": "0xdcf5130274753c8050ab061b1a1dcbf583f5bfd0",
+      "name": "ViciCoin",
+      "symbol": "VCNT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38774/large/Pfp2_%281%29.png?1724903016"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf95e1c0a67492720ca22842122fe7fa63d5519e5",
-      "name": "Lunarlens",
-      "symbol": "LUNARLENS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39304/large/%E6%9C%88%E4%BA%AE%E5%B8%8164.png?1721633565"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4d25e94291fe8dcfbfa572cbb2aaa7b755087c91",
-      "name": "High",
-      "symbol": "HIGH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36318/large/high200x200.png?1711092521"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x41a22eb30df65d6ab0ce0b4cfe8f4e0eb306d471",
-      "name": "BaseBearCute",
-      "symbol": "BBQ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40006/large/logo.jpg?1725221317"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4d58608eff50b691a3b76189af2a7a123df1e9ba",
-      "name": "Boysclubbase",
-      "symbol": "BOYS",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37825/large/IMG_20240507_221140_398.jpg?1715668247"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x420b0fa3de2efcf2b2fd04152eb1df36a09717cd",
-      "name": "King Of Memes",
-      "symbol": "KING",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38261/large/kingofmemes.png?1716929140"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x38d513ec43dda20f323f26c7bef74c5cf80b6477",
-      "name": "Carlo",
-      "symbol": "CARLO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37553/large/CARLO_200x200.png?1714752141"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbf4db8b7a679f89ef38125d5f84dd1446af2ea3b",
-      "name": "Le Bleu Elefant",
-      "symbol": "BLEU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37811/large/b.png?1715597915"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9124577428c5bd73ad7636cbc5014081384f29d6",
-      "name": "Monky",
-      "symbol": "MONKY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38522/large/1000084004.jpg?1717759092"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x33ad778e6c76237d843c52d7cafc972bb7cf8729",
-      "name": "Boshi",
-      "symbol": "BOSHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37222/large/boshi.jpeg?1713775901"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd064c53f043d5aee2ac9503b13ee012bf2def1d0",
-      "name": "DeFido",
-      "symbol": "DEFIDO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18861/large/coingecko.png?1712043959"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6b82297c6f1f9c3b1f501450d2ee7c37667ab70d",
-      "name": "goatwifhat",
-      "symbol": "GIF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37776/large/GIF_logo_200x200.png?1715581191"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xed1978d01d4a8a9d6a43ac79403d5b8dfbed739b",
-      "name": "Sandwich Cat",
-      "symbol": "SACA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36876/large/200x200_%281%29.png?1712646447"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcc6ce98579ba909344bb765f0c4f45964d5ce1d2",
-      "name": "DUDEGEN",
-      "symbol": "DUDEGEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39323/large/Untitled_Artwork_5-enhanced_copy_2.png?1721711203"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x87c211144b1d9bdaa5a791b8099ea4123dc31d21",
-      "name": "BlockChainPeople",
-      "symbol": "BCP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38085/large/200x200.png?1716477512"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4c40454659c8ec1283355d8e3911ba1745ff6fd1",
-      "name": "Blue Chip",
-      "symbol": "CHIP",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/36433/large/BlueChip-200x200.png?1711435311"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x82aed68f1deaca2b2aa4c5f27276374228a9f923",
-      "name": "Based Beast Coin",
-      "symbol": "BEAST",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/51121/large/IMG_7914.png?1730164559"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3933012dcf9beb0d63778725345e04dcc0c69c7e",
-      "name": "UNLUCKY",
-      "symbol": "UNLUCKY",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/38691/large/unlucky.jpeg?1718346998"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x881ed0fcef78120a135ec6cc66cef2779fe95bba",
-      "name": "DogeGF",
-      "symbol": "DOGEGF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18651/large/dogegf_logo_200x200.png?1712082872"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x39d24405ca717ef841e4a782da97284cf2dc7628",
-      "name": "Agent Zeek by Virtuals",
-      "symbol": "ZEEK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52331/large/dwWGlf18_400x400.jpg?1733086398"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9a6d24c02ec35ad970287ee8296d4d6552a31dbe",
-      "name": "OPEN Ticketing Ecosystem",
-      "symbol": "OPN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36612/large/TOKEN.png?1711975511"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6ce7c23b917284e21d55cea20acaeb2bc58594be",
-      "name": "Rizz",
-      "symbol": "RIZZ",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/50598/large/200x200px.png?1728446110"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfd008f937b4d73eeb00cf74ce90c392be5f07f96",
-      "name": "MOON INU",
-      "symbol": "MOON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36493/large/moon-200.png?1711612557"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4b556f3a476b58be7f35df77edd68fbe5076f706",
-      "name": "MintStakeShare",
-      "symbol": "MSS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39424/large/logo200x200.png?1729946358"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x599f07567656e6961e20fa6a90685d393808c192",
-      "name": "Department Of Government Efficiency",
-      "symbol": "DOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51896/large/coingecko_%282%29.png?1732124666"
+      "logoURI": "https://assets.coingecko.com/coins/images/31305/large/ViciCoin_-_small.png?1696530124"
     },
     {
       "chainId": 8453,
@@ -3972,27 +2708,1051 @@
     },
     {
       "chainId": 8453,
-      "address": "0x1986cc18d8ec757447254310d2604f85741aa732",
-      "name": "Rewardable",
-      "symbol": "REWARD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52274/large/reward-token-icon-200x200.png?1732888312"
+      "address": "0x041fdf3f472d2c8a7ecc458fc3b7f543e6c57ef7",
+      "name": "Shiba Armstrong",
+      "symbol": "SHIBA",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37708/large/LOGO256.png?1715273986"
     },
     {
       "chainId": 8453,
-      "address": "0x22222bd682745cf032006394750739684e45a5f8",
-      "name": "Jasse Polluk",
-      "symbol": "POLLUK",
+      "address": "0x776aaef8d8760129a0398cf8674ee28cefc0eab9",
+      "name": "Floppa Cat",
+      "symbol": "FLOPPA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38510/large/Jasse_Polluk.png?1717754036"
+      "logoURI": "https://assets.coingecko.com/coins/images/36969/large/floppa.jpg?1722771377"
     },
     {
       "chainId": 8453,
-      "address": "0x8bf591eae535f93a242d5a954d3cde648b48a5a8",
-      "name": "Sumer Money suUSD",
-      "symbol": "SUUSD",
+      "address": "0xde5ed76e7c05ec5e4572cfc88d1acea165109e44",
+      "name": "DEUS Finance",
+      "symbol": "DEUS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33266/large/Sumer_Money_Logo.jpg?1701321416"
+      "logoURI": "https://assets.coingecko.com/coins/images/18778/large/Black_Background_200x200.png?1696518242"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe8aae6251c6cf39927b0ff31399030c60bec798f",
+      "name": "SUMI",
+      "symbol": "SUMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51253/large/SUMI.jpg?1730477794"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x623cd3a3edf080057892aaf8d773bbb7a5c9b6e9",
+      "name": "Sekuya Multiverse",
+      "symbol": "SKYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38096/large/SKYA_Logo_200x200.png?1731909478"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe161be4a74ab8fa8706a2d03e67c02318d0a0ad6",
+      "name": "Apetardio",
+      "symbol": "APETARDIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38155/large/apetardio200x200.png?1716669062"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c4b6cd7874edc945797123fce2d9a871818524b",
+      "name": "PARADOX",
+      "symbol": "PARADOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51590/large/IMG_1408.jpeg?1731570502"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9beec80e62aa257ced8b0edd8692f79ee8783777",
+      "name": "This Is My Iguana",
+      "symbol": "TIMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39361/large/200x200.png?1722464115"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x28e29ec91db66733a94ee8e3b86a6199117baf99",
+      "name": "Basedmilio",
+      "symbol": "BASED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37685/large/tokenicon.png?1715224333"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9e53e88dcff56d3062510a745952dec4cefdff9e",
+      "name": "Basic Dog Meme",
+      "symbol": "DOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33749/large/Round_Logo.png?1703245893"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x78a087d713be963bf307b18f2ff8122ef9a63ae9",
+      "name": "BaseSwap",
+      "symbol": "BSWAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31245/large/Baseswap_LogoNew.jpg?1696530070"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x681a09a902d9c7445b3b1ab282c38d60c72f1f09",
+      "name": "AlphaKEK AI",
+      "symbol": "AIKEK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35445/large/alphakek_-_Copy.png?1708620097"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1287a235474e0331c0975e373bdd066444d1bd35",
+      "name": "TAIKAI",
+      "symbol": "TKAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34827/large/TKAI.jpg?1706191900"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x004aa1586011f3454f487eac8d0d5c647d646c69",
+      "name": "DogeVerse",
+      "symbol": "DOGEVERSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38495/large/DogeVerse_200x200.png?1717692269"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcc7ff230365bd730ee4b352cc2492cedac49383e",
+      "name": "High Yield USD  Base ",
+      "symbol": "HYUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33636/large/hyusdlogo.png?1702536133"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x99298c6be0e8ec9e56b7a2be5850abe1fc109d94",
+      "name": "Degen Capital by Virtuals",
+      "symbol": "DEGENC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52246/large/Degen_Capital_DEGENC.png?1732824263"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7d9ce55d54ff3feddb611fc63ff63ec01f26d15f",
+      "name": "Fungi",
+      "symbol": "FUNGI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/36690/large/image_2024-03-29_20-10-19_%282%29_%283%29.png?1712091884"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb8e564b206032bbcda2c3978bc371da52152f72e",
+      "name": "Base Terminal",
+      "symbol": "BASEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50300/large/Base_Terminal_Logo_200x200.png?1727021406"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x891502ba08132653151f822a3a430198f1844115",
+      "name": "Blue Guy",
+      "symbol": "BLUE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39645/large/IMG_20240810_073513_639.png?1723412054"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x82aed68f1deaca2b2aa4c5f27276374228a9f923",
+      "name": "Based Beast Coin",
+      "symbol": "BEAST",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/51121/large/IMG_7914.png?1730164559"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x88faea256f789f8dd50de54f9c807eef24f71b16",
+      "name": "Landwolf",
+      "symbol": "WOLF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36803/large/IMG_8678.jpeg?1712469842"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa0a2e84f6f19c09a095d4a83ac8de5a32d303a13",
+      "name": "Lil Brett",
+      "symbol": "LILB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51813/large/%28100_x_100_px%29.png?1732029374"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
+      "name": "Overnight Finance",
+      "symbol": "OVN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31970/large/OVN.png?1696959174"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xaec9e50e3397f9ddc635c6c429c8c7eca418a143",
+      "name": "Arcana arcUSD",
+      "symbol": "ARCUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38490/large/USDa.png?1717688209"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdbe125089d0752ef458c0685436ace93a7f1f8ca",
+      "name": "Aqualibre",
+      "symbol": "AQLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35026/large/aq1.png?1707147950"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8931ee05ec111325c1700b68e5ef7b887e00661d",
+      "name": "The Big Guy",
+      "symbol": "BGUY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/38875/large/download.png?1719336441"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x474f4cb764df9da079d94052fed39625c147c12c",
+      "name": "Bonsai Token",
+      "symbol": "BONSAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35884/large/Bonsai_BW_Coingecko-200x200.jpg?1710071621"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5cc5e64ab764a0f1e97f23984e20fd4528356a6a",
+      "name": "XRGB",
+      "symbol": "XRGB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35447/large/log2.png?1708620430"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6a4f69da1e2fb2a9b11d1aad60d03163fe567732",
+      "name": "SHOG",
+      "symbol": "SHOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39328/large/149291639.png?1721742924"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x13741c5df9ab03e7aa9fb3bf1f714551dd5a5f8a",
+      "name": "Noggles",
+      "symbol": "NOGS",
+      "decimals": 15,
+      "logoURI": "https://assets.coingecko.com/coins/images/37238/large/nogs.jpeg?1713851209"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc36f19bccd51e3f1163eff07b5edf9d2850acec4",
+      "name": "Brett s Dog",
+      "symbol": "BROGG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37044/large/1000006526.png?1713163132"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1b6a569dd61edce3c383f6d565e2f79ec3a12980",
+      "name": "Young Peezy AKA Pepe",
+      "symbol": "PEEZY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36649/large/PFP_CG_200x200.jpeg?1719953176"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1b5ce2a593a840e3ad3549a34d7b3dec697c114d",
+      "name": "Altcoinist Token",
+      "symbol": "ALTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39455/large/Altcoinist_logo_png_%282%29.png?1733342642"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xaf07d812d1dcec20bf741075bc18660738d226dd",
+      "name": "SNORT",
+      "symbol": "SNORT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37329/large/QZl65V8_%282%29.png?1714028404"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3054e8f8fba3055a42e5f5228a2a4e2ab1326933",
+      "name": "zuzalu",
+      "symbol": "ZUZALU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36909/large/ZUZALA.jpg?1712732086"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4b6f82a4ed0b9e3767f53309b87819a78d041a7f",
+      "name": "Juicybet",
+      "symbol": "JSP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38262/large/JB_token.png?1717686707"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4194f4e29d652656b6dc84f10363482c5ac101b5",
+      "name": "MPAA",
+      "symbol": "MPAA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39521/large/photo_2024-08-03_12-01-50.jpg?1722790299"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd88611a629265c9af294ffdd2e7fa4546612273e",
+      "name": "Metapro",
+      "symbol": "MPRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35128/large/mpro.jpeg?1707440015"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x22a2488fe295047ba13bd8cccdbc8361dbd8cf7c",
+      "name": "Sonne Finance",
+      "symbol": "SONNE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27540/large/Token1.png?1696526577"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf04d220b8136e2d3d4be08081dbb565c3c302ffd",
+      "name": "Freya by Virtuals",
+      "symbol": "FREYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52325/large/FREYA_%281%29.png?1733079799"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa8c2e771288585229eea8dbe072edfa7bcb388bb",
+      "name": "Apollo Name Service",
+      "symbol": "ANS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40040/large/star_logo8305.png?1725392202"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6c7ebb64e258f5712eeec83ceaf41c3dcbb534b1",
+      "name": "Vainguard",
+      "symbol": "VAIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52365/large/Vain_CG.png?1733210740"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd85eff20288ca72ea9eecffb428f89ee5066ca5c",
+      "name": "ISKRA Token",
+      "symbol": "ISK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27428/large/ISKRA_logo.png?1696526469"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfd008f937b4d73eeb00cf74ce90c392be5f07f96",
+      "name": "MOON INU",
+      "symbol": "MOON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36493/large/moon-200.png?1711612557"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x65e570b560027f493f2b1907e8e8e3b9546053bd",
+      "name": "Tyler",
+      "symbol": "TYLER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50734/large/photo_2024-09-23_09-14-08.jpg?1728916087"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066",
+      "name": "Rug World Assets",
+      "symbol": "RWA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37119/large/0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066.jpg?1713356569"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xebb78043e29f4af24e6266a7d142f5a08443969e",
+      "name": "Derp",
+      "symbol": "DERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33069/large/derpdex_%281%29.png?1700793428"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6a27cd26a373530835b9fe7ac472b3e080070f64",
+      "name": "BlockAI",
+      "symbol": "BAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39638/large/logo-200x200-transparent-bg.png?1723278224"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
+      "name": "Lava Network",
+      "symbol": "LAVA",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37354/large/lava_logo.png?1714098423"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf8a99f2bf2ce5bb6ce4aafcf070d8723bc904aa2",
+      "name": "Chinese Brett",
+      "symbol": "CHRETT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38541/large/GNQP9A7WwAIcolJ_%282%29.png?1717926712"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb56d0839998fd79efcd15c27cf966250aa58d6d3",
+      "name": "Based USA",
+      "symbol": "USA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37981/large/BASE_USA_200px.png?1716203776"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb488fcb23333e7baa28d1dfd7b69a5d3a8bfeb3a",
+      "name": "Terminal",
+      "symbol": "TERMINAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51477/large/terminalLogo.png?1731403786"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x58d75a1c4477914f9a98a8708feaed1dbe40b8a3",
+      "name": "AthenaDAO",
+      "symbol": "ATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33349/large/ATH_Token_Black_Logo.png?1701981879"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5b5dee44552546ecea05edea01dcd7be7aa6144a",
+      "name": "TN100x",
+      "symbol": "TN100X",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35729/large/patch-transparent-blue.png?1729878068"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xed899bfdb28c8ad65307fa40f4acab113ae2e14c",
+      "name": "Roost",
+      "symbol": "ROOST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36458/large/roost.jpeg?1711493580"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd652c5425aea2afd5fb142e120fecf79e18fafc3",
+      "name": "PoolTogether",
+      "symbol": "POOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14003/large/PoolTogether.png?1696513732"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf3708859c178709d5319ad5405bc81511b72b9e9",
+      "name": "Aethernet",
+      "symbol": "AETHER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51065/large/Aether_Farcaster_frame.png?1729943869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x92fb1b7d9730b2f1bd4e2e91368c1eb6fdd2a009",
+      "name": "Jogeco Dog",
+      "symbol": "JOGECO",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37579/large/photo_2024-05-04_04.13.39_%282%29.png?1714964255"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x511ef9ad5e645e533d15df605b4628e3d0d0ff53",
+      "name": "Velvet Unicorn by Virtuals",
+      "symbol": "VU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52175/large/velvet_unicorn.jpg?1732684869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3fbde9864362ce4abb244ebef2ef0482aba8ea39",
+      "name": "Baklava",
+      "symbol": "BAVA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23780/large/200x200_BAVA_LOGO_%282%29.png?1696522980"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8c81b4c816d66d36c4bf348bdec01dbcbc70e987",
+      "name": "Briun Armstrung",
+      "symbol": "BRIUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36183/large/200x200.png?1710758416"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x92dc4ab92eb16e781559e612f349916988013d5a",
+      "name": "Agent Zero",
+      "symbol": "WSB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51310/large/photo_2024-11-03_07-33-29.jpg?1730643955"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7f62ac1e974d65fab4a81821ca6af659a5f46298",
+      "name": "Ethlas",
+      "symbol": "ELS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30331/large/ELS_Logo_200x200.png?1696529232"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x31b28012f61fc3600e1c076bafc9fd997fb2da90",
+      "name": "Mrs Miggles",
+      "symbol": "MRSMIGGLES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39282/large/token.png?1722045136"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb34457736aa191ff423f84f5d669f68b231e6c4e",
+      "name": "AGENT DOGE by Virtuals",
+      "symbol": "AIDOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52187/large/Screenshot_2024-11-23_at_4.09.40%E2%80%AFPM.png?1732723139"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd07379a755a8f11b57610154861d694b2a0f615a",
+      "name": "Base",
+      "symbol": "BASE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31199/large/59302ba8-022e-45a4-8d00-e29fe2ee768c-removebg-preview.png?1696530026"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x38d513ec43dda20f323f26c7bef74c5cf80b6477",
+      "name": "Carlo",
+      "symbol": "CARLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37553/large/CARLO_200x200.png?1714752141"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x41a22eb30df65d6ab0ce0b4cfe8f4e0eb306d471",
+      "name": "BaseBearCute",
+      "symbol": "BBQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40006/large/logo.jpg?1725221317"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x78b3c724a2f663d11373c4a1978689271895256f",
+      "name": "Token Name Service",
+      "symbol": "TKN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39886/large/Tri-gradient_Group_5135_2x.png?1724682287"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb755506531786c8ac63b756bab1ac387bacb0c04",
+      "name": "ZARP Stablecoin",
+      "symbol": "ZARP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27333/large/zarp_coin.png?1696526381"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x599f07567656e6961e20fa6a90685d393808c192",
+      "name": "Department Of Government Efficiency",
+      "symbol": "DOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51896/large/coingecko_%282%29.png?1732124666"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5d9c2457a10d455e0ad8e28e40cc28eacf27a06a",
+      "name": "GM Everyday",
+      "symbol": "GM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52139/large/sRavZnte_.png?1732642259"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb0e87796380172f911214208df966a84cceaaf82",
+      "name": "DOM",
+      "symbol": "DOM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51723/large/463fac78-dcc9-49cf-879f-b0b1af658295.png?1731903839"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6e2c81b6c2c0e02360f00a0da694e489acb0b05e",
+      "name": "Reflect",
+      "symbol": "RFL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39189/large/Reflect.png?1720855854"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac27fa800955849d6d17cc8952ba9dd6eaa66187",
+      "name": "UnlockProtocolToken",
+      "symbol": "UP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51457/large/up2.png?1731318758"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x42069babe14fb1802c5cb0f50bb9d2ad6fef55e2",
+      "name": "Frok ai",
+      "symbol": "FROK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36028/large/Frok_logo.png?1710389187"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7e72d6410803c40e73806f2a72e3eade5d075cc0",
+      "name": "Marvin On Base",
+      "symbol": "MOB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38960/large/Marvin_200.png?1719692064"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbeb0fd48c2ba0f1aacad2814605f09e08a96b94e",
+      "name": "GME  Base ",
+      "symbol": "GME",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37229/large/gamestop.jpeg?1713780481"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0028e1e60167b48a938b785aa5292917e7eaca8b",
+      "name": "Coinye West",
+      "symbol": "COINYE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36403/large/Coinye_West.png?1711369153"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x524d524b4c9366be706d3a90dcf70076ca037ae3",
+      "name": "RMRK",
+      "symbol": "RMRK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18656/large/download_%281%29_%281%29.png?1696518126"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8853f0c059c27527d33d02378e5e4f6d5afb574a",
+      "name": "AI INU",
+      "symbol": "AIINU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36902/large/aiinu.png?1712699681"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x25e1c298f100d7c600e9e44d46788c1ebbd4f69b",
+      "name": "Pike Finance",
+      "symbol": "P",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50771/large/image.png?1729132574"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x474cb5b5087e13ea006e13702e330c93c825ab5d",
+      "name": "Make Fun",
+      "symbol": "MF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51437/large/logo-128.png?1731224206"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x881ed0fcef78120a135ec6cc66cef2779fe95bba",
+      "name": "DogeGF",
+      "symbol": "DOGEGF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18651/large/dogegf_logo_200x200.png?1712082872"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbf4db8b7a679f89ef38125d5f84dd1446af2ea3b",
+      "name": "Le Bleu Elefant",
+      "symbol": "BLEU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37811/large/b.png?1715597915"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x72e72193ea14ac3b469f881989d18a2ba021b4c6",
+      "name": "Dollar",
+      "symbol": "DOLLAR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39312/large/pfp_200x200.png?1721706165"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x45d9c101a3870ca5024582fd788f4e1e8f7971c3",
+      "name": "MASQ",
+      "symbol": "MASQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13699/large/masq.png?1696513446"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+      "name": "Equalizer  BASE ",
+      "symbol": "SCALE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32221/large/SCALE_icon_200x200.png?1696835640"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f019931375454fe4ee353427eb94e2e0c9e0a8c",
+      "name": "KOMPETE",
+      "symbol": "KOMPETE",
+      "decimals": 10,
+      "logoURI": "https://assets.coingecko.com/coins/images/24298/large/200x200.png?1732826917"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcba6fabf7df8ada1995d1f57acaf520198289ca9",
+      "name": "BeromesButt",
+      "symbol": "BUTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52419/large/BUTT_Logo.jpg?1733326535"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xda761a290e01c69325d12d82ac402e5a73d62e81",
+      "name": "Base Pro Shops",
+      "symbol": "BPS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36855/large/BPS_2.png?1712634757"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7480527815ccae421400da01e052b120cc4255e9",
+      "name": "Workie",
+      "symbol": "WORKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38774/large/Pfp2_%281%29.png?1724903016"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8a638ea79f71f3b91bdc96bbdf9fb27c93013d60",
+      "name": "Baby Tiger",
+      "symbol": "BBT",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/51933/large/BBT_%282%29_%281%29.png?1732205350"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x80b3455e1db60b4cba46aba12e8b1e256dd64979",
+      "name": "Blue Footed Booby",
+      "symbol": "BOOBY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38859/large/Pfp2200x200.png?1719952590"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x87c211144b1d9bdaa5a791b8099ea4123dc31d21",
+      "name": "BlockChainPeople",
+      "symbol": "BCP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38085/large/200x200.png?1716477512"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0a14ef61afb32e5ca672e021784f71705ac14908",
+      "name": "NULL MATRIX",
+      "symbol": "NULL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51086/large/dark.png?1732460149"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf95e1c0a67492720ca22842122fe7fa63d5519e5",
+      "name": "Lunarlens",
+      "symbol": "LUNARLENS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39304/large/%E6%9C%88%E4%BA%AE%E5%B8%8164.png?1721633565"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc73dc7ae7a4fa40517aafa941ae1ee436b91a12c",
+      "name": "Buz Economy",
+      "symbol": "BUZ",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/39793/large/buz-economy-logo-dark.png?1724117134"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1f1aa4d239002bb818536c95e9b762a1fc8484c1",
+      "name": "Precipitate ai",
+      "symbol": "RAIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32405/large/RAIN_200-removebg-preview.png?1711371589"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbe5614875952b1683cb0a2c20e6509be46d353a4",
+      "name": "Baby Brett on Base",
+      "symbol": "BBRETT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/38887/large/200x200.png?1719380024"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6112b8714221bbd96ae0a0032a683e38b475d06c",
+      "name": "WAI Combinator by Virtuals",
+      "symbol": "WAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52181/large/wai.jpg?1732689732"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4d58608eff50b691a3b76189af2a7a123df1e9ba",
+      "name": "Boysclubbase",
+      "symbol": "BOYS",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37825/large/IMG_20240507_221140_398.jpg?1715668247"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfafb7581a65a1f554616bf780fc8a8acd2ab8c9b",
+      "name": "Squid Game",
+      "symbol": "SQUID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20506/large/squid.png?1696519912"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7ed613ab8b2b4c6a781ddc97ea98a666c6437511",
+      "name": "All Your Base",
+      "symbol": "AYB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35777/large/AYB-Coingecko.png?1718634946"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x49c86046903807d0a3193a221c1a3e1b1b6c9ba3",
+      "name": "CYI by Virtuals",
+      "symbol": "CYI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52125/large/Cryptoyieldinfo.jpg?1732611368"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6b9bb36519538e0c073894e964e90172e1c0b41f",
+      "name": "WEWECOIN",
+      "symbol": "WEWE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39135/large/wewe_logo.png?1720857800"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1754e5aadce9567a95f545b146a616ce34eead53",
+      "name": "Bonke  Base ",
+      "symbol": "BONKE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/38448/large/bonke200.png?1717556675"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa334884bf6b0a066d553d19e507315e839409e62",
+      "name": "Ethos Reserve Note",
+      "symbol": "ERN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29744/large/ERN200x200.png?1696528676"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7cf7132ede0ca592a236b6198a681bb7b42dd5ae",
+      "name": "BOLT on Base",
+      "symbol": "BOLT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38449/large/wwwww.png?1717557162"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xba71cb8ef2d59de7399745793657838829e0b147",
+      "name": "Siamese",
+      "symbol": "SIAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36489/large/transparant-200x200.png?1728005931"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x39d24405ca717ef841e4a782da97284cf2dc7628",
+      "name": "Agent Zeek by Virtuals",
+      "symbol": "ZEEK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52331/large/dwWGlf18_400x400.jpg?1733086398"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4498cd8ba045e00673402353f5a4347562707e7d",
+      "name": "r DataDAO",
+      "symbol": "RDAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39174/large/Q7oVa2cC_400x400.png?1720799391"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6b82297c6f1f9c3b1f501450d2ee7c37667ab70d",
+      "name": "goatwifhat",
+      "symbol": "GIF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37776/large/GIF_logo_200x200.png?1715581191"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc1ffaef4e7d553bbaf13926e258a1a555a363a07",
+      "name": "Human Intelligence Machin",
+      "symbol": "HIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37898/large/Human_Intelligence_Machine.png?1715848133"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x55027a5b06f4340cc4c82dcc74c90ca93dcb173e",
+      "name": "Tadpole",
+      "symbol": "TAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39783/large/IMG_7927.PNG?1724101375"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xea1d649ddc8e2a6e6ee40b89b2997518476cafa5",
+      "name": "MOBY",
+      "symbol": "MOBY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38988/large/moby-icon_%281%29.png?1719807217"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x29e39327b5b1e500b87fc0fcae3856cd8f96ed2a",
+      "name": "Bark Ruffalo by Virtuals",
+      "symbol": "PAWSY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52205/large/00_Avatar_200x200.png?1732736729"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbe58fda3bcf03b6bbc821d1f0e6b764c86709227",
+      "name": "Vabble",
+      "symbol": "VFX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52126/large/vabble.jpg?1732611797"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x645c7aa841087e2e7f741c749ab27422ff5bba8e",
+      "name": "Iona by Virtuals",
+      "symbol": "IONA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52166/large/iona.jpg?1732682259"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbe35071605277d8be5a52c84a66ab1bc855a758d",
+      "name": "Be For FWX",
+      "symbol": "B4FWX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38663/large/B4FWX_Logo-02_200x200.png?1718256956"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe3cf8dbcbdc9b220ddead0bd6342e245daff934d",
+      "name": "Piggy",
+      "symbol": "PIGGY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52128/large/image_%288%29.png?1732740724"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf1143f3a8d76f1ca740d29d5671d365f66c44ed1",
+      "name": "Wrapped Bitcoin  Universal ",
+      "symbol": "UBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50252/large/UA-BTC_1.png?1726721793"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9a6d24c02ec35ad970287ee8296d4d6552a31dbe",
+      "name": "OPEN Ticketing Ecosystem",
+      "symbol": "OPN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36612/large/TOKEN.png?1711975511"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xde7a416ac821c77478340eebaa21b68297025ef3",
+      "name": "Beni",
+      "symbol": "BENI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36691/large/Logo_Image_Beni_Uodate.png?1732385556"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc9b6ef062fab19d3f1eabc36b1f2e852af1acd18",
+      "name": "Brett s cat",
+      "symbol": "BALT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38428/large/IMG_4717.PNG?1717627270"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd7d919ea0c33a97ad6e7bd4f510498e2ec98cb78",
+      "name": "Penjamin Blinkerton",
+      "symbol": "PEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37269/large/PEN_COIN_LOGO.png?1713887481"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd1e6f3f0a7f40d5412f7471875879381441bf722",
+      "name": "ARI",
+      "symbol": "ARI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51167/large/ARI_TOKEN_WHITE_2_%281%29.png?1730267906"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f4e4221ba88d4e9bb76ecfb91d7c5ce08d7d5b9",
+      "name": "FU Money",
+      "symbol": "FU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38629/large/FU_logo_black.png?1718170125"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2075f6e2147d4ac26036c9b4084f8e28b324397d",
+      "name": "BaseCTO",
+      "symbol": "CTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50716/large/IMG_1480.jpeg?1728792869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8a9430e92153c026092544444cbb38077e6688d1",
+      "name": "KeptChain",
+      "symbol": "KEPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38406/large/Kept_200_200.png?1717463539"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8b52f46a52d86c131222ee14167da6a847bdb84a",
+      "name": "Etho Protocol",
+      "symbol": "ETHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5194/large/IconOnly_Transparent_NoBuffer_resized.png?1713297055"
     },
     {
       "chainId": 8453,
@@ -4004,12 +3764,252 @@
     },
     {
       "chainId": 8453,
+      "address": "0x20b048fa035d5763685d695e66adf62c5d9f5055",
+      "name": "Biochar",
+      "symbol": "CHAR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38094/large/char_logo_toucan.png?1716488453"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x75e6b648c91d222b2f6318e8ceeed4b691d5323f",
+      "name": "AnonFi",
+      "symbol": "ANON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50446/large/IMG_20240928_164632_277.png?1727771357"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc2fe011c3885277c7f0e7ffd45ff90cadc8ecd12",
+      "name": "Poncho",
+      "symbol": "PONCHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36160/large/ponchologo.PNG?1710744293"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x22222bd682745cf032006394750739684e45a5f8",
+      "name": "Jasse Polluk",
+      "symbol": "POLLUK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38510/large/Jasse_Polluk.png?1717754036"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa067436db77ab18b1a315095e4b816791609897c",
+      "name": "WASSIE",
+      "symbol": "WASSIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30144/large/logo-coingecko.png?1696529065"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe31ee12bdfdd0573d634124611e85338e2cbf0cf",
+      "name": "Anzen Staked USDz",
+      "symbol": "SUSDZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38040/large/susdz-symbol-200x200.png?1716334492"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbe3111856e4aca828593274ea6872f27968c8dd6",
+      "name": "Krav",
+      "symbol": "KRAV",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/31243/large/Screen_Shot_2023-08-05_at_2.13.21_PM.png?1696530069"
+    },
+    {
+      "chainId": 8453,
       "address": "0x41ed891897117450adbd710006855b12f98cb86b",
       "name": "LazyCat",
       "symbol": "LAZYCAT",
       "decimals": 9,
       "logoURI": "https://assets.coingecko.com/coins/images/40029/large/LAZYCAT.jpg?1725360523"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfea9dcdc9e23a9068bf557ad5b186675c61d33ea",
+      "name": "Based Shiba Inu",
+      "symbol": "BSHIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36092/large/logocg.png?1710478223"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf578ad8809f13dabf921bdd3fcfbe194d0ab5628",
+      "name": "Virtue Poker Points",
+      "symbol": "VPP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3386/large/vp-logo-200x200.png?1696504084"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x589864a9892b1a736ae70a91824ab4dc591fd8cd",
+      "name": "Gibape",
+      "symbol": "GIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37691/large/gib_ape_logo.jpeg?1715650189"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x357655df177fb0229dc8aca977114a420bf81799",
+      "name": "Royal Finance Coin",
+      "symbol": "RFC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39205/large/1718077177995-c26be60cfd1ba40772b5ac48b95ab19b.png?1721067386"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xed1978d01d4a8a9d6a43ac79403d5b8dfbed739b",
+      "name": "Sandwich Cat",
+      "symbol": "SACA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36876/large/200x200_%281%29.png?1712646447"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdaf3c78f165d26f821d3d39d6598a96e962b1508",
+      "name": "The Css God by Virtuals",
+      "symbol": "WEBSIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52173/large/the_css_god.jpg?1732684452"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8216e8143902a8fe0b676006bc25eb23829c123d",
+      "name": "Wow",
+      "symbol": "WOW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51527/large/23bafybeialew5mz6o2d6abynkd7kafunbgcgxcatyjdr5s2mgr4ae4zeltwe_%281%29.jpg?1731497334"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x653a143b8d15c565c6623d1f168cfbec1056d872",
+      "name": "kurbi",
+      "symbol": "KURBI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37466/large/photo_2024-04-23_11-40-15.png?1714455133"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3636a7734b669ce352e97780df361ce1f809c58c",
+      "name": "ROCKY",
+      "symbol": "ROCKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37465/large/rocky3.png?1714454996"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x76e7447bafa3f0acafc9692629b1d1bc937ca15d",
+      "name": "Pola On Base",
+      "symbol": "POLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37314/large/pola.jpg?1713971028"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1c9f5e5b5c172955660c11ec0df65b68ecb5fb69",
+      "name": "Help",
+      "symbol": "HELP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51165/large/help.png?1731654094"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x31ea904a7eca45122890deb8da3473a2081bc9d1",
+      "name": "Bonsai3",
+      "symbol": "SEED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33162/large/logo-bonsai3200x200.png?1700830408"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7f65323e468939073ef3b5287c73f13951b0ff5b",
+      "name": "Blue",
+      "symbol": "BLUE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51053/large/Blue200p.png?1729873273"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1db0fc8933f545648b54a9ee4326209a9a259643",
+      "name": "Zunami Governance Token",
+      "symbol": "ZUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38298/large/ZUN_200x200.png?1717194404"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5e432eecd01c12ee7071ee9219c2477a347da192",
+      "name": "ARQx AI",
+      "symbol": "ARQX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37808/large/ARQX_GC.png?1715591796"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb3a9bd4861454ba94931ebff410c3d828525dce2",
+      "name": "WoofWork io",
+      "symbol": "WOOF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28903/large/WWlogoTransparent_200x200.png?1696527879"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf4435cc8b478d54313f04c956882be3d9acf9f6f",
+      "name": "Lucha",
+      "symbol": "LUCHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22794/large/lucha.png?1696522097"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8319767a7b602f88e376368dca1b92d38869b9b4",
+      "name": "Based Peaches",
+      "symbol": "PEACH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36762/large/Peaches-New-Logo-200x200.png?1719742607"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3f14920c99beb920afa163031c4e47a3e03b3e4a",
+      "name": " send",
+      "symbol": "SEND",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/30847/large/avatar.png?1716654949"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0002bcdaf53f4889bf2f43a3252d7c03fe1b80bc",
+      "name": "GorplesCoin",
+      "symbol": "GORPLES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38681/large/Round_Avatar.png?1720520435"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x97b959385dfdcaf252223838746beb232ac601aa",
+      "name": "AI Market Compass",
+      "symbol": "AIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39363/large/AIM_%282%29.jpg?1723415448"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe4fcf2d991505089bbb36275570757c1f9800cb0",
+      "name": "Purrcoin",
+      "symbol": "PURR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37429/large/logo.png?1714379357"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xecc68d0451e20292406967fe7c04280e5238ac7d",
+      "name": "Axelar Bridged Frax Ether",
+      "symbol": "AXLFRXETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38976/large/Screen_Shot_2024-06-18_at_12.55.54_PM_2.png?1719714886"
     }
   ],
-  "timestamp": "2024-12-06T16:14:59.808Z"
+  "timestamp": "2024-12-10T17:05:15.603Z"
 }

--- a/src/scripts/baseChainTopTokens.js
+++ b/src/scripts/baseChainTopTokens.js
@@ -5,76 +5,224 @@ import path from 'path'
 
 const TOP_TOKENS_COUNT = 500 // Number of top tokens to display
 
-const TOKEN_LIST_URL = 'https://tokens.coingecko.com/base/all.json'
-const COINGECKO_API_URL = 'https://pro-api.coingecko.com/api/v3/coins/base/contract'
 const VS_CURRENCY = 'usd' // Base currency for volume data
 
-const TOKEN_LIST_INFO = {
-  name: 'CoinGecko',
-  logoURI:
-    'https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png',
-  keywords: ['defi'],
-  version: {
-    major: 0,
-    minor: 0,
-    patch: 0,
-  },
+let COINGECKO_IDS_MAP = {}
+
+const COINGECKO_CHAINS = {
+  1: 'ethereum',
+  100: 'xdai',
+  8453: 'base',
+  42161: 'arbitrum-one',
 }
+const DISPLAY_CHAIN_NAMES = {
+  1: 'Ethereum',
+  100: 'Gnosis chain',
+  8453: 'Base',
+  42161: 'Arbitrum one',
+}
+const COINGECKO_CHAINS_NAMES = Object.values(COINGECKO_CHAINS)
 
 const COINGECKO_API_KEY = process.env.COINGECKO_API_KEY
 assert(COINGECKO_API_KEY, 'COINGECKO_API_KEY env is required')
 
-async function getTokenList() {
-  const response = await fetch(TOKEN_LIST_URL)
+function getCoingeckoApiUrl(chain) {
+  return `https://pro-api.coingecko.com/api/v3/coins/${DISPLAY_CHAIN_NAMES[chain]}/contract`
+}
+
+function getTokenListUrl(chain) {
+  return `https://tokens.coingecko.com/${COINGECKO_CHAINS[chain]}/all.json`
+}
+
+function getEmptyList(chain) {
+  return {
+    name: `Coingecko top ${TOP_TOKENS_COUNT} on ${COINGECKO_CHAINS[chain]}`,
+    logoURI:
+      'https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png',
+    keywords: ['defi'],
+    version: {
+      major: 0,
+      minor: 0,
+      patch: 0,
+    },
+  }
+}
+
+async function getTokenList(chain) {
+  const tokenListUrl = getTokenListUrl(chain)
+  const response = await fetch(tokenListUrl)
   const data = await response.json()
   return data.tokens
 }
 
-async function getTokenVolume(token) {
+async function getTokenVolume(token, chain) {
   try {
     const headers = COINGECKO_API_KEY ? { 'X-Cg-Pro-Api-Key': COINGECKO_API_KEY } : {}
 
-    const url = `${COINGECKO_API_URL}/${token.address}?localization=false`
+    const url = `${getCoingeckoApiUrl(chain)}/${token.address}?localization=false`
     const response = await fetch(url, { headers })
     const data = await response.json()
 
-    // console.log('[getTokenVolume] url:', url)
-    // console.log('[getTokenVolume] token:', token.symbol)
-    // console.log(`[getTokenVolume] ${token.symbol} $${data.market_data.total_volume[VS_CURRENCY]}`)
+    // console.log(`[getTokenVolume] url: ${url}, chain: ${chain}`)
+    // console.log(`[getTokenVolume] token: ${token.symbol}, chain: ${chain}`)
+    // console.log(`[getTokenVolume] ${token.symbol} $${data.market_data.total_volume[VS_CURRENCY]}, chain: ${chain}`)
     return data.market_data.total_volume[VS_CURRENCY] || 0
   } catch (error) {
-    console.error(`Error fetching volume for token ${token.name}:`, error)
+    console.error(`Error fetching volume for token ${token.name} on chain ${chain}:`, error)
     return 0
   }
 }
 
-async function main() {
+async function getCoingeckoTokenIds() {
   try {
+    const headers = COINGECKO_API_KEY ? { 'X-Cg-Pro-Api-Key': COINGECKO_API_KEY } : {}
+
+    const url = `https://pro-api.coingecko.com/api/v3/coins/list?include_platform=true&status=active`
+    const response = await fetch(url, { headers })
+    return await response.json()
+  } catch (error) {
+    console.error(`Error fetching Coingecko's coin list`, error)
+    return []
+  }
+}
+
+/**
+ * Get a map of contract addresses to coingecko coin id.
+ *
+ * Result is stored in a local file since this shouldn't change often.
+ *
+ * Takes in one parameter forceUpdate, to ignore local content - if any.
+ */
+async function getCoingeckoTokenIdsMap(forceUpdate) {
+  const localFilePath = 'build/coingeckoTokenIdsMap.json'
+  let tokenIdsMap = COINGECKO_CHAINS_NAMES.reduce((acc, name) => ({ ...acc, [name]: {} }), {})
+
+  // Check if local file exists and forceUpdate is false
+  if (!forceUpdate && fs.existsSync(localFilePath)) {
+    try {
+      // Read the local file
+      const data = fs.readFileSync(localFilePath)
+      tokenIdsMap = JSON.parse(data)
+    } catch (error) {
+      console.error(`Error reading local file: ${error}`)
+    }
+  } else {
+    // Fetch the token IDs from Coingecko API
+    try {
+      const tokenIds = await getCoingeckoTokenIds()
+
+      tokenIds.forEach((token) => {
+        COINGECKO_CHAINS_NAMES.forEach((chain) => {
+          const address = token.platforms[chain]
+          if (address) {
+            tokenIdsMap[chain][address] = token.id
+            // reverse mapping
+            tokenIdsMap[chain][token.id] = address
+          }
+        })
+      })
+
+      // Save the fetched data to the local file
+      fs.writeFileSync(localFilePath, JSON.stringify(tokenIdsMap))
+    } catch (error) {
+      console.error(`Error fetching Coingecko token IDs: ${error}`)
+    }
+  }
+
+  return tokenIdsMap
+}
+
+async function getCoingeckoMarket(chainId, tokens) {
+  const coingeckoIdsForChain = COINGECKO_IDS_MAP[COINGECKO_CHAINS[chainId]]
+  const ids = tokens.reduce((acc, token) => {
+    const coingeckoId = coingeckoIdsForChain[token.address]
+    if (coingeckoId) {
+      acc += `${coingeckoId},`
+    }
+    return acc
+  }, '')
+
+  try {
+    const headers = COINGECKO_API_KEY ? { 'X-Cg-Pro-Api-Key': COINGECKO_API_KEY } : {}
+
+    const url = `https://pro-api.coingecko.com/api/v3/coins/markets?vs_currency=${VS_CURRENCY}&per_page=250&ids=${ids}`
+    const response = await fetch(url, { headers })
+    return await response.json()
+  } catch (error) {
+    console.error(`Error fetching Coingecko's coin list`, error)
+    return []
+  }
+}
+
+async function getTokenVolumes(chainId, tokens) {
+  // Max items per query is 250
+  const chunkSize = 250
+  const chunkVolumes = []
+
+  // Chunk tokens for each individual query
+  for (let i = 0; i < tokens.length; i += chunkSize) {
+    const chunk = tokens.slice(i, i + chunkSize)
+    chunkVolumes.push({ tokens: chunk, volume: getCoingeckoMarket(chainId, chunk) })
+  }
+
+  const ids = COINGECKO_IDS_MAP[COINGECKO_CHAINS[chainId]]
+
+  const volumes = await Promise.all(
+    chunkVolumes.map(async ({ tokens, volume }) => {
+      // Await query in parallel
+      const volumeData = await volume
+      // Create a map with volumes since the ordering is lost
+      const volumeMap = volumeData.reduce((acc, cur) => {
+        if (cur.total_volume && ids[cur.id]) {
+          acc[ids[cur.id]] = cur.total_volume || 0
+        }
+        return acc
+      }, {})
+
+      return tokens.reduce((acc, token) => {
+        if (volumeMap[token.address]) {
+          acc.push({ token, volume: volumeMap[token.address] })
+        }
+        return acc
+      }, [])
+    }),
+  )
+
+  // Flatten and sort volumes by volume in descending order
+  return volumes.flat().sort((a, b) => b.volume - a.volume)
+}
+
+async function fetchAndProcessTokens(chainId) {
+  try {
+    // Get coingecko ids
+    COINGECKO_IDS_MAP = await getCoingeckoTokenIdsMap()
+
     // Fetch tokens
-    const tokens = await getTokenList()
+    const tokens = await getTokenList(chainId)
 
     // Fetch volume for each token
-    const tokenVolumes = await Promise.all(
-      tokens.map(async (token) => ({
-        token,
-        volume: await getTokenVolume(token),
-      })),
-    )
+    // const tokenVolumes = await Promise.all(
+    //   tokens.map(async (token) => ({
+    //     token,
+    //     volume: await getTokenVolume(token, chainId),
+    //   })),
+    // )
 
     // Sort by volume and pick top tokens
-    const topTokens = tokenVolumes.sort((a, b) => b.volume - a.volume).slice(0, TOP_TOKENS_COUNT)
+    // const topTokens = tokenVolumes.sort((a, b) => b.volume - a.volume).slice(0, TOP_TOKENS_COUNT)
+    const topTokens = (await getTokenVolumes(chainId, tokens)).slice(0, TOP_TOKENS_COUNT)
 
     // Print top tokens
     let position = 1
-    console.log(`🥇 Top ${TOP_TOKENS_COUNT} tokens`)
+    console.log(`🥇 Top ${TOP_TOKENS_COUNT} tokens on chain ${chainId}`)
     for (const { token, volume } of topTokens) {
       console.log(`\t-${position.toString().padStart(3, '0')}) ${token.name} (${token.symbol}): $${volume}`)
       position++
     }
 
-    const tokenListPath = path.join('src/public/CoinGecko.8453.json')
+    const tokenListPath = path.join(`src/public/CoinGecko.${chainId}.json`)
 
-    const tokenList = getLocalTokenList(tokenListPath, TOKEN_LIST_INFO)
+    const tokenList = getLocalTokenList(tokenListPath, getEmptyList(chainId))
 
     // Replace tokens
     tokenList.tokens = topTokens.map(({ token }) => token)
@@ -82,8 +230,14 @@ async function main() {
     // Write token file
     saveLocalTokenList(tokenListPath, tokenList)
   } catch (error) {
-    console.error('Error fetching data:', error)
+    console.error(`Error fetching data for chain ${chainId}:`, error)
   }
+}
+
+async function main() {
+  // Fetch tokens for all chains
+  Object.keys(COINGECKO_CHAINS).forEach((chain) => fetchAndProcessTokens(chain))
+  // fetchAndProcessTokens(100)
 }
 
 /**

--- a/src/scripts/coingeckoTop500.js
+++ b/src/scripts/coingeckoTop500.js
@@ -7,7 +7,8 @@ const TOP_TOKENS_COUNT = 500 // Number of top tokens to display
 
 const VS_CURRENCY = 'usd' // Base currency for volume data
 
-let COINGECKO_IDS_MAP = {}
+const COINGECKO_API_KEY = process.env.COINGECKO_API_KEY
+assert(COINGECKO_API_KEY, 'COINGECKO_API_KEY env is required')
 
 const COINGECKO_CHAINS = {
   1: 'ethereum',
@@ -15,16 +16,16 @@ const COINGECKO_CHAINS = {
   8453: 'base',
   42161: 'arbitrum-one',
 }
+
 const DISPLAY_CHAIN_NAMES = {
   1: 'Ethereum',
   100: 'Gnosis chain',
   8453: 'Base',
   42161: 'Arbitrum one',
 }
-const COINGECKO_CHAINS_NAMES = Object.values(COINGECKO_CHAINS)
 
-const COINGECKO_API_KEY = process.env.COINGECKO_API_KEY
-assert(COINGECKO_API_KEY, 'COINGECKO_API_KEY env is required')
+const COINGECKO_CHAINS_NAMES = Object.values(COINGECKO_CHAINS)
+let COINGECKO_IDS_MAP = {}
 
 function getCoingeckoApiUrl(chain) {
   return `https://pro-api.coingecko.com/api/v3/coins/${COINGECKO_CHAINS[chain]}/contract`
@@ -34,102 +35,67 @@ function getTokenListUrl(chain) {
   return `https://tokens.coingecko.com/${COINGECKO_CHAINS[chain]}/all.json`
 }
 
-function getListName(chain, count) {
-  return `Coingecko top ${count} on ${DISPLAY_CHAIN_NAMES[chain]}`
+async function fetchWithApiKey(url) {
+  const headers = COINGECKO_API_KEY ? { 'X-Cg-Pro-Api-Key': COINGECKO_API_KEY } : {}
+  const response = await fetch(url, { headers })
+  return response.json()
 }
 
 function getEmptyList() {
   return {
-    name: `Coingecko`,
+    name: 'Coingecko',
     logoURI:
       'https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png',
     keywords: ['defi'],
-    version: {
-      major: 0,
-      minor: 0,
-      patch: 0,
-    },
+    version: { major: 0, minor: 0, patch: 0 },
   }
+}
+
+function getListName(chain, count) {
+  return `Coingecko top ${count} on ${DISPLAY_CHAIN_NAMES[chain]}`
 }
 
 async function getTokenList(chain) {
-  const tokenListUrl = getTokenListUrl(chain)
-  const response = await fetch(tokenListUrl)
-  const data = await response.json()
+  const data = await fetchWithApiKey(getTokenListUrl(chain))
   return data.tokens
-}
-
-async function getTokenVolume(token, chain) {
-  try {
-    const headers = COINGECKO_API_KEY ? { 'X-Cg-Pro-Api-Key': COINGECKO_API_KEY } : {}
-
-    const url = `${getCoingeckoApiUrl(chain)}/${token.address}?localization=false`
-    const response = await fetch(url, { headers })
-    const data = await response.json()
-
-    return data.market_data.total_volume[VS_CURRENCY] || 0
-  } catch (error) {
-    console.error(`Error fetching volume for token ${token.name} on chain ${chain}:`, error)
-    return 0
-  }
 }
 
 async function getCoingeckoTokenIds() {
   try {
-    const headers = COINGECKO_API_KEY ? { 'X-Cg-Pro-Api-Key': COINGECKO_API_KEY } : {}
-
-    const url = `https://pro-api.coingecko.com/api/v3/coins/list?include_platform=true&status=active`
-    const response = await fetch(url, { headers })
-    return await response.json()
+    return await fetchWithApiKey('https://pro-api.coingecko.com/api/v3/coins/list?include_platform=true&status=active')
   } catch (error) {
     console.error(`Error fetching Coingecko's coin list`, error)
     return []
   }
 }
 
-/**
- * Get a map of contract addresses to coingecko coin id.
- *
- * Result is stored in a local file since this shouldn't change often.
- *
- * Takes in one parameter forceUpdate, to ignore local content - if any.
- */
-async function getCoingeckoTokenIdsMap(forceUpdate) {
+async function getCoingeckoTokenIdsMap(forceUpdate = false) {
   const localFilePath = 'build/coingeckoTokenIdsMap.json'
   let tokenIdsMap = COINGECKO_CHAINS_NAMES.reduce((acc, name) => ({ ...acc, [name]: {} }), {})
 
-  // Check if local file exists and forceUpdate is false
   if (!forceUpdate && fs.existsSync(localFilePath)) {
     try {
-      // Read the local file
-      const data = fs.readFileSync(localFilePath)
-      tokenIdsMap = JSON.parse(data)
+      tokenIdsMap = JSON.parse(fs.readFileSync(localFilePath))
     } catch (error) {
       console.error(`Error reading local file: ${error}`)
     }
   } else {
-    // Fetch the token IDs from Coingecko API
     try {
       const tokenIds = await getCoingeckoTokenIds()
-
       tokenIds.forEach((token) => {
         COINGECKO_CHAINS_NAMES.forEach((chain) => {
           const address = token.platforms[chain]
           if (address) {
             tokenIdsMap[chain][address] = token.id
-            // reverse mapping
-            tokenIdsMap[chain][token.id] = address
+            tokenIdsMap[chain][token.id] = address // reverse mapping
           }
         })
       })
-
-      // Save the fetched data to the local file
       fs.writeFileSync(localFilePath, JSON.stringify(tokenIdsMap))
     } catch (error) {
       console.error(`Error fetching Coingecko token IDs: ${error}`)
     }
   }
-
   return tokenIdsMap
 }
 
@@ -137,18 +103,13 @@ async function getCoingeckoMarket(chainId, tokens) {
   const coingeckoIdsForChain = COINGECKO_IDS_MAP[COINGECKO_CHAINS[chainId]]
   const ids = tokens.reduce((acc, token) => {
     const coingeckoId = coingeckoIdsForChain[token.address]
-    if (coingeckoId) {
-      acc += `${coingeckoId},`
-    }
-    return acc
+    return coingeckoId ? `${acc}${coingeckoId},` : acc
   }, '')
 
   try {
-    const headers = COINGECKO_API_KEY ? { 'X-Cg-Pro-Api-Key': COINGECKO_API_KEY } : {}
-
-    const url = `https://pro-api.coingecko.com/api/v3/coins/markets?vs_currency=${VS_CURRENCY}&per_page=250&ids=${ids}`
-    const response = await fetch(url, { headers })
-    return await response.json()
+    return await fetchWithApiKey(
+      `https://pro-api.coingecko.com/api/v3/coins/markets?vs_currency=${VS_CURRENCY}&per_page=250&ids=${ids}`,
+    )
   } catch (error) {
     console.error(`Error fetching Coingecko's coin list`, error)
     return []
@@ -156,26 +117,21 @@ async function getCoingeckoMarket(chainId, tokens) {
 }
 
 async function getTokenVolumes(chainId, tokens) {
-  // Max items per query is 250
   const chunkSize = 250
-  const chunkVolumes = []
+  const chunks = []
 
-  // Chunk tokens for each individual query
   for (let i = 0; i < tokens.length; i += chunkSize) {
     const chunk = tokens.slice(i, i + chunkSize)
-    chunkVolumes.push({ tokens: chunk, volume: getCoingeckoMarket(chainId, chunk) })
+    chunks.push({ tokens: chunk, volume: getCoingeckoMarket(chainId, chunk) })
   }
 
   const ids = COINGECKO_IDS_MAP[COINGECKO_CHAINS[chainId]]
-
   const volumes = await Promise.all(
-    chunkVolumes.map(async ({ tokens, volume }) => {
-      // Await query in parallel
+    chunks.map(async ({ tokens, volume }) => {
       const volumeData = await volume
-      // Create a map with volumes since the ordering is lost
       const volumeMap = volumeData.reduce((acc, cur) => {
         if (cur.total_volume && ids[cur.id]) {
-          acc[ids[cur.id]] = cur.total_volume || 0
+          acc[ids[cur.id]] = cur.total_volume
         }
         return acc
       }, {})
@@ -189,50 +145,50 @@ async function getTokenVolumes(chainId, tokens) {
     }),
   )
 
-  // Flatten and sort volumes by volume in descending order
   return volumes.flat().sort((a, b) => b.volume - a.volume)
+}
+
+function getLocalTokenList(listPath, defaultEmptyList) {
+  try {
+    return JSON.parse(fs.readFileSync(listPath, 'utf8'))
+  } catch (error) {
+    console.error(`Error reading token list from ${listPath}:`, error)
+    return defaultEmptyList
+  }
+}
+
+function saveLocalTokenList(listPath, list) {
+  try {
+    list.version = list.version || { major: 0, minor: 0, patch: 0 }
+    list.version.major += 1
+    list.timestamp = new Date().toISOString()
+    fs.writeFileSync(listPath, JSON.stringify(list, null, 2))
+    console.log(`Token list saved to ${listPath}`)
+  } catch (error) {
+    console.error(`Error saving token list to ${listPath}:`, error)
+  }
 }
 
 async function fetchAndProcessTokens(chainId) {
   try {
-    // Get coingecko ids
     COINGECKO_IDS_MAP = await getCoingeckoTokenIdsMap()
-
-    // Fetch tokens
     const tokens = await getTokenList(chainId)
-
-    // Fetch volume for each token
-    // const tokenVolumes = await Promise.all(
-    //   tokens.map(async (token) => ({
-    //     token,
-    //     volume: await getTokenVolume(token, chainId),
-    //   })),
-    // )
-
-    // Sort by volume and pick top tokens
-    // const topTokens = tokenVolumes.sort((a, b) => b.volume - a.volume).slice(0, TOP_TOKENS_COUNT)
     const topTokens = (await getTokenVolumes(chainId, tokens)).slice(0, TOP_TOKENS_COUNT)
 
-    // Print top tokens
-    let position = 1
     console.log(`🥇 Top ${TOP_TOKENS_COUNT} tokens on chain ${chainId}`)
-    for (const { token, volume } of topTokens) {
-      console.log(`\t-${position.toString().padStart(3, '0')}) ${token.name} (${token.symbol}): $${volume}`)
-      position++
-    }
+    topTokens.forEach(({ token, volume }, index) => {
+      console.log(`\t-${(index + 1).toString().padStart(3, '0')}) ${token.name} (${token.symbol}): $${volume}`)
+    })
 
     const tokenListPath = path.join(`src/public/CoinGecko.${chainId}.json`)
-
     const tokenList = getLocalTokenList(tokenListPath, getEmptyList())
 
-    // Replace tokens
     tokenList.tokens = topTokens.map(({ token }) => ({
       ...token,
       logoURI: token.logoURI ? token.logoURI.replace(/thumb/, 'large') : undefined,
     }))
     tokenList.name = getListName(chainId, tokenList.tokens.length)
 
-    // Write token file
     saveLocalTokenList(tokenListPath, tokenList)
   } catch (error) {
     console.error(`Error fetching data for chain ${chainId}:`, error)
@@ -240,44 +196,7 @@ async function fetchAndProcessTokens(chainId) {
 }
 
 async function main() {
-  // Fetch tokens for all chains
   Object.keys(COINGECKO_CHAINS).forEach((chain) => fetchAndProcessTokens(chain))
-}
-
-/**
- * Given a listPath with the relative path to the local token list, try to load it.
- * Return the loaded list if it's found, return the defaultEmptyList otherwise
- */
-function getLocalTokenList(listPath, defaultEmptyList) {
-  try {
-    const listData = fs.readFileSync(listPath, 'utf8')
-    return JSON.parse(listData)
-  } catch (error) {
-    console.error(`Error reading token list from ${listPath}:`, error)
-    return defaultEmptyList
-  }
-}
-
-/**
- * Given a listPath and a list object, write the list to the specified listPath.
- * List version.major is incremented, and timestamp is set to current ISO date, in UTC.
- */
-function saveLocalTokenList(listPath, list) {
-  try {
-    // Set default values for required fields if they are missing
-    list.version = list.version || { major: 0, minor: 0, patch: 0 }
-    // Increment the major version
-    list.version.major += 1
-    // Set the timestamp to the current ISO date in UTC
-    list.timestamp = new Date().toISOString()
-    // Convert the list object to a JSON string
-    const listJSON = JSON.stringify(list, null, 2)
-    // Write the JSON string to the specified file path
-    fs.writeFileSync(listPath, listJSON)
-    console.log(`Token list saved to ${listPath}`)
-  } catch (error) {
-    console.error(`Error saving token list to ${listPath}:`, error)
-  }
 }
 
 main()

--- a/src/scripts/coingeckoTop500.js
+++ b/src/scripts/coingeckoTop500.js
@@ -70,32 +70,23 @@ async function getCoingeckoTokenIds() {
 }
 
 async function getCoingeckoTokenIdsMap(forceUpdate = false) {
-  const localFilePath = 'build/coingeckoTokenIdsMap.json'
   let tokenIdsMap = COINGECKO_CHAINS_NAMES.reduce((acc, name) => ({ ...acc, [name]: {} }), {})
 
-  if (!forceUpdate && fs.existsSync(localFilePath)) {
-    try {
-      tokenIdsMap = JSON.parse(fs.readFileSync(localFilePath))
-    } catch (error) {
-      console.error(`Error reading local file: ${error}`)
-    }
-  } else {
-    try {
-      const tokenIds = await getCoingeckoTokenIds()
-      tokenIds.forEach((token) => {
-        COINGECKO_CHAINS_NAMES.forEach((chain) => {
-          const address = token.platforms[chain]
-          if (address) {
-            tokenIdsMap[chain][address] = token.id
-            tokenIdsMap[chain][token.id] = address // reverse mapping
-          }
-        })
+  try {
+    const tokenIds = await getCoingeckoTokenIds()
+    tokenIds.forEach((token) => {
+      COINGECKO_CHAINS_NAMES.forEach((chain) => {
+        const address = token.platforms[chain]
+        if (address) {
+          tokenIdsMap[chain][address] = token.id
+          tokenIdsMap[chain][token.id] = address // reverse mapping
+        }
       })
-      fs.writeFileSync(localFilePath, JSON.stringify(tokenIdsMap))
-    } catch (error) {
-      console.error(`Error fetching Coingecko token IDs: ${error}`)
-    }
+    })
+  } catch (error) {
+    console.error(`Error fetching Coingecko token IDs: ${error}`)
   }
+
   return tokenIdsMap
 }
 
@@ -171,7 +162,7 @@ function saveLocalTokenList(listPath, list) {
 
 async function fetchAndProcessTokens(chainId) {
   try {
-    COINGECKO_IDS_MAP = await getCoingeckoTokenIdsMap()
+    COINGECKO_IDS_MAP = Object.keys(COINGECKO_IDS_MAP).length || (await getCoingeckoTokenIdsMap())
     const tokens = await getTokenList(chainId)
     const topTokens = (await getTokenVolumes(chainId, tokens)).slice(0, TOP_TOKENS_COUNT)
 

--- a/src/scripts/coingeckoTop500.js
+++ b/src/scripts/coingeckoTop500.js
@@ -67,9 +67,6 @@ async function getTokenVolume(token, chain) {
     const response = await fetch(url, { headers })
     const data = await response.json()
 
-    // console.log(`[getTokenVolume] url: ${url}, chain: ${chain}`)
-    // console.log(`[getTokenVolume] token: ${token.symbol}, chain: ${chain}`)
-    // console.log(`[getTokenVolume] ${token.symbol} $${data.market_data.total_volume[VS_CURRENCY]}, chain: ${chain}`)
     return data.market_data.total_volume[VS_CURRENCY] || 0
   } catch (error) {
     console.error(`Error fetching volume for token ${token.name} on chain ${chain}:`, error)

--- a/src/scripts/coingeckoTop500.js
+++ b/src/scripts/coingeckoTop500.js
@@ -27,16 +27,20 @@ const COINGECKO_API_KEY = process.env.COINGECKO_API_KEY
 assert(COINGECKO_API_KEY, 'COINGECKO_API_KEY env is required')
 
 function getCoingeckoApiUrl(chain) {
-  return `https://pro-api.coingecko.com/api/v3/coins/${DISPLAY_CHAIN_NAMES[chain]}/contract`
+  return `https://pro-api.coingecko.com/api/v3/coins/${COINGECKO_CHAINS[chain]}/contract`
 }
 
 function getTokenListUrl(chain) {
   return `https://tokens.coingecko.com/${COINGECKO_CHAINS[chain]}/all.json`
 }
 
-function getEmptyList(chain) {
+function getListName(chain, count) {
+  return `Coingecko top ${count} on ${DISPLAY_CHAIN_NAMES[chain]}`
+}
+
+function getEmptyList() {
   return {
-    name: `Coingecko top ${TOP_TOKENS_COUNT} on ${COINGECKO_CHAINS[chain]}`,
+    name: `Coingecko`,
     logoURI:
       'https://static.coingecko.com/s/thumbnail-007177f3eca19695592f0b8b0eabbdae282b54154e1be912285c9034ea6cbaf2.png',
     keywords: ['defi'],
@@ -222,10 +226,14 @@ async function fetchAndProcessTokens(chainId) {
 
     const tokenListPath = path.join(`src/public/CoinGecko.${chainId}.json`)
 
-    const tokenList = getLocalTokenList(tokenListPath, getEmptyList(chainId))
+    const tokenList = getLocalTokenList(tokenListPath, getEmptyList())
 
     // Replace tokens
-    tokenList.tokens = topTokens.map(({ token }) => ({ ...token, logoURI: token.logoURI.replace(/thumb/, 'large') }))
+    tokenList.tokens = topTokens.map(({ token }) => ({
+      ...token,
+      logoURI: token.logoURI ? token.logoURI.replace(/thumb/, 'large') : undefined,
+    }))
+    tokenList.name = getListName(chainId, tokenList.tokens.length)
 
     // Write token file
     saveLocalTokenList(tokenListPath, tokenList)
@@ -237,7 +245,6 @@ async function fetchAndProcessTokens(chainId) {
 async function main() {
   // Fetch tokens for all chains
   Object.keys(COINGECKO_CHAINS).forEach((chain) => fetchAndProcessTokens(chain))
-  // fetchAndProcessTokens(100)
 }
 
 /**

--- a/src/scripts/coingeckoTop500.js
+++ b/src/scripts/coingeckoTop500.js
@@ -225,7 +225,7 @@ async function fetchAndProcessTokens(chainId) {
     const tokenList = getLocalTokenList(tokenListPath, getEmptyList(chainId))
 
     // Replace tokens
-    tokenList.tokens = topTokens.map(({ token }) => token)
+    tokenList.tokens = topTokens.map(({ token }) => ({ ...token, logoURI: token.logoURI.replace(/thumb/, 'large') }))
 
     // Write token file
     saveLocalTokenList(tokenListPath, tokenList)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,11 +1485,6 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-uri-to-buffer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
-  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
-
 debug@2.6.9, debug@^2.2.0:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
@@ -2070,14 +2065,6 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
-  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
-  dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
-
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
@@ -2176,13 +2163,6 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
-  dependencies:
-    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -3262,26 +3242,12 @@ node-addon-api@^2.0.0:
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
 node-fetch@^2.6.1, node-fetch@^2.6.12:
   version "2.7.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-fetch@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
-  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
-  dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
 
 node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.6.1"
@@ -4404,11 +4370,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-web-streams-polyfill@^3.0.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
-  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 web3-bzz@1.10.3:
   version "1.10.3"


### PR DESCRIPTION
# Summary

Generates coingecko top (up to) 500 for all chains.

Uses [coingecko coin markets endpoint](https://docs.coingecko.com/reference/coins-markets) to fetch up to 250 tokens at a time for all tokens in the respective coingecko token list per chain.
Then, sorts them by volume, and picks up to 500 (Gnosis chain only has ~80).

# Testing

1. Get the coingecko API key and run locally: `COINGECKO_API_KEY=... yarn coingeckoTop500`
* Should update all 4 lists and bump their major version and timestamp