### PR TITLE
fix: fix decimals and update lists

### DIFF
--- a/src/public/CoinGecko.1.json
+++ b/src/public/CoinGecko.1.json
@@ -5,9 +5,9 @@
     "defi"
   ],
   "version": {
-    "major": 0,
+    "major": 1,
     "minor": 0,
-    "patch": 1
+    "patch": 0
   },
   "tokens": [
     {
@@ -20,19 +20,19 @@
     },
     {
       "chainId": 1,
-      "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-      "name": "USDC",
-      "symbol": "USDC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696506694"
-    },
-    {
-      "chainId": 1,
       "address": "0xc5f0f7b66764f6ec8c8dff7ba683102295e16409",
       "name": "First Digital USD",
       "symbol": "FDUSD",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/31079/large/FDUSD_icon_black.png?1731097953"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "name": "USDC",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696506694"
     },
     {
       "chainId": 1,
@@ -60,14 +60,6 @@
     },
     {
       "chainId": 1,
-      "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
-      "name": "Aave",
-      "symbol": "AAVE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12645/large/aave-token-round.png?1720472354"
-    },
-    {
-      "chainId": 1,
       "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
       "name": "WETH",
       "symbol": "WETH",
@@ -76,19 +68,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
-      "name": "Shiba Inu",
-      "symbol": "SHIB",
+      "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+      "name": "Aave",
+      "symbol": "AAVE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11939/large/shiba.png?1696511800"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1",
-      "name": "Arbitrum",
-      "symbol": "ARB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16547/large/arb.jpg?1721358242"
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/large/aave-token-round.png?1720472354"
     },
     {
       "chainId": 1,
@@ -108,6 +92,22 @@
     },
     {
       "chainId": 1,
+      "address": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1",
+      "name": "Arbitrum",
+      "symbol": "ARB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16547/large/arb.jpg?1721358242"
+    },
+    {
+      "chainId": 1,
+      "address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+      "name": "Shiba Inu",
+      "symbol": "SHIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11939/large/shiba.png?1696511800"
+    },
+    {
+      "chainId": 1,
       "address": "0x1151cb3d861920e07a38e03eead12c32178567f6",
       "name": "Bonk",
       "symbol": "BONK",
@@ -124,115 +124,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x163f8c2467924be0ae7b5347228cabf260318753",
-      "name": "Worldcoin",
-      "symbol": "WLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31069/large/worldcoin.jpeg?1696529903"
-    },
-    {
-      "chainId": 1,
       "address": "0xd1d2eb1b1e90b638588728b4130137d262c87cae",
       "name": "GALA",
       "symbol": "GALA",
       "decimals": 8,
       "logoURI": "https://assets.coingecko.com/coins/images/12493/large/GALA_token_image_-_200PNG.png?1709725869"
-    },
-    {
-      "chainId": 1,
-      "address": "0x57e114b691db790c35207b2e685d4a43181e6061",
-      "name": "Ethena",
-      "symbol": "ENA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36530/large/ethena.png?1711701436"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaea46a60368a7bd060eec7df8cba43b7ef41ad85",
-      "name": "Artificial Superintelligence Alliance",
-      "symbol": "FET",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5681/large/ASI.png?1719827289"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
-      "name": "Ethereum Name Service",
-      "symbol": "ENS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19785/large/ENS.jpg?1727872989"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
-      "name": "LayerZero",
-      "symbol": "ZRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
-      "name": "Wrapped Bitcoin",
-      "symbol": "WBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1696507857"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
-      "name": "Coinbase Wrapped BTC",
-      "symbol": "CBBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3073f7aaa4db83f95e9fff17424f71d4751a3073",
-      "name": "Movement",
-      "symbol": "MOVE",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39345/large/movement-testnet-token.png?1721878759"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
-      "name": "FLOKI",
-      "symbol": "FLOKI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/16746/large/PNG_image.png?1696516318"
-    },
-    {
-      "chainId": 1,
-      "address": "0x44ff8620b8ca30902395a7bd3f2407e1a091bf73",
-      "name": "Virtuals Protocol",
-      "symbol": "VIRTUAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34057/large/LOGOMARK.png?1708356054"
-    },
-    {
-      "chainId": 1,
-      "address": "0x582d872a1b094fc48f5de31d3b73f2d9be47def1",
-      "name": "Toncoin",
-      "symbol": "TON",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/17980/large/photo_2024-09-10_17.09.00.jpeg?1725963446"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
-      "name": "The Sandbox",
-      "symbol": "SAND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12129/large/sandbox_logo.jpg?1696511971"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
-      "name": "Lido DAO",
-      "symbol": "LDO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1696513326"
     },
     {
       "chainId": 1,
@@ -244,11 +140,107 @@
     },
     {
       "chainId": 1,
-      "address": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
-      "name": "Eigenlayer",
-      "symbol": "EIGEN",
+      "address": "0x163f8c2467924be0ae7b5347228cabf260318753",
+      "name": "Worldcoin",
+      "symbol": "WLD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37441/large/eigen.jpg?1728023974"
+      "logoURI": "https://assets.coingecko.com/coins/images/31069/large/worldcoin.jpeg?1696529903"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "name": "LayerZero",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/large/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaea46a60368a7bd060eec7df8cba43b7ef41ad85",
+      "name": "Artificial Superintelligence Alliance",
+      "symbol": "FET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5681/large/ASI.png?1719827289"
+    },
+    {
+      "chainId": 1,
+      "address": "0x57e114b691db790c35207b2e685d4a43181e6061",
+      "name": "Ethena",
+      "symbol": "ENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36530/large/ethena.png?1711701436"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      "name": "Wrapped Bitcoin",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1696507857"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
+      "name": "FLOKI",
+      "symbol": "FLOKI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16746/large/PNG_image.png?1696516318"
+    },
+    {
+      "chainId": 1,
+      "address": "0x582d872a1b094fc48f5de31d3b73f2d9be47def1",
+      "name": "Toncoin",
+      "symbol": "TON",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17980/large/photo_2024-09-10_17.09.00.jpeg?1725963446"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+      "name": "Coinbase Wrapped BTC",
+      "symbol": "CBBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+      "name": "The Sandbox",
+      "symbol": "SAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12129/large/sandbox_logo.jpg?1696511971"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+      "name": "Ethereum Name Service",
+      "symbol": "ENS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19785/large/ENS.jpg?1727872989"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3073f7aaa4db83f95e9fff17424f71d4751a3073",
+      "name": "Movement",
+      "symbol": "MOVE",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39345/large/movement-testnet-token.png?1721878759"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44ff8620b8ca30902395a7bd3f2407e1a091bf73",
+      "name": "Virtuals Protocol",
+      "symbol": "VIRTUAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34057/large/LOGOMARK.png?1708356054"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+      "name": "Lido DAO",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1696513326"
     },
     {
       "chainId": 1,
@@ -260,11 +252,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xfe0c30065b384f05761f15d0cc899d4f9f9cc0eb",
-      "name": "Ether fi",
-      "symbol": "ETHFI",
+      "address": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
+      "name": "Eigenlayer",
+      "symbol": "EIGEN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35958/large/etherfi.jpeg?1710254562"
+      "logoURI": "https://assets.coingecko.com/coins/images/37441/large/eigen.jpg?1728023974"
     },
     {
       "chainId": 1,
@@ -276,35 +268,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b",
-      "name": "Cronos",
-      "symbol": "CRO",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/7310/large/cro_token_logo.png?1696507599"
-    },
-    {
-      "chainId": 1,
-      "address": "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
-      "name": "POL  ex MATIC ",
-      "symbol": "POL",
+      "address": "0xfe0c30065b384f05761f15d0cc899d4f9f9cc0eb",
+      "name": "Ether fi",
+      "symbol": "ETHFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32440/large/polygon.png?1698233684"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe28b3b32b6c345a34ff64674606124dd5aceca30",
-      "name": "Injective",
-      "symbol": "INJ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12882/large/Secondary_Symbol.png?1696512670"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
-      "name": "Render",
-      "symbol": "RENDER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11636/large/rndr.png?1696511529"
+      "logoURI": "https://assets.coingecko.com/coins/images/35958/large/etherfi.jpeg?1710254562"
     },
     {
       "chainId": 1,
@@ -316,11 +284,35 @@
     },
     {
       "chainId": 1,
+      "address": "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
+      "name": "POL  ex MATIC ",
+      "symbol": "POL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32440/large/polygon.png?1698233684"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
+      "name": "Render",
+      "symbol": "RENDER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11636/large/rndr.png?1696511529"
+    },
+    {
+      "chainId": 1,
       "address": "0x812ba41e071c7b7fa4ebcfb62df5f45f6fa853ee",
       "name": "Neiro",
       "symbol": "NEIRO",
       "decimals": 9,
       "logoURI": "https://assets.coingecko.com/coins/images/39488/large/neiro.jpg?1731449567"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe28b3b32b6c345a34ff64674606124dd5aceca30",
+      "name": "Injective",
+      "symbol": "INJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12882/large/Secondary_Symbol.png?1696512670"
     },
     {
       "chainId": 1,
@@ -332,19 +324,19 @@
     },
     {
       "chainId": 1,
-      "address": "0xf944e35f95e819e752f3ccb5faf40957d311e8c5",
-      "name": "Moca Coin",
-      "symbol": "MOCA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37812/large/moca.jpg?1720693068"
-    },
-    {
-      "chainId": 1,
       "address": "0xa35923162c49cf95e6bf26623385eb431ad920d3",
       "name": "Turbo",
       "symbol": "TURBO",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/30117/large/TurboMark-QL_200.png?1708079597"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf944e35f95e819e752f3ccb5faf40957d311e8c5",
+      "name": "Moca Coin",
+      "symbol": "MOCA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37812/large/moca.jpg?1720693068"
     },
     {
       "chainId": 1,
@@ -356,6 +348,14 @@
     },
     {
       "chainId": 1,
+      "address": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+      "name": "Axie Infinity",
+      "symbol": "AXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13029/large/axie_infinity_logo.png?1696512817"
+    },
+    {
+      "chainId": 1,
       "address": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
       "name": "Lido Staked Ether",
       "symbol": "STETH",
@@ -364,19 +364,19 @@
     },
     {
       "chainId": 1,
+      "address": "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b",
+      "name": "Cronos",
+      "symbol": "CRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/7310/large/cro_token_logo.png?1696507599"
+    },
+    {
+      "chainId": 1,
       "address": "0x69af81e73a73b40adf4f3d4223cd9b1ece623074",
       "name": "Mask Network",
       "symbol": "MASK",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/14051/large/Mask_Network.jpg?1696513776"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
-      "name": "Axie Infinity",
-      "symbol": "AXS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13029/large/axie_infinity_logo.png?1696512817"
     },
     {
       "chainId": 1,
@@ -396,14 +396,6 @@
     },
     {
       "chainId": 1,
-      "address": "0x3c3a81e81dc49a522a592e7622a7e711c06bf354",
-      "name": "Mantle",
-      "symbol": "MNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30980/large/token-logo.png?1696529819"
-    },
-    {
-      "chainId": 1,
       "address": "0xac57de9c1a09fec648e93eb98875b212db0d460b",
       "name": "Baby Doge Coin",
       "symbol": "BABYDOGE",
@@ -412,19 +404,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x5283d291dbcf85356a21ba090e6db59121208b44",
-      "name": "Blur",
-      "symbol": "BLUR",
+      "address": "0x3c3a81e81dc49a522a592e7622a7e711c06bf354",
+      "name": "Mantle",
+      "symbol": "MNT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28453/large/blur.png?1696527448"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3506424f91fd33084466f402d5d97f05f8e3b4af",
-      "name": "Chiliz",
-      "symbol": "CHZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8834/large/CHZ_Token_updated.png?1696508986"
+      "logoURI": "https://assets.coingecko.com/coins/images/30980/large/token-logo.png?1696529819"
     },
     {
       "chainId": 1,
@@ -436,11 +420,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9",
-      "name": "FTX",
-      "symbol": "FTT",
+      "address": "0x3506424f91fd33084466f402d5d97f05f8e3b4af",
+      "name": "Chiliz",
+      "symbol": "CHZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9026/large/F.png?1696509161"
+      "logoURI": "https://assets.coingecko.com/coins/images/8834/large/CHZ_Token_updated.png?1696508986"
     },
     {
       "chainId": 1,
@@ -468,27 +452,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xca14007eff0db1f8135f4c25b34de49ab0d42766",
-      "name": "Starknet",
-      "symbol": "STRK",
+      "address": "0x5283d291dbcf85356a21ba090e6db59121208b44",
+      "name": "Blur",
+      "symbol": "BLUR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26433/large/starknet.png?1696525507"
-    },
-    {
-      "chainId": 1,
-      "address": "0x808507121b80c02388fad14726482e061b8da827",
-      "name": "Pendle",
-      "symbol": "PENDLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
-      "name": "Dai",
-      "symbol": "DAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9956/large/Badge_Dai.png?1696509996"
+      "logoURI": "https://assets.coingecko.com/coins/images/28453/large/blur.png?1696527448"
     },
     {
       "chainId": 1,
@@ -500,11 +468,35 @@
     },
     {
       "chainId": 1,
+      "address": "0xca14007eff0db1f8135f4c25b34de49ab0d42766",
+      "name": "Starknet",
+      "symbol": "STRK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26433/large/starknet.png?1696525507"
+    },
+    {
+      "chainId": 1,
+      "address": "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9",
+      "name": "FTX",
+      "symbol": "FTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9026/large/F.png?1696509161"
+    },
+    {
+      "chainId": 1,
       "address": "0xa6c0c097741d55ecd9a3a7def3a8253fd022ceb9",
       "name": "AVA  Travala ",
       "symbol": "AVA",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/3014/large/AVA_Logo_160x160px_Black.png?1696503750"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+      "name": "The Graph",
+      "symbol": "GRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/large/Graph_Token.png?1696513159"
     },
     {
       "chainId": 1,
@@ -524,11 +516,19 @@
     },
     {
       "chainId": 1,
-      "address": "0x92d6c1e31e14520e676a687f0a93788b716beff5",
-      "name": "dYdX",
-      "symbol": "ETHDYDX",
+      "address": "0x808507121b80c02388fad14726482e061b8da827",
+      "name": "Pendle",
+      "symbol": "PENDLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17500/large/hjnIm9bV.jpg?1696517040"
+      "logoURI": "https://assets.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfd418e42783382e86ae91e445406600ba144d162",
+      "name": "Zircuit",
+      "symbol": "ZRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35960/large/zircuit_token_icon_2.png?1732502352"
     },
     {
       "chainId": 1,
@@ -548,11 +548,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xfd418e42783382e86ae91e445406600ba144d162",
-      "name": "Zircuit",
-      "symbol": "ZRC",
+      "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+      "name": "Wrapped stETH",
+      "symbol": "WSTETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35960/large/zircuit_token_icon_2.png?1732502352"
+      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
     },
     {
       "chainId": 1,
@@ -564,19 +564,19 @@
     },
     {
       "chainId": 1,
-      "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
-      "name": "The Graph",
-      "symbol": "GRT",
+      "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+      "name": "Dai",
+      "symbol": "DAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13397/large/Graph_Token.png?1696513159"
+      "logoURI": "https://assets.coingecko.com/coins/images/9956/large/Badge_Dai.png?1696509996"
     },
     {
       "chainId": 1,
-      "address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
-      "name": "Across Protocol",
-      "symbol": "ACX",
+      "address": "0x92d6c1e31e14520e676a687f0a93788b716beff5",
+      "name": "dYdX",
+      "symbol": "ETHDYDX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+      "logoURI": "https://assets.coingecko.com/coins/images/17500/large/hjnIm9bV.jpg?1696517040"
     },
     {
       "chainId": 1,
@@ -588,11 +588,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
-      "name": "Onooks",
-      "symbol": "OOKS",
+      "address": "0x3593d125a4f7849a1b059e64f4517a86dd60c95d",
+      "name": "MANTRA",
+      "symbol": "OM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16281/large/onooks-logo.png?1696515879"
+      "logoURI": "https://assets.coingecko.com/coins/images/12151/large/OM_Token.png?1696511991"
     },
     {
       "chainId": 1,
@@ -604,11 +604,35 @@
     },
     {
       "chainId": 1,
+      "address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+      "name": "Across Protocol",
+      "symbol": "ACX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+      "name": "CARV",
+      "symbol": "CARV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
+    },
+    {
+      "chainId": 1,
       "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
       "name": "Synthetix Network",
       "symbol": "SNX",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/3406/large/SNX.png?1696504103"
+    },
+    {
+      "chainId": 1,
+      "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
+      "name": "Onooks",
+      "symbol": "OOKS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16281/large/onooks-logo.png?1696515879"
     },
     {
       "chainId": 1,
@@ -636,30 +660,6 @@
     },
     {
       "chainId": 1,
-      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
-      "name": "CARV",
-      "symbol": "CARV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe41d2489571d322189246dafa5ebde1f4699f498",
-      "name": "0x Protocol",
-      "symbol": "ZRX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/863/large/0x.png?1696501996"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3593d125a4f7849a1b059e64f4517a86dd60c95d",
-      "name": "MANTRA",
-      "symbol": "OM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12151/large/OM_Token.png?1696511991"
-    },
-    {
-      "chainId": 1,
       "address": "0x58b6a8a3302369daec383334672404ee733ab239",
       "name": "Livepeer",
       "symbol": "LPT",
@@ -668,27 +668,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x64bc2ca1be492be7185faa2c8835d9b824c8a194",
-      "name": "Big Time",
-      "symbol": "BIGTIME",
+      "address": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+      "name": "0x Protocol",
+      "symbol": "ZRX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32251/large/-6136155493475923781_121.jpg?1696998691"
-    },
-    {
-      "chainId": 1,
-      "address": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
-      "name": "Yield Guild Games",
-      "symbol": "YGG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17358/large/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
-      "name": "Threshold Network",
-      "symbol": "T",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22228/large/nFPNiSbL_400x400.jpg?1696521570"
+      "logoURI": "https://assets.coingecko.com/coins/images/863/large/0x.png?1696501996"
     },
     {
       "chainId": 1,
@@ -716,51 +700,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xdc9ac3c20d1ed0b540df9b1fedc10039df13f99c",
-      "name": "xMoney",
-      "symbol": "UTK",
+      "address": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
+      "name": "Yield Guild Games",
+      "symbol": "YGG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1824/large/200x200.png?1696723239"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
-      "name": "Liquity",
-      "symbol": "LQTY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14665/large/logo_V2.png?1725437146"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
-      "name": "Wrapped stETH",
-      "symbol": "WSTETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc669928185dbce49d2230cc9b0979be6dc797957",
-      "name": "BitTorrent",
-      "symbol": "BTT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22457/large/btt_logo.png?1696521780"
-    },
-    {
-      "chainId": 1,
-      "address": "0x14fee680690900ba0cccfc76ad70fd1b95d10e16",
-      "name": "PAAL AI",
-      "symbol": "PAAL",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/30815/large/Paal_New_Logo_%281%29.png?1718160584"
-    },
-    {
-      "chainId": 1,
-      "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
-      "name": "Tellor Tributes",
-      "symbol": "TRB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9644/large/Blk_icon_current.png?1696509713"
+      "logoURI": "https://assets.coingecko.com/coins/images/17358/large/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
     },
     {
       "chainId": 1,
@@ -772,19 +716,59 @@
     },
     {
       "chainId": 1,
+      "address": "0xc669928185dbce49d2230cc9b0979be6dc797957",
+      "name": "BitTorrent",
+      "symbol": "BTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22457/large/btt_logo.png?1696521780"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+      "name": "Liquity",
+      "symbol": "LQTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14665/large/logo_V2.png?1725437146"
+    },
+    {
+      "chainId": 1,
+      "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
+      "name": "Tellor Tributes",
+      "symbol": "TRB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/large/Blk_icon_current.png?1696509713"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
+      "name": "Threshold Network",
+      "symbol": "T",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22228/large/nFPNiSbL_400x400.jpg?1696521570"
+    },
+    {
+      "chainId": 1,
+      "address": "0x14fee680690900ba0cccfc76ad70fd1b95d10e16",
+      "name": "PAAL AI",
+      "symbol": "PAAL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/30815/large/Paal_New_Logo_%281%29.png?1718160584"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdc9ac3c20d1ed0b540df9b1fedc10039df13f99c",
+      "name": "xMoney",
+      "symbol": "UTK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1824/large/200x200.png?1696723239"
+    },
+    {
+      "chainId": 1,
       "address": "0x58d97b57bb95320f9a05dc918aef65434969c2b2",
       "name": "Morpho",
       "symbol": "MORPHO",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
-      "name": "Convex Finance",
-      "symbol": "CVX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15585/large/convex.png?1696515221"
     },
     {
       "chainId": 1,
@@ -796,14 +780,6 @@
     },
     {
       "chainId": 1,
-      "address": "0x8457ca5040ad67fdebbcc8edce889a335bc0fbfb",
-      "name": "AltLayer",
-      "symbol": "ALT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34608/large/Logomark_200x200.png?1715107868"
-    },
-    {
-      "chainId": 1,
       "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
       "name": "Basic Attention",
       "symbol": "BAT",
@@ -812,19 +788,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xe53ec727dbdeb9e2d5456c3be40cff031ab40a55",
-      "name": "SuperVerse",
-      "symbol": "SUPER",
+      "address": "0x8457ca5040ad67fdebbcc8edce889a335bc0fbfb",
+      "name": "AltLayer",
+      "symbol": "ALT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14040/large/SV-Logo-200x200.png?1706880312"
-    },
-    {
-      "chainId": 1,
-      "address": "0x11eef04c884e24d9b7b4760e7476d06ddf797f36",
-      "name": "MX",
-      "symbol": "MX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8545/large/MEXC_GLOBAL_LOGO.jpeg?1696508719"
+      "logoURI": "https://assets.coingecko.com/coins/images/34608/large/Logomark_200x200.png?1715107868"
     },
     {
       "chainId": 1,
@@ -836,11 +804,27 @@
     },
     {
       "chainId": 1,
-      "address": "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
-      "name": "Civic",
-      "symbol": "CVC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/788/large/civic-orange.png?1696501939"
+      "address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
+      "name": "Convex Finance",
+      "symbol": "CVX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15585/large/convex.png?1696515221"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe53ec727dbdeb9e2d5456c3be40cff031ab40a55",
+      "name": "SuperVerse",
+      "symbol": "SUPER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14040/large/SV-Logo-200x200.png?1706880312"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa3ee21c306a700e682abcdfe9baa6a08f3820419",
+      "name": "Creditcoin",
+      "symbol": "CTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10569/large/ctc.png?1696510552"
     },
     {
       "chainId": 1,
@@ -852,51 +836,19 @@
     },
     {
       "chainId": 1,
+      "address": "0x11eef04c884e24d9b7b4760e7476d06ddf797f36",
+      "name": "MX",
+      "symbol": "MX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8545/large/MEXC_GLOBAL_LOGO.jpeg?1696508719"
+    },
+    {
+      "chainId": 1,
       "address": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
       "name": "EURC",
       "symbol": "EURC",
       "decimals": 6,
       "logoURI": "https://assets.coingecko.com/coins/images/26045/large/euro.png?1696525125"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa9b1eb5908cfc3cdf91f9b8b3a74108598009096",
-      "name": "Bounce",
-      "symbol": "AUCTION",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13860/large/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1696513606"
-    },
-    {
-      "chainId": 1,
-      "address": "0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7",
-      "name": "SKALE",
-      "symbol": "SKL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13245/large/SKALE_token_300x300.png?1696513021"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaedf386b755465871ff874e3e37af5976e247064",
-      "name": "Fasttoken",
-      "symbol": "FTN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28478/large/lightenicon_200x200.png?1696527472"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbe0ed4138121ecfc5c0e56b40517da27e6c5226b",
-      "name": "Aethir",
-      "symbol": "ATH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
-    },
-    {
-      "chainId": 1,
-      "address": "0x198d14f2ad9ce69e76ea330b374de4957c3f850a",
-      "name": "APENFT",
-      "symbol": "NFT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/15687/large/apenft.jpg?1696515316"
     },
     {
       "chainId": 1,
@@ -908,19 +860,27 @@
     },
     {
       "chainId": 1,
-      "address": "0xff20817765cb7f73d4bde2e66e067e58d11095c2",
-      "name": "Amp",
-      "symbol": "AMP",
+      "address": "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+      "name": "Ethena Staked USDe",
+      "symbol": "SUSDE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12409/large/amp-200x200.png?1696512231"
+      "logoURI": "https://assets.coingecko.com/coins/images/33669/large/sUSDe-Symbol-Color.png?1716307680"
     },
     {
       "chainId": 1,
-      "address": "0x3429d03c6f7521aec737a0bbf2e5ddcef2c3ae31",
-      "name": "Pixels",
-      "symbol": "PIXEL",
+      "address": "0x198d14f2ad9ce69e76ea330b374de4957c3f850a",
+      "name": "APENFT",
+      "symbol": "NFT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/15687/large/apenft.jpg?1696515316"
+    },
+    {
+      "chainId": 1,
+      "address": "0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7",
+      "name": "SKALE",
+      "symbol": "SKL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35100/large/pixel-icon.png?1708339519"
+      "logoURI": "https://assets.coingecko.com/coins/images/13245/large/SKALE_token_300x300.png?1696513021"
     },
     {
       "chainId": 1,
@@ -932,43 +892,19 @@
     },
     {
       "chainId": 1,
+      "address": "0x3429d03c6f7521aec737a0bbf2e5ddcef2c3ae31",
+      "name": "Pixels",
+      "symbol": "PIXEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35100/large/pixel-icon.png?1708339519"
+    },
+    {
+      "chainId": 1,
       "address": "0x4be10da47a07716af28ad199fbe020501bddd7af",
       "name": "XT com",
       "symbol": "XT",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/8391/large/20240701-155217.jpeg?1719895785"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
-      "name": "Enjin Coin",
-      "symbol": "ENJ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1102/large/Symbol_Only_-_Purple.png?1709725966"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1bbe973bef3a977fc51cbed703e8ffdefe001fed",
-      "name": "Portal",
-      "symbol": "PORTAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35436/large/portal.jpeg?1708590254"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe0f63a424a4439cbe457d80e4f4b51ad25b2c56c",
-      "name": "SPX6900",
-      "symbol": "SPX",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/31401/large/sticker_%281%29.jpg?1702371083"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2781246fe707bb15cee3e5ea354e2154a2877b16",
-      "name": "ELYSIA",
-      "symbol": "EL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10887/large/elysia_logo_200.png?1718149410"
     },
     {
       "chainId": 1,
@@ -980,51 +916,59 @@
     },
     {
       "chainId": 1,
-      "address": "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
-      "name": "Ethena Staked USDe",
-      "symbol": "SUSDE",
+      "address": "0x83f20f44975d03b1b09e64809b757c47f942beea",
+      "name": "Savings Dai",
+      "symbol": "SDAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33669/large/sUSDe-Symbol-Color.png?1716307680"
+      "logoURI": "https://assets.coingecko.com/coins/images/32254/large/sdai.png?1697015278"
     },
     {
       "chainId": 1,
-      "address": "0xaaee1a9723aadb7afa2810263653a34ba2c21c7a",
-      "name": "Mog Coin",
-      "symbol": "MOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png?1696529893"
+      "address": "0xe0f63a424a4439cbe457d80e4f4b51ad25b2c56c",
+      "name": "SPX6900",
+      "symbol": "SPX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/31401/large/sticker_%281%29.jpg?1702371083"
     },
     {
       "chainId": 1,
-      "address": "0x6033f7f88332b8db6ad452b7c6d5bb643990ae3f",
-      "name": "Lisk",
-      "symbol": "LSK",
+      "address": "0xff20817765cb7f73d4bde2e66e067e58d11095c2",
+      "name": "Amp",
+      "symbol": "AMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/385/large/Lisk_logo.png?1722338450"
+      "logoURI": "https://assets.coingecko.com/coins/images/12409/large/amp-200x200.png?1696512231"
     },
     {
       "chainId": 1,
-      "address": "0x2242328a9e9a2dea3b9ef5952b9614f45c7585d6",
-      "name": "Diamond castle",
-      "symbol": "DMCK",
+      "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
+      "name": "Enjin Coin",
+      "symbol": "ENJ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39573/large/DMCk_%EB%A1%9C%EA%B3%A0%28%EB%A9%94%EC%9D%B8_%EC%BD%94%EC%9D%B8%29_%EB%8C%80%EC%A7%80_1_%EC%82%AC%EB%B3%B8_7.png?1722958221"
+      "logoURI": "https://assets.coingecko.com/coins/images/1102/large/Symbol_Only_-_Purple.png?1709725966"
     },
     {
       "chainId": 1,
-      "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
-      "name": "TrueUSD",
-      "symbol": "TUSD",
+      "address": "0xaedf386b755465871ff874e3e37af5976e247064",
+      "name": "Fasttoken",
+      "symbol": "FTN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3449/large/tusd.png?1696504140"
+      "logoURI": "https://assets.coingecko.com/coins/images/28478/large/lightenicon_200x200.png?1696527472"
     },
     {
       "chainId": 1,
-      "address": "0x0a6e7ba5042b38349e437ec6db6214aec7b35676",
-      "name": "Swell",
-      "symbol": "SWELL",
+      "address": "0x1bbe973bef3a977fc51cbed703e8ffdefe001fed",
+      "name": "Portal",
+      "symbol": "PORTAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28777/large/swell1.png?1727899715"
+      "logoURI": "https://assets.coingecko.com/coins/images/35436/large/portal.jpeg?1708590254"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe0ed4138121ecfc5c0e56b40517da27e6c5226b",
+      "name": "Aethir",
+      "symbol": "ATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
     },
     {
       "chainId": 1,
@@ -1036,43 +980,27 @@
     },
     {
       "chainId": 1,
-      "address": "0x2dff88a56767223a5529ea5960da7a3f5f766406",
-      "name": "SPACE ID",
-      "symbol": "ID",
+      "address": "0x2781246fe707bb15cee3e5ea354e2154a2877b16",
+      "name": "ELYSIA",
+      "symbol": "EL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29468/large/sid_token_logo_%28green2%29.png?1696528413"
+      "logoURI": "https://assets.coingecko.com/coins/images/10887/large/elysia_logo_200.png?1718149410"
     },
     {
       "chainId": 1,
-      "address": "0xb0c7a3ba49c7a6eaba6cd4a96c55a1391070ac9a",
-      "name": "Treasure",
-      "symbol": "MAGIC",
+      "address": "0x2242328a9e9a2dea3b9ef5952b9614f45c7585d6",
+      "name": "Diamond castle",
+      "symbol": "DMCK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18623/large/magic.png?1696518095"
+      "logoURI": "https://assets.coingecko.com/coins/images/39573/large/DMCk_%EB%A1%9C%EA%B3%A0%28%EB%A9%94%EC%9D%B8_%EC%BD%94%EC%9D%B8%29_%EB%8C%80%EC%A7%80_1_%EC%82%AC%EB%B3%B8_7.png?1722958221"
     },
     {
       "chainId": 1,
-      "address": "0x888888848b652b3e3a0f34c96e00eec0f3a23f72",
-      "name": "Alien Worlds",
-      "symbol": "TLM",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/14676/large/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1696514350"
-    },
-    {
-      "chainId": 1,
-      "address": "0xed04915c23f00a313a544955524eb7dbd823143d",
-      "name": "Alchemy Pay",
-      "symbol": "ACH",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/12390/large/ACH_%281%29.png?1696512213"
-    },
-    {
-      "chainId": 1,
-      "address": "0x15700b564ca08d9439c58ca5053166e8317aa138",
-      "name": "Elixir deUSD",
-      "symbol": "DEUSD",
+      "address": "0x0a6e7ba5042b38349e437ec6db6214aec7b35676",
+      "name": "Swell",
+      "symbol": "SWELL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39494/large/deUSD_Logo_%281%29.png?1723689002"
+      "logoURI": "https://assets.coingecko.com/coins/images/28777/large/swell1.png?1727899715"
     },
     {
       "chainId": 1,
@@ -1084,11 +1012,51 @@
     },
     {
       "chainId": 1,
+      "address": "0xde4ee8057785a7e8e800db58f9784845a5c2cbd6",
+      "name": "DeXe",
+      "symbol": "DEXE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12713/large/DEXE_token_logo.png?1696512514"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6033f7f88332b8db6ad452b7c6d5bb643990ae3f",
+      "name": "Lisk",
+      "symbol": "LSK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/385/large/Lisk_logo.png?1722338450"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa9b1eb5908cfc3cdf91f9b8b3a74108598009096",
+      "name": "Bounce",
+      "symbol": "AUCTION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13860/large/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1696513606"
+    },
+    {
+      "chainId": 1,
+      "address": "0x15700b564ca08d9439c58ca5053166e8317aa138",
+      "name": "Elixir deUSD",
+      "symbol": "DEUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39494/large/deUSD_Logo_%281%29.png?1723689002"
+    },
+    {
+      "chainId": 1,
       "address": "0x031b8d752d73d7fe9678acef26e818280d0646b4",
       "name": "Sovrun",
       "symbol": "SOVRN",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/52312/large/IMG_20241202_183145_081.jpg?1733135740"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2dff88a56767223a5529ea5960da7a3f5f766406",
+      "name": "SPACE ID",
+      "symbol": "ID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29468/large/sid_token_logo_%28green2%29.png?1696528413"
     },
     {
       "chainId": 1,
@@ -1100,6 +1068,14 @@
     },
     {
       "chainId": 1,
+      "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
+      "name": "TrueUSD",
+      "symbol": "TUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3449/large/tusd.png?1696504140"
+    },
+    {
+      "chainId": 1,
       "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
       "name": "XSGD",
       "symbol": "XSGD",
@@ -1108,11 +1084,35 @@
     },
     {
       "chainId": 1,
-      "address": "0x7dd9c5cba05e151c895fde1cf355c9a1d5da6429",
-      "name": "Golem",
-      "symbol": "GLM",
+      "address": "0x888888848b652b3e3a0f34c96e00eec0f3a23f72",
+      "name": "Alien Worlds",
+      "symbol": "TLM",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/14676/large/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1696514350"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaaee1a9723aadb7afa2810263653a34ba2c21c7a",
+      "name": "Mog Coin",
+      "symbol": "MOG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/542/large/Golem_Submark_Positive_RGB.png?1696501761"
+      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png?1696529893"
+    },
+    {
+      "chainId": 1,
+      "address": "0xed04915c23f00a313a544955524eb7dbd823143d",
+      "name": "Alchemy Pay",
+      "symbol": "ACH",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12390/large/ACH_%281%29.png?1696512213"
+    },
+    {
+      "chainId": 1,
+      "address": "0x64bc2ca1be492be7185faa2c8835d9b824c8a194",
+      "name": "Big Time",
+      "symbol": "BIGTIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32251/large/-6136155493475923781_121.jpg?1696998691"
     },
     {
       "chainId": 1,
@@ -1124,19 +1124,27 @@
     },
     {
       "chainId": 1,
-      "address": "0x83f20f44975d03b1b09e64809b757c47f942beea",
-      "name": "Savings Dai",
-      "symbol": "SDAI",
+      "address": "0x7dd9c5cba05e151c895fde1cf355c9a1d5da6429",
+      "name": "Golem",
+      "symbol": "GLM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32254/large/sdai.png?1697015278"
+      "logoURI": "https://assets.coingecko.com/coins/images/542/large/Golem_Submark_Positive_RGB.png?1696501761"
     },
     {
       "chainId": 1,
-      "address": "0xde4ee8057785a7e8e800db58f9784845a5c2cbd6",
-      "name": "DeXe",
-      "symbol": "DEXE",
+      "address": "0xb0c7a3ba49c7a6eaba6cd4a96c55a1391070ac9a",
+      "name": "Treasure",
+      "symbol": "MAGIC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12713/large/DEXE_token_logo.png?1696512514"
+      "logoURI": "https://assets.coingecko.com/coins/images/18623/large/magic.png?1696518095"
+    },
+    {
+      "chainId": 1,
+      "address": "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
+      "name": "Civic",
+      "symbol": "CVC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/788/large/civic-orange.png?1696501939"
     },
     {
       "chainId": 1,
@@ -1148,75 +1156,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
-      "name": "Gitcoin",
-      "symbol": "GTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15810/large/gitcoin.png?1696515429"
-    },
-    {
-      "chainId": 1,
       "address": "0x5afe3855358e112b5647b952709e6165e1c1eeee",
       "name": "Safe",
       "symbol": "SAFE",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/27032/large/Artboard_1_copy_8circle-1.png?1696526084"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
-      "name": "WOO",
-      "symbol": "WOO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
-      "name": "Loopring",
-      "symbol": "LRC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/913/large/LRC.png?1696502034"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8290333cef9e6d528dd5618fb97a76f268f3edd4",
-      "name": "Ankr Network",
-      "symbol": "ANKR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1696504928"
-    },
-    {
-      "chainId": 1,
-      "address": "0x467719ad09025fcc6cf6f8311755809d45a5e5f3",
-      "name": "Axelar",
-      "symbol": "AXL",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg?1696526329"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3b50805453023a91a8bf641e279401a0b23fa6f9",
-      "name": "Renzo",
-      "symbol": "REZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37327/large/renzo_200x200.png?1714025012"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
-      "name": "Biconomy",
-      "symbol": "BICO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21061/large/biconomy_logo.jpg?1696520444"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf2b2f7b47715256ce4ea43363a867fdce9353e3a",
-      "name": "Bitgert",
-      "symbol": "BRISE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/17388/large/200x200.png?1696516937"
     },
     {
       "chainId": 1,
@@ -1228,19 +1172,35 @@
     },
     {
       "chainId": 1,
-      "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
-      "name": "Status",
-      "symbol": "SNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/779/large/status.png?1696501931"
+      "address": "0xf2b2f7b47715256ce4ea43363a867fdce9353e3a",
+      "name": "Bitgert",
+      "symbol": "BRISE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17388/large/200x200.png?1696516937"
     },
     {
       "chainId": 1,
-      "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
-      "name": "UMA",
-      "symbol": "UMA",
+      "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+      "name": "Loopring",
+      "symbol": "LRC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10951/large/UMA.png?1696510900"
+      "logoURI": "https://assets.coingecko.com/coins/images/913/large/LRC.png?1696502034"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
+      "name": "WOO",
+      "symbol": "WOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
+    },
+    {
+      "chainId": 1,
+      "address": "0x467719ad09025fcc6cf6f8311755809d45a5e5f3",
+      "name": "Axelar",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg?1696526329"
     },
     {
       "chainId": 1,
@@ -1252,94 +1212,6 @@
     },
     {
       "chainId": 1,
-      "address": "0x32353a6c91143bfd6c7d363b546e62a9a2489a20",
-      "name": "Adventure Gold",
-      "symbol": "AGLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18125/large/lpgblc4h_400x400.jpg?1696517628"
-    },
-    {
-      "chainId": 1,
-      "address": "0xddb3422497e61e13543bea06989c0789117555c5",
-      "name": "COTI",
-      "symbol": "COTI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2962/large/Coti.png?1696503705"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
-      "name": "Stargate Finance",
-      "symbol": "STG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
-    },
-    {
-      "chainId": 1,
-      "address": "0x61ec85ab89377db65762e234c946b5c25a56e99e",
-      "name": "HTX DAO",
-      "symbol": "HTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35491/large/Frame_1321318576.png?1708908626"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb23d80f5fefcddaa212212f028021b41ded428cf",
-      "name": "Echelon Prime",
-      "symbol": "PRIME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/prime-logo-small-border_%282%29.png?1696528020"
-    },
-    {
-      "chainId": 1,
-      "address": "0x38e68a37e401f7271568cecaac63c6b1e19130b4",
-      "name": "Banana Gun",
-      "symbol": "BANANA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31744/large/bg-logo-coingecko-200.png?1716971024"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
-      "name": "Frax Share",
-      "symbol": "FXS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1696513183"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba11d00c5f74255f56a5e366f4f77f5a186d7f55",
-      "name": "Band Protocol",
-      "symbol": "BAND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9545/large/Band_token_blue_violet_token.png?1696509627"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
-      "name": "Holo",
-      "symbol": "HOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3348/large/Holologo_Profile.png?1696504052"
-    },
-    {
-      "chainId": 1,
-      "address": "0x946fb08103b400d1c79e07acccdef5cfd26cd374",
-      "name": "KIP",
-      "symbol": "KIP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52585/large/200x200-kip.png?1733764030"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbf2179859fc6d5bee9bf9158632dc51678a4100e",
-      "name": "aelf",
-      "symbol": "ELF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1371/large/aelf-logo.png?1696502429"
-    },
-    {
-      "chainId": 1,
       "address": "0x6e15a54b5ecac17e58dadeddbe8506a7560252f9",
       "name": "SynFutures",
       "symbol": "F",
@@ -1348,43 +1220,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5",
-      "name": "Usual USD",
-      "symbol": "USD0",
+      "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+      "name": "UMA",
+      "symbol": "UMA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38272/large/USD0LOGO.png?1716962811"
-    },
-    {
-      "chainId": 1,
-      "address": "0x581911b360b6eb3a14ef295a83a91dc2bce2d6f7",
-      "name": "MileVerse",
-      "symbol": "MVC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13146/large/kXSdwuxD_400x400.jpg?1696512931"
-    },
-    {
-      "chainId": 1,
-      "address": "0x137ddb47ee24eaa998a535ab00378d6bfa84f893",
-      "name": "Radiant Capital",
-      "symbol": "RDNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
-      "name": "TrueFi",
-      "symbol": "TRU",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/13180/large/truefi_glyph_color.png?1696512963"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9e32b13ce7f2e80a01932b42553652e053d6ed8e",
-      "name": "Metis",
-      "symbol": "METIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15595/large/Metis_Black_Bg.png?1702968192"
+      "logoURI": "https://assets.coingecko.com/coins/images/10951/large/UMA.png?1696510900"
     },
     {
       "chainId": 1,
@@ -1396,11 +1236,107 @@
     },
     {
       "chainId": 1,
-      "address": "0xcc8fa225d80b9c7d42f96e9570156c65d6caaa25",
-      "name": "Smooth Love Potion",
-      "symbol": "SLP",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/10366/large/SLP.png?1696510368"
+      "address": "0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5",
+      "name": "Usual USD",
+      "symbol": "USD0",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38272/large/USD0LOGO.png?1716962811"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
+      "name": "Biconomy",
+      "symbol": "BICO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/large/biconomy_logo.jpg?1696520444"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
+      "name": "Stargate Finance",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
+    },
+    {
+      "chainId": 1,
+      "address": "0x946fb08103b400d1c79e07acccdef5cfd26cd374",
+      "name": "KIP",
+      "symbol": "KIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52585/large/200x200-kip.png?1733764030"
+    },
+    {
+      "chainId": 1,
+      "address": "0x581911b360b6eb3a14ef295a83a91dc2bce2d6f7",
+      "name": "MileVerse",
+      "symbol": "MVC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13146/large/kXSdwuxD_400x400.jpg?1696512931"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8290333cef9e6d528dd5618fb97a76f268f3edd4",
+      "name": "Ankr Network",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1696504928"
+    },
+    {
+      "chainId": 1,
+      "address": "0xddb3422497e61e13543bea06989c0789117555c5",
+      "name": "COTI",
+      "symbol": "COTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2962/large/Coti.png?1696503705"
+    },
+    {
+      "chainId": 1,
+      "address": "0x61ec85ab89377db65762e234c946b5c25a56e99e",
+      "name": "HTX DAO",
+      "symbol": "HTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35491/large/Frame_1321318576.png?1708908626"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba11d00c5f74255f56a5e366f4f77f5a186d7f55",
+      "name": "Band Protocol",
+      "symbol": "BAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9545/large/Band_token_blue_violet_token.png?1696509627"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+      "name": "Frax Share",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1696513183"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
+      "name": "Holo",
+      "symbol": "HOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3348/large/Holologo_Profile.png?1696504052"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbf2179859fc6d5bee9bf9158632dc51678a4100e",
+      "name": "aelf",
+      "symbol": "ELF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1371/large/aelf-logo.png?1696502429"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+      "name": "Gitcoin",
+      "symbol": "GTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15810/large/gitcoin.png?1696515429"
     },
     {
       "chainId": 1,
@@ -1412,11 +1348,43 @@
     },
     {
       "chainId": 1,
+      "address": "0x38e68a37e401f7271568cecaac63c6b1e19130b4",
+      "name": "Banana Gun",
+      "symbol": "BANANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31744/large/bg-logo-coingecko-200.png?1716971024"
+    },
+    {
+      "chainId": 1,
       "address": "0xf4d2888d29d722226fafa5d9b24f9164c092421e",
       "name": "LooksRare",
       "symbol": "LOOKS",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/22173/large/circle-black-256.png?1696521517"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3b50805453023a91a8bf641e279401a0b23fa6f9",
+      "name": "Renzo",
+      "symbol": "REZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37327/large/renzo_200x200.png?1714025012"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
+      "name": "TrueFi",
+      "symbol": "TRU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13180/large/truefi_glyph_color.png?1696512963"
+    },
+    {
+      "chainId": 1,
+      "address": "0x137ddb47ee24eaa998a535ab00378d6bfa84f893",
+      "name": "Radiant Capital",
+      "symbol": "RDNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
     },
     {
       "chainId": 1,
@@ -1428,11 +1396,27 @@
     },
     {
       "chainId": 1,
-      "address": "0x8de5b80a0c1b02fe4976851d030b36122dbb8624",
-      "name": "Vanar Chain",
-      "symbol": "VANRY",
+      "address": "0xdefa4e8a7bcba345f687a2f1456f5edd9ce97202",
+      "name": "Kyber Network Crystal",
+      "symbol": "KNC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+      "logoURI": "https://assets.coingecko.com/coins/images/14899/large/RwdVsGcw_400x400.jpg?1696514562"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcc8fa225d80b9c7d42f96e9570156c65d6caaa25",
+      "name": "Smooth Love Potion",
+      "symbol": "SLP",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/10366/large/SLP.png?1696510368"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd19b72e027cd66bde41d8f60a13740a26c4be8f3",
+      "name": "SUI Agents",
+      "symbol": "SUIAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52545/large/200x200.jpg?1733588339"
     },
     {
       "chainId": 1,
@@ -1444,11 +1428,51 @@
     },
     {
       "chainId": 1,
+      "address": "0x32353a6c91143bfd6c7d363b546e62a9a2489a20",
+      "name": "Adventure Gold",
+      "symbol": "AGLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18125/large/lpgblc4h_400x400.jpg?1696517628"
+    },
+    {
+      "chainId": 1,
       "address": "0x814e0908b12a99fecf5bc101bb5d0b8b5cdf7d26",
       "name": "Measurable Data",
       "symbol": "MDT",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/2441/large/mdt_icon_120x120.png?1711452723"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1cf4592ebffd730c7dc92c1bdffdfc3b9efcf29a",
+      "name": "Waves",
+      "symbol": "WAVES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/425/large/waves.png?1696501700"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb23d80f5fefcddaa212212f028021b41ded428cf",
+      "name": "Echelon Prime",
+      "symbol": "PRIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/prime-logo-small-border_%282%29.png?1696528020"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9e32b13ce7f2e80a01932b42553652e053d6ed8e",
+      "name": "Metis",
+      "symbol": "METIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15595/large/Metis_Black_Bg.png?1702968192"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7a56e1c57c7475ccf742a1832b028f0456652f97",
+      "name": "Solv Protocol SolvBTC",
+      "symbol": "SOLVBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36800/large/solvBTC.png?1719810684"
     },
     {
       "chainId": 1,
@@ -1460,6 +1484,30 @@
     },
     {
       "chainId": 1,
+      "address": "0xef3a930e1ffffacd2fc13434ac81bd278b0ecc8d",
+      "name": "Stafi",
+      "symbol": "FIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12423/large/FIS.png?1696512244"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb7109df1a93f8fe2b8162c6207c9b846c1c68090",
+      "name": "Matr1x",
+      "symbol": "MAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39481/large/t05.png?1722465175"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8de5b80a0c1b02fe4976851d030b36122dbb8624",
+      "name": "Vanar Chain",
+      "symbol": "VANRY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+    },
+    {
+      "chainId": 1,
       "address": "0x4507cef57c46789ef8d1a19ea45f4216bae2b528",
       "name": "TokenFi",
       "symbol": "TOKEN",
@@ -1468,19 +1516,27 @@
     },
     {
       "chainId": 1,
-      "address": "0xdefa4e8a7bcba345f687a2f1456f5edd9ce97202",
-      "name": "Kyber Network Crystal",
-      "symbol": "KNC",
+      "address": "0xd0a6053f087e87a25dc60701ba6e663b1a548e85",
+      "name": "BLOCKLORDS",
+      "symbol": "LRDS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14899/large/RwdVsGcw_400x400.jpg?1696514562"
+      "logoURI": "https://assets.coingecko.com/coins/images/34775/large/LRDS_PNG.png?1706001771"
     },
     {
       "chainId": 1,
-      "address": "0xef3a930e1ffffacd2fc13434ac81bd278b0ecc8d",
-      "name": "Stafi",
-      "symbol": "FIS",
+      "address": "0x157a6df6b74f4e5e45af4e4615fde7b49225a662",
+      "name": "ISLAND Token",
+      "symbol": "ISLAND",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12423/large/FIS.png?1696512244"
+      "logoURI": "https://assets.coingecko.com/coins/images/52797/large/ISLAND_200x200.jpg?1734330930"
+    },
+    {
+      "chainId": 1,
+      "address": "0xac51066d7bec65dc4589368da368b212745d63e8",
+      "name": "My Neighbor Alice",
+      "symbol": "ALICE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14375/large/alice_logo.jpg?1696514067"
     },
     {
       "chainId": 1,
@@ -1500,643 +1556,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x7da2641000cbb407c329310c461b2cb9c70c3046",
-      "name": "Delysium",
-      "symbol": "AGI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29299/large/AGI_logo_200.png?1696528251"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb7109df1a93f8fe2b8162c6207c9b846c1c68090",
-      "name": "Matr1x",
-      "symbol": "MAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39481/large/t05.png?1722465175"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd5f7838f5c461feff7fe49ea5ebaf7728bb0adfa",
-      "name": "Mantle Staked Ether",
-      "symbol": "METH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33345/large/symbol_transparent_bg.png?1701697066"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7a56e1c57c7475ccf742a1832b028f0456652f97",
-      "name": "Solv Protocol SolvBTC",
-      "symbol": "SOLVBTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36800/large/solvBTC.png?1719810684"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
-      "name": "Rocket Pool",
-      "symbol": "RPL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc52c326331e9ce41f04484d3b5e5648158028804",
-      "name": "Unizen",
-      "symbol": "ZCX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14830/large/logo128px.png?1700169101"
-    },
-    {
-      "chainId": 1,
-      "address": "0xac51066d7bec65dc4589368da368b212745d63e8",
-      "name": "My Neighbor Alice",
-      "symbol": "ALICE",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/14375/large/alice_logo.jpg?1696514067"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd0a6053f087e87a25dc60701ba6e663b1a548e85",
-      "name": "BLOCKLORDS",
-      "symbol": "LRDS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34775/large/LRDS_PNG.png?1706001771"
-    },
-    {
-      "chainId": 1,
-      "address": "0xadf7c35560035944e805d98ff17d58cde2449389",
-      "name": "Spectral",
-      "symbol": "SPEC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36138/large/ls7wS7vf_400x400.jpg?1724975224"
-    },
-    {
-      "chainId": 1,
-      "address": "0x55296f69f40ea6d20e478533c15a6b08b654e758",
-      "name": "XYO Network",
-      "symbol": "XYO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4519/large/XYO_Network-logo.png?1696505103"
-    },
-    {
-      "chainId": 1,
       "address": "0xabd4c63d2616a5201454168269031355f4764337",
       "name": "Orderly Network",
       "symbol": "ORDER",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/38501/large/Orderly_Network_Coingecko_200*200.png?1717751359"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd19b72e027cd66bde41d8f60a13740a26c4be8f3",
-      "name": "SUI Agents",
-      "symbol": "SUIAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52545/large/200x200.jpg?1733588339"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
-      "name": "Wrapped eETH",
-      "symbol": "WEETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
-    },
-    {
-      "chainId": 1,
-      "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
-      "name": "OKB",
-      "symbol": "OKB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4463/large/WeChat_Image_20220118095654.png?1696505053"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
-      "name": "Badger",
-      "symbol": "BADGER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1696513059"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba100000625a3754423978a60c9317c58a424e3d",
-      "name": "Balancer",
-      "symbol": "BAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
-      "name": "IDEX",
-      "symbol": "IDEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2565/large/idexlogo.png?1696503371"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
-      "name": "API3",
-      "symbol": "API3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13256/large/api3.jpg?1696513031"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa3ee21c306a700e682abcdfe9baa6a08f3820419",
-      "name": "Creditcoin",
-      "symbol": "CTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10569/large/ctc.png?1696510552"
-    },
-    {
-      "chainId": 1,
-      "address": "0x157a6df6b74f4e5e45af4e4615fde7b49225a662",
-      "name": "ISLAND Token",
-      "symbol": "ISLAND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52797/large/ISLAND_200x200.jpg?1734330930"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
-      "name": "Solar",
-      "symbol": "SXP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9368/large/swipe.png?1696509466"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdbb7a34bf10169d6d2d0d02a6cbb436cf4381bfa",
-      "name": "Zentry",
-      "symbol": "ZENT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36979/large/Zentry-rebrand-Primary_200px.png?1713743277"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0f3a12b78fee11ee088e454a0547bdbc5a253a6d",
-      "name": "Merlin Chain",
-      "symbol": "MERL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37118/large/merlin.jpeg?1713352230"
-    },
-    {
-      "chainId": 1,
-      "address": "0x66761fa41377003622aee3c7675fc7b5c1c2fac5",
-      "name": "Clearpool",
-      "symbol": "CPOOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19252/large/photo_2022-08-31_12.45.02.jpeg?1696518697"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
-      "name": "Perpetual Protocol",
-      "symbol": "PERP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
-    },
-    {
-      "chainId": 1,
-      "address": "0x491604c0fdf08347dd1fa4ee062a822a5dd06b5d",
-      "name": "Cartesi",
-      "symbol": "CTSI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
-    },
-    {
-      "chainId": 1,
-      "address": "0x57b946008913b82e4df85f501cbaed910e58d26c",
-      "name": "Marlin",
-      "symbol": "POND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8903/large/200x200.png?1706115827"
-    },
-    {
-      "chainId": 1,
-      "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
-      "name": "Audius",
-      "symbol": "AUDIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12913/large/AudiusCoinLogo_2x.png?1696512701"
-    },
-    {
-      "chainId": 1,
-      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
-      "name": "Telos",
-      "symbol": "TLOS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7588/large/tlos_png.png?1722391289"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaaaaaa20d9e0e2461697782ef11675f668207961",
-      "name": "Aurora",
-      "symbol": "AURORA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20582/large/aurora.jpeg?1696519989"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe7c6bf469e97eeb0bfb74c8dbff5bd47d4c1c98a",
-      "name": "HashKey Platform Token",
-      "symbol": "HSK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29779/large/HSKlogo.jpg?1719445510"
-    },
-    {
-      "chainId": 1,
-      "address": "0xec12ba5ac0f259e9ac6fc9a3bc23a76ad2fde5d9",
-      "name": "HugeWin",
-      "symbol": "HUGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35923/large/2024-03-01_17.49.27_%281%29.png?1710221459"
-    },
-    {
-      "chainId": 1,
-      "address": "0x940a2db1b7008b6c776d4faaca729d6d4a4aa551",
-      "name": "DUSK",
-      "symbol": "DUSK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5217/large/image_widget_biddfvxd454b1.png?1696505726"
-    },
-    {
-      "chainId": 1,
-      "address": "0x081131434f93063751813c619ecca9c4dc7862a3",
-      "name": "Mines of Dalarnia",
-      "symbol": "DAR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/19837/large/dar.png?1696519259"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa1faa113cbe53436df28ff0aee54275c13b40975",
-      "name": "Stella",
-      "symbol": "ALPHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12738/large/Stella200x200-06.png?1696512537"
-    },
-    {
-      "chainId": 1,
-      "address": "0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419",
-      "name": "DIA",
-      "symbol": "DIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11955/large/Token_Logo.png?1696511815"
-    },
-    {
-      "chainId": 1,
-      "address": "0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110",
-      "name": "Resolv USR",
-      "symbol": "USR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40008/large/USR_LOGO.png?1725222638"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa62cc35625b0c8dc1faea39d33625bb4c15bd71c",
-      "name": "StormX",
-      "symbol": "STMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1369/large/StormX.png?1696502427"
-    },
-    {
-      "chainId": 1,
-      "address": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd",
-      "name": "DODO",
-      "symbol": "DODO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12651/large/dodo_logo.png?1696512458"
-    },
-    {
-      "chainId": 1,
-      "address": "0x91af0fbb28aba7e31403cb457106ce79397fd4e6",
-      "name": "Aergo",
-      "symbol": "AERGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4490/large/aergo.png?1696505079"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0d3cbed3f69ee050668adf3d9ea57241cba33a2b",
-      "name": "PlayDapp",
-      "symbol": "PDA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14316/large/PDA-symbol.png?1710234068"
-    },
-    {
-      "chainId": 1,
-      "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
-      "name": "Radworks",
-      "symbol": "RAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14013/large/radicle.png?1696513741"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa2e3356610840701bdf5611a53974510ae27e2e1",
-      "name": "Wrapped Beacon ETH",
-      "symbol": "WBETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30061/large/wbeth-icon.png?1696528983"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd433138d12beb9929ff6fd583dc83663eea6aaa5",
-      "name": "Bitrue Coin",
-      "symbol": "BTR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8873/large/Bittrue_logo.png?1696509025"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf411903cbc70a74d22900a5de66a2dda66507255",
-      "name": "Verasity",
-      "symbol": "VRA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14025/large/logo_%281%29.png?1716968890"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
-      "name": "Gnosis",
-      "symbol": "GNO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/662/large/logo_square_simple_300px.png?1696501854"
-    },
-    {
-      "chainId": 1,
-      "address": "0x430ef9263e76dae63c84292c3409d61c598e9682",
-      "name": "Vulcan Forged",
-      "symbol": "PYR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14770/large/1617088937196.png?1696514439"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb3999f658c0391d94a37f7ff328f3fec942bcadc",
-      "name": "Hashflow",
-      "symbol": "HFT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26136/large/200x200_360.png?1728551257"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3e5a19c91266ad8ce2477b91585d1856b84062df",
-      "name": "Ancient8",
-      "symbol": "A8",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39170/large/A8_Token-04_200x200.png?1720798300"
-    },
-    {
-      "chainId": 1,
-      "address": "0x595832f8fc6bf59c85c527fec3740a1b7a361269",
-      "name": "Powerledger",
-      "symbol": "POWR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/1104/large/Powerledger_Northstar_colour_digital_%282%29.png?1706702222"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
-      "name": "Alchemix",
-      "symbol": "ALCX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14113/large/Alchemix.png?1696513834"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
-      "name": "Coinbase Wrapped Staked ETH",
-      "symbol": "CBETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1709186989"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
-      "name": "Bluzelle",
-      "symbol": "BLZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2848/large/ColorIcon_3x.png?1696503607"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e",
-      "name": "crvUSD",
-      "symbol": "CRVUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30118/large/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba50933c268f567bdc86e1ac131be072c6b0b71a",
-      "name": "ARPA",
-      "symbol": "ARPA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8506/large/9u0a23XY_400x400.jpg?1696508685"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
-      "name": "Celer Network",
-      "symbol": "CELR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4379/large/Celr.png?1696504978"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd29da236dd4aac627346e1bba06a619e8c22d7c5",
-      "name": "MAGA Hat",
-      "symbol": "MAGA",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37988/large/MAGA200.jpg?1716223291"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc71b5f631354be6853efe9c3ab6b9590f8302e81",
-      "name": "Polyhedra Network",
-      "symbol": "ZKJ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36198/large/ZK.jpg?1710812518"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3da932456d082cba208feb0b096d49b202bf89c8",
-      "name": "Dego Finance",
-      "symbol": "DEGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12503/large/Token.png?1733381203"
-    },
-    {
-      "chainId": 1,
-      "address": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
-      "name": "AUSD",
-      "symbol": "AUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39284/large/Circle_Agora_White_on_Olive_1080px.png?1722961274"
-    },
-    {
-      "chainId": 1,
-      "address": "0x26aad156ba8efa501b32b42ffcdc8413f90e9c99",
-      "name": "Open Campus",
-      "symbol": "EDU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29948/large/EDU_Logo.png?1696528874"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9e46a38f5daabe8683e10793b06749eef7d733d1",
-      "name": "PolySwarm",
-      "symbol": "NCT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2843/large/ImcYCVfX_400x400.jpg?1696503602"
-    },
-    {
-      "chainId": 1,
-      "address": "0x090185f2135308bad17527004364ebcc2d37e5f6",
-      "name": "Spell",
-      "symbol": "SPELL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15861/large/abracadabra-3.png?1696515477"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2a79324c19ef2b89ea98b23bc669b7e7c9f8a517",
-      "name": "WAX",
-      "symbol": "WAXP",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/1372/large/WAX_Coin_Tickers_P_512px.png?1696502430"
-    },
-    {
-      "chainId": 1,
-      "address": "0x1cf4592ebffd730c7dc92c1bdffdfc3b9efcf29a",
-      "name": "Waves",
-      "symbol": "WAVES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/425/large/waves.png?1696501700"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7448c7456a97769f6cd04f1e83a4a23ccdc46abd",
-      "name": "Maverick Protocol",
-      "symbol": "MAV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30850/large/MAV_Logo.png?1696529701"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd795eb12034c2b77d787a22292c26fab5f5c70aa",
-      "name": "Pixelverse",
-      "symbol": "PIXFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38279/large/pixelverse_logo.png?1716993023"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7ddc52c4de30e94be3a6a0a2b259b2850f421989",
-      "name": "GoMining Token",
-      "symbol": "GOMINING",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15662/large/GoMining_Logo.png?1714757256"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
-      "name": "Linear",
-      "symbol": "LINA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12509/large/1649227343-linalogo200px.png?1696512324"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd3cc9d8f3689b83c91b7b59cab4946b063eb894a",
-      "name": "Venus",
-      "symbol": "XVS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
-    },
-    {
-      "chainId": 1,
-      "address": "0x03dde9e5bb31ee40a471476e2fccf75c67921062",
-      "name": "EML Protocol",
-      "symbol": "EML",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30950/large/EML_LOGO.png?1696529788"
-    },
-    {
-      "chainId": 1,
-      "address": "0x71ab77b7dbb4fa7e017bc15090b2163221420282",
-      "name": "Highstreet",
-      "symbol": "HIGH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18973/large/logosq200200Coingecko.png?1696518427"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4b5f49487ea7b3609b1ad05459be420548789f1f",
-      "name": "LeverFi",
-      "symbol": "LEVER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26205/large/WI72SpBl_400x400.jpeg?1696525291"
-    },
-    {
-      "chainId": 1,
-      "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
-      "name": "tBTC",
-      "symbol": "TBTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
-      "name": "Kaon",
-      "symbol": "AKRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3328/large/kaon.jpg?1730712283"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
-      "name": "Origin Token",
-      "symbol": "OGN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3296/large/op.jpg?1696504006"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5e8422345238f34275888049021821e8e08caa1f",
-      "name": "Frax Ether",
-      "symbol": "FRXETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28284/large/frxETH_icon.png?1696527284"
-    },
-    {
-      "chainId": 1,
-      "address": "0x80c62fe4487e1351b47ba49809ebd60ed085bf52",
-      "name": "Clover Finance",
-      "symbol": "CLV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15278/large/CLV_-_Circle_Logo_-_Only_Icon_1_%281%29.png?1734037808"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3010ccb5419f1ef26d40a7cd3f0d707a0fa127dc",
-      "name": "Gems VIP",
-      "symbol": "GEMS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38725/large/200x200.png?1718478016"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe6829d9a7ee3040e1276fa75293bde931859e8fa",
-      "name": "Mantle Restaked ETH",
-      "symbol": "CMETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51114/large/symbol.png?1730117724"
     },
     {
       "chainId": 1,
@@ -2148,195 +1572,179 @@
     },
     {
       "chainId": 1,
-      "address": "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
-      "name": "NEXO",
-      "symbol": "NEXO",
+      "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+      "name": "Badger",
+      "symbol": "BADGER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3695/large/CG-nexo-token-200x200_2x.png?1730414360"
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1696513059"
     },
     {
       "chainId": 1,
-      "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
-      "name": "Polygon",
-      "symbol": "MATIC",
+      "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
+      "name": "IDEX",
+      "symbol": "IDEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4713/large/polygon.png?1698233745"
+      "logoURI": "https://assets.coingecko.com/coins/images/2565/large/idexlogo.png?1696503371"
     },
     {
       "chainId": 1,
-      "address": "0x33349b282065b0284d756f0577fb39c158f935e6",
-      "name": "Maple",
-      "symbol": "MPL",
+      "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+      "name": "Balancer",
+      "symbol": "BAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14097/large/Maple_Logo_Mark_Maple_Orange.png?1696513819"
+      "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
     },
     {
       "chainId": 1,
-      "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
-      "name": "Dent",
-      "symbol": "DENT",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/1152/large/DENT_Token.png?1718837065"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd31a59c85ae9d8edefec411d448f90841571b89c",
-      "name": "SOL  Wormhole ",
-      "symbol": "SOL",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/22876/large/SOL_wh_small.png?1696522175"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5cf04716ba20127f1e2297addcf4b5035000c9eb",
-      "name": "NKN",
-      "symbol": "NKN",
+      "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+      "name": "Rocket Pool",
+      "symbol": "RPL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3375/large/nkn.png?1696504074"
+      "logoURI": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
     },
     {
       "chainId": 1,
-      "address": "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
-      "name": "Synapse",
-      "symbol": "SYN",
+      "address": "0x9e46a38f5daabe8683e10793b06749eef7d733d1",
+      "name": "PolySwarm",
+      "symbol": "NCT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18024/large/synapse_social_icon.png?1696517540"
+      "logoURI": "https://assets.coingecko.com/coins/images/2843/large/ImcYCVfX_400x400.jpg?1696503602"
     },
     {
       "chainId": 1,
-      "address": "0x643c4e15d7d62ad0abec4a9bd4b001aa3ef52d66",
-      "name": "Syrup",
-      "symbol": "SYRUP",
+      "address": "0x55296f69f40ea6d20e478533c15a6b08b654e758",
+      "name": "XYO Network",
+      "symbol": "XYO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51232/large/IMG_7420.png?1730831572"
+      "logoURI": "https://assets.coingecko.com/coins/images/4519/large/XYO_Network-logo.png?1696505103"
     },
     {
       "chainId": 1,
-      "address": "0x4575f41308ec1483f3d399aa9a2826d74da13deb",
-      "name": "Orchid Protocol",
-      "symbol": "OXT",
+      "address": "0xd5f7838f5c461feff7fe49ea5ebaf7728bb0adfa",
+      "name": "Mantle Staked Ether",
+      "symbol": "METH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3916/large/download_%285%29.png?1696504574"
+      "logoURI": "https://assets.coingecko.com/coins/images/33345/large/symbol_transparent_bg.png?1701697066"
     },
     {
       "chainId": 1,
-      "address": "0xec67005c4e498ec7f55e092bd1d35cbc47c91892",
-      "name": "Enzyme",
-      "symbol": "MLN",
+      "address": "0xe77f6acd24185e149e329c1c0f479201b9ec2f4b",
+      "name": "Zeebu",
+      "symbol": "ZBU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/605/large/Enzyme_Icon_Secondary.png?1696501803"
+      "logoURI": "https://assets.coingecko.com/coins/images/31145/large/200x200_Front_token.png?1696529974"
     },
     {
       "chainId": 1,
-      "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
-      "name": "Numeraire",
-      "symbol": "NMR",
+      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
+      "name": "Telos",
+      "symbol": "TLOS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/752/large/numeraire.png?1696501906"
+      "logoURI": "https://assets.coingecko.com/coins/images/7588/large/tlos_png.png?1722391289"
     },
     {
       "chainId": 1,
-      "address": "0x0fd10b9899882a6f2fcb5c371e17e70fdee00c38",
-      "name": "Pundi X",
-      "symbol": "PUNDIX",
+      "address": "0x0f3a12b78fee11ee088e454a0547bdbc5a253a6d",
+      "name": "Merlin Chain",
+      "symbol": "MERL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14571/large/vDyefsXq_400x400.jpg?1696514252"
+      "logoURI": "https://assets.coingecko.com/coins/images/37118/large/merlin.jpeg?1713352230"
     },
     {
       "chainId": 1,
-      "address": "0xe66747a101bff2dba3697199dcce5b743b454759",
-      "name": "Gate",
-      "symbol": "GT",
+      "address": "0xadf7c35560035944e805d98ff17d58cde2449389",
+      "name": "Spectral",
+      "symbol": "SPEC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8183/large/gate.png?1696508395"
+      "logoURI": "https://assets.coingecko.com/coins/images/36138/large/ls7wS7vf_400x400.jpg?1724975224"
     },
     {
       "chainId": 1,
-      "address": "0xd26114cd6ee289accf82350c8d8487fedb8a0c07",
-      "name": "OMG Network",
-      "symbol": "OMG",
+      "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
+      "name": "Solar",
+      "symbol": "SXP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/776/large/OMG_Network.jpg?1696501928"
+      "logoURI": "https://assets.coingecko.com/coins/images/9368/large/swipe.png?1696509466"
     },
     {
       "chainId": 1,
-      "address": "0xee2a03aa6dacf51c18679c516ad5283d8e7c2637",
-      "name": "Neiro on ETH",
-      "symbol": "NEIRO",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/39438/large/Neiro.png?1722915026"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
-      "name": "USDS",
-      "symbol": "USDS",
+      "address": "0xaaaaaa20d9e0e2461697782ef11675f668207961",
+      "name": "Aurora",
+      "symbol": "AURORA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
+      "logoURI": "https://assets.coingecko.com/coins/images/20582/large/aurora.jpeg?1696519989"
     },
     {
       "chainId": 1,
-      "address": "0x3be7bf1a5f23bd8336787d0289b70602f1940875",
-      "name": "VIDT DAO",
-      "symbol": "VIDT",
+      "address": "0xec12ba5ac0f259e9ac6fc9a3bc23a76ad2fde5d9",
+      "name": "HugeWin",
+      "symbol": "HUGE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27552/large/VIDTDAO_logo.png?1696526588"
+      "logoURI": "https://assets.coingecko.com/coins/images/35923/large/2024-03-01_17.49.27_%281%29.png?1710221459"
     },
     {
       "chainId": 1,
-      "address": "0x79f05c263055ba20ee0e814acd117c20caa10e0c",
-      "name": "Ice Open Network",
-      "symbol": "ICE",
+      "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
+      "name": "API3",
+      "symbol": "API3",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34674/large/ion-coingecko-200w.png?1714009819"
+      "logoURI": "https://assets.coingecko.com/coins/images/13256/large/api3.jpg?1696513031"
     },
     {
       "chainId": 1,
-      "address": "0x944824290cc12f31ae18ef51216a223ba4063092",
-      "name": "Masa",
-      "symbol": "MASA",
+      "address": "0x57b946008913b82e4df85f501cbaed910e58d26c",
+      "name": "Marlin",
+      "symbol": "POND",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35538/large/masa.png?1712635899"
+      "logoURI": "https://assets.coingecko.com/coins/images/8903/large/200x200.png?1706115827"
     },
     {
       "chainId": 1,
-      "address": "0x77fba179c79de5b7653f68b5039af940ada60ce0",
-      "name": "Ampleforth Governance",
-      "symbol": "FORTH",
+      "address": "0x491604c0fdf08347dd1fa4ee062a822a5dd06b5d",
+      "name": "Cartesi",
+      "symbol": "CTSI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14917/large/photo_2021-04-22_00.00.03.jpeg?1696514579"
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
     },
     {
       "chainId": 1,
-      "address": "0x6c5ba91642f10282b576d91922ae6448c9d52f4e",
-      "name": "PHALA",
-      "symbol": "PHA",
+      "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+      "name": "Perpetual Protocol",
+      "symbol": "PERP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12451/large/phala.png?1696512270"
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
     },
     {
       "chainId": 1,
-      "address": "0x579cea1889991f68acc35ff5c3dd0621ff29b0c9",
-      "name": "IQ",
-      "symbol": "IQ",
+      "address": "0xdbb7a34bf10169d6d2d0d02a6cbb436cf4381bfa",
+      "name": "Zentry",
+      "symbol": "ZENT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5010/large/YAIS3fUh.png?1696505542"
+      "logoURI": "https://assets.coingecko.com/coins/images/36979/large/Zentry-rebrand-Primary_200px.png?1713743277"
     },
     {
       "chainId": 1,
-      "address": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
-      "name": "Stader",
-      "symbol": "SD",
+      "address": "0xe7c6bf469e97eeb0bfb74c8dbff5bd47d4c1c98a",
+      "name": "HashKey Platform Token",
+      "symbol": "HSK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20658/large/SD_Token_Logo.png?1696520060"
+      "logoURI": "https://assets.coingecko.com/coins/images/29779/large/HSKlogo.jpg?1719445510"
     },
     {
       "chainId": 1,
-      "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
-      "name": "iExec RLC",
-      "symbol": "RLC",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/646/large/pL1VuXm.png?1696501840"
+      "address": "0xc52c326331e9ce41f04484d3b5e5648158028804",
+      "name": "Unizen",
+      "symbol": "ZCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14830/large/logo128px.png?1700169101"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
+      "name": "Wrapped eETH",
+      "symbol": "WEETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
     },
     {
       "chainId": 1,
@@ -2348,35 +1756,235 @@
     },
     {
       "chainId": 1,
-      "address": "0x168e209d7b2f58f1f24b8ae7b7d35e662bbf11cc",
-      "name": "LayerAI",
-      "symbol": "LAI",
+      "address": "0x3e5a19c91266ad8ce2477b91585d1856b84062df",
+      "name": "Ancient8",
+      "symbol": "A8",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29223/large/Favicon_200x200px.png?1696528181"
+      "logoURI": "https://assets.coingecko.com/coins/images/39170/large/A8_Token-04_200x200.png?1720798300"
     },
     {
       "chainId": 1,
-      "address": "0x67466be17df832165f8c80a5a120ccc652bd7e69",
-      "name": "LandWolf",
-      "symbol": "WOLF",
+      "address": "0x66761fa41377003622aee3c7675fc7b5c1c2fac5",
+      "name": "Clearpool",
+      "symbol": "CPOOL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37403/large/wolf_200x200.png?1715222165"
+      "logoURI": "https://assets.coingecko.com/coins/images/19252/large/photo_2022-08-31_12.45.02.jpeg?1696518697"
     },
     {
       "chainId": 1,
-      "address": "0x8642a849d0dcb7a15a974794668adcfbe4794b56",
-      "name": "Prosper",
-      "symbol": "PROS",
+      "address": "0xb3999f658c0391d94a37f7ff328f3fec942bcadc",
+      "name": "Hashflow",
+      "symbol": "HFT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13668/large/PFP_Visual_CG.png?1727714135"
+      "logoURI": "https://assets.coingecko.com/coins/images/26136/large/200x200_360.png?1728551257"
     },
     {
       "chainId": 1,
-      "address": "0x9ce84f6a69986a83d92c324df10bc8e64771030f",
-      "name": "CHEX Token",
-      "symbol": "CHEX",
+      "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+      "name": "Audius",
+      "symbol": "AUDIO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10349/large/logo-white-bg-dark.png?1733475849"
+      "logoURI": "https://assets.coingecko.com/coins/images/12913/large/AudiusCoinLogo_2x.png?1696512701"
+    },
+    {
+      "chainId": 1,
+      "address": "0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110",
+      "name": "Resolv USR",
+      "symbol": "USR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40008/large/USR_LOGO.png?1725222638"
+    },
+    {
+      "chainId": 1,
+      "address": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd",
+      "name": "DODO",
+      "symbol": "DODO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12651/large/dodo_logo.png?1696512458"
+    },
+    {
+      "chainId": 1,
+      "address": "0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419",
+      "name": "DIA",
+      "symbol": "DIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11955/large/Token_Logo.png?1696511815"
+    },
+    {
+      "chainId": 1,
+      "address": "0x430ef9263e76dae63c84292c3409d61c598e9682",
+      "name": "Vulcan Forged",
+      "symbol": "PYR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14770/large/1617088937196.png?1696514439"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd433138d12beb9929ff6fd583dc83663eea6aaa5",
+      "name": "Bitrue Coin",
+      "symbol": "BTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8873/large/Bittrue_logo.png?1696509025"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+      "name": "Gnosis",
+      "symbol": "GNO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/662/large/logo_square_simple_300px.png?1696501854"
+    },
+    {
+      "chainId": 1,
+      "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
+      "name": "Radworks",
+      "symbol": "RAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14013/large/radicle.png?1696513741"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf411903cbc70a74d22900a5de66a2dda66507255",
+      "name": "Verasity",
+      "symbol": "VRA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14025/large/logo_%281%29.png?1716968890"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc71b5f631354be6853efe9c3ab6b9590f8302e81",
+      "name": "Polyhedra Network",
+      "symbol": "ZKJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36198/large/ZK.jpg?1710812518"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa1faa113cbe53436df28ff0aee54275c13b40975",
+      "name": "Stella",
+      "symbol": "ALPHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12738/large/Stella200x200-06.png?1696512537"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+      "name": "Alchemix",
+      "symbol": "ALCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14113/large/Alchemix.png?1696513834"
+    },
+    {
+      "chainId": 1,
+      "address": "0x081131434f93063751813c619ecca9c4dc7862a3",
+      "name": "Mines of Dalarnia",
+      "symbol": "DAR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/19837/large/dar.png?1696519259"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
+      "name": "Bluzelle",
+      "symbol": "BLZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2848/large/ColorIcon_3x.png?1696503607"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
+      "name": "Coinbase Wrapped Staked ETH",
+      "symbol": "CBETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1709186989"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd29da236dd4aac627346e1bba06a619e8c22d7c5",
+      "name": "MAGA Hat",
+      "symbol": "MAGA",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37988/large/MAGA200.jpg?1716223291"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa62cc35625b0c8dc1faea39d33625bb4c15bd71c",
+      "name": "StormX",
+      "symbol": "STMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1369/large/StormX.png?1696502427"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e",
+      "name": "crvUSD",
+      "symbol": "CRVUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30118/large/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e.png?1721097561"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3010ccb5419f1ef26d40a7cd3f0d707a0fa127dc",
+      "name": "Gems VIP",
+      "symbol": "GEMS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38725/large/200x200.png?1718478016"
+    },
+    {
+      "chainId": 1,
+      "address": "0x26aad156ba8efa501b32b42ffcdc8413f90e9c99",
+      "name": "Open Campus",
+      "symbol": "EDU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29948/large/EDU_Logo.png?1696528874"
+    },
+    {
+      "chainId": 1,
+      "address": "0x940a2db1b7008b6c776d4faaca729d6d4a4aa551",
+      "name": "DUSK",
+      "symbol": "DUSK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5217/large/image_widget_biddfvxd454b1.png?1696505726"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0d3cbed3f69ee050668adf3d9ea57241cba33a2b",
+      "name": "PlayDapp",
+      "symbol": "PDA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14316/large/PDA-symbol.png?1710234068"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77fba179c79de5b7653f68b5039af940ada60ce0",
+      "name": "Ampleforth Governance",
+      "symbol": "FORTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14917/large/photo_2021-04-22_00.00.03.jpeg?1696514579"
+    },
+    {
+      "chainId": 1,
+      "address": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
+      "name": "AUSD",
+      "symbol": "AUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39284/large/Circle_Agora_White_on_Olive_1080px.png?1722961274"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7ddc52c4de30e94be3a6a0a2b259b2850f421989",
+      "name": "GoMining Token",
+      "symbol": "GOMINING",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15662/large/GoMining_Logo.png?1714757256"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd795eb12034c2b77d787a22292c26fab5f5c70aa",
+      "name": "Pixelverse",
+      "symbol": "PIXFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38279/large/pixelverse_logo.png?1716993023"
     },
     {
       "chainId": 1,
@@ -2388,11 +1996,395 @@
     },
     {
       "chainId": 1,
+      "address": "0x4b5f49487ea7b3609b1ad05459be420548789f1f",
+      "name": "LeverFi",
+      "symbol": "LEVER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26205/large/WI72SpBl_400x400.jpeg?1696525291"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
+      "name": "Linear",
+      "symbol": "LINA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12509/large/1649227343-linalogo200px.png?1696512324"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
+      "name": "Kaon",
+      "symbol": "AKRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3328/large/kaon.jpg?1730712283"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7448c7456a97769f6cd04f1e83a4a23ccdc46abd",
+      "name": "Maverick Protocol",
+      "symbol": "MAV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30850/large/MAV_Logo.png?1696529701"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba50933c268f567bdc86e1ac131be072c6b0b71a",
+      "name": "ARPA",
+      "symbol": "ARPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8506/large/9u0a23XY_400x400.jpg?1696508685"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd3cc9d8f3689b83c91b7b59cab4946b063eb894a",
+      "name": "Venus",
+      "symbol": "XVS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a79324c19ef2b89ea98b23bc669b7e7c9f8a517",
+      "name": "WAX",
+      "symbol": "WAXP",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/1372/large/WAX_Coin_Tickers_P_512px.png?1696502430"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd31a59c85ae9d8edefec411d448f90841571b89c",
+      "name": "SOL  Wormhole ",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/large/SOL_wh_small.png?1696522175"
+    },
+    {
+      "chainId": 1,
+      "address": "0x825459139c897d769339f295e962396c4f9e4a4d",
+      "name": "GameBuild",
+      "symbol": "GAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37789/large/Gamebuild-logo-200.png?1715586834"
+    },
+    {
+      "chainId": 1,
+      "address": "0x80c62fe4487e1351b47ba49809ebd60ed085bf52",
+      "name": "Clover Finance",
+      "symbol": "CLV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15278/large/CLV_-_Circle_Logo_-_Only_Icon_1_%281%29.png?1734037808"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7da2641000cbb407c329310c461b2cb9c70c3046",
+      "name": "Delysium",
+      "symbol": "AGI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29299/large/AGI_logo_200.png?1696528251"
+    },
+    {
+      "chainId": 1,
+      "address": "0x71ab77b7dbb4fa7e017bc15090b2163221420282",
+      "name": "Highstreet",
+      "symbol": "HIGH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18973/large/logosq200200Coingecko.png?1696518427"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+      "name": "Polygon",
+      "symbol": "MATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/large/polygon.png?1698233745"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2e3356610840701bdf5611a53974510ae27e2e1",
+      "name": "Wrapped Beacon ETH",
+      "symbol": "WBETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30061/large/wbeth-icon.png?1696528983"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
+      "name": "Celer Network",
+      "symbol": "CELR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/large/Celr.png?1696504978"
+    },
+    {
+      "chainId": 1,
+      "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
+      "name": "tBTC",
+      "symbol": "TBTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe6829d9a7ee3040e1276fa75293bde931859e8fa",
+      "name": "Mantle Restaked ETH",
+      "symbol": "CMETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51114/large/symbol.png?1730117724"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
+      "name": "Origin Token",
+      "symbol": "OGN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3296/large/op.jpg?1696504006"
+    },
+    {
+      "chainId": 1,
+      "address": "0x090185f2135308bad17527004364ebcc2d37e5f6",
+      "name": "Spell",
+      "symbol": "SPELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/large/abracadabra-3.png?1696515477"
+    },
+    {
+      "chainId": 1,
+      "address": "0x643c4e15d7d62ad0abec4a9bd4b001aa3ef52d66",
+      "name": "Syrup",
+      "symbol": "SYRUP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51232/large/IMG_7420.png?1730831572"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
+      "name": "NEXO",
+      "symbol": "NEXO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3695/large/CG-nexo-token-200x200_2x.png?1730414360"
+    },
+    {
+      "chainId": 1,
+      "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
+      "name": "OKB",
+      "symbol": "OKB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4463/large/WeChat_Image_20220118095654.png?1696505053"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe66747a101bff2dba3697199dcce5b743b454759",
+      "name": "Gate",
+      "symbol": "GT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8183/large/gate.png?1696508395"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5cf04716ba20127f1e2297addcf4b5035000c9eb",
+      "name": "NKN",
+      "symbol": "NKN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3375/large/nkn.png?1696504074"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
+      "name": "Dent",
+      "symbol": "DENT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/1152/large/DENT_Token.png?1718837065"
+    },
+    {
+      "chainId": 1,
+      "address": "0x33349b282065b0284d756f0577fb39c158f935e6",
+      "name": "Maple",
+      "symbol": "MPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14097/large/Maple_Logo_Mark_Maple_Orange.png?1696513819"
+    },
+    {
+      "chainId": 1,
+      "address": "0x595832f8fc6bf59c85c527fec3740a1b7a361269",
+      "name": "Powerledger",
+      "symbol": "POWR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/1104/large/Powerledger_Northstar_colour_digital_%282%29.png?1706702222"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
+      "name": "Synapse",
+      "symbol": "SYN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/large/synapse_social_icon.png?1696517540"
+    },
+    {
+      "chainId": 1,
+      "address": "0x79f05c263055ba20ee0e814acd117c20caa10e0c",
+      "name": "Ice Open Network",
+      "symbol": "ICE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34674/large/ion-coingecko-200w.png?1714009819"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
+      "name": "USDS",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
+    },
+    {
+      "chainId": 1,
+      "address": "0x944824290cc12f31ae18ef51216a223ba4063092",
+      "name": "Masa",
+      "symbol": "MASA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35538/large/masa.png?1712635899"
+    },
+    {
+      "chainId": 1,
+      "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
+      "name": "Status",
+      "symbol": "SNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/779/large/status.png?1696501931"
+    },
+    {
+      "chainId": 1,
+      "address": "0xee2a03aa6dacf51c18679c516ad5283d8e7c2637",
+      "name": "Neiro on ETH",
+      "symbol": "NEIRO",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/39438/large/Neiro.png?1722915026"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd26114cd6ee289accf82350c8d8487fedb8a0c07",
+      "name": "OMG Network",
+      "symbol": "OMG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/776/large/OMG_Network.jpg?1696501928"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0fd10b9899882a6f2fcb5c371e17e70fdee00c38",
+      "name": "Pundi X",
+      "symbol": "PUNDIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14571/large/vDyefsXq_400x400.jpg?1696514252"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
+      "name": "Numeraire",
+      "symbol": "NMR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/752/large/numeraire.png?1696501906"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec67005c4e498ec7f55e092bd1d35cbc47c91892",
+      "name": "Enzyme",
+      "symbol": "MLN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/605/large/Enzyme_Icon_Secondary.png?1696501803"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9ce84f6a69986a83d92c324df10bc8e64771030f",
+      "name": "CHEX Token",
+      "symbol": "CHEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10349/large/logo-white-bg-dark.png?1733475849"
+    },
+    {
+      "chainId": 1,
+      "address": "0x579cea1889991f68acc35ff5c3dd0621ff29b0c9",
+      "name": "IQ",
+      "symbol": "IQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5010/large/YAIS3fUh.png?1696505542"
+    },
+    {
+      "chainId": 1,
+      "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
+      "name": "iExec RLC",
+      "symbol": "RLC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/646/large/pL1VuXm.png?1696501840"
+    },
+    {
+      "chainId": 1,
+      "address": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
+      "name": "Stader",
+      "symbol": "SD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20658/large/SD_Token_Logo.png?1696520060"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4575f41308ec1483f3d399aa9a2826d74da13deb",
+      "name": "Orchid Protocol",
+      "symbol": "OXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3916/large/download_%285%29.png?1696504574"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c5ba91642f10282b576d91922ae6448c9d52f4e",
+      "name": "PHALA",
+      "symbol": "PHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12451/large/phala.png?1696512270"
+    },
+    {
+      "chainId": 1,
+      "address": "0x168e209d7b2f58f1f24b8ae7b7d35e662bbf11cc",
+      "name": "LayerAI",
+      "symbol": "LAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29223/large/Favicon_200x200px.png?1696528181"
+    },
+    {
+      "chainId": 1,
       "address": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
       "name": "Staked USD0",
       "symbol": "USD0++",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/39169/large/0x35d8949372d46b7a3d5a56006ae77b215fc69bc0.png?1720798057"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8642a849d0dcb7a15a974794668adcfbe4794b56",
+      "name": "Prosper",
+      "symbol": "PROS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13668/large/PFP_Visual_CG.png?1727714135"
+    },
+    {
+      "chainId": 1,
+      "address": "0x91af0fbb28aba7e31403cb457106ce79397fd4e6",
+      "name": "Aergo",
+      "symbol": "AERGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4490/large/aergo.png?1696505079"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ed97a637a790be1feff5e888d43629dc05408f6",
+      "name": "Non Playable Coin",
+      "symbol": "NPC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31193/large/NPC_200x200.png?1696530021"
+    },
+    {
+      "chainId": 1,
+      "address": "0x67466be17df832165f8c80a5a120ccc652bd7e69",
+      "name": "LandWolf",
+      "symbol": "WOLF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37403/large/wolf_200x200.png?1715222165"
     },
     {
       "chainId": 1,
@@ -2404,11 +2396,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x9f0c013016e8656bc256f948cd4b79ab25c7b94d",
-      "name": "mETH Protocol",
-      "symbol": "COOK",
+      "address": "0x24fcfc492c1393274b6bcd568ac9e225bec93584",
+      "name": "Heroes of Mavia",
+      "symbol": "MAVIA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50969/large/Logomark-Gradient_Official.png?1729620221"
+      "logoURI": "https://assets.coingecko.com/coins/images/33895/large/2023-12-20_21.21.41_%281%29.jpg?1703230771"
     },
     {
       "chainId": 1,
@@ -2417,22 +2409,6 @@
       "symbol": "GHST",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/12467/large/GHST.png?1696512286"
-    },
-    {
-      "chainId": 1,
-      "address": "0x853d955acef822db058eb8505911ed77f175b99e",
-      "name": "Frax",
-      "symbol": "FRAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1696513182"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8ed97a637a790be1feff5e888d43629dc05408f6",
-      "name": "Non Playable Coin",
-      "symbol": "NPC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31193/large/NPC_200x200.png?1696530021"
     },
     {
       "chainId": 1,
@@ -2452,19 +2428,27 @@
     },
     {
       "chainId": 1,
-      "address": "0x12bb890508c125661e03b09ec06e404bc9289040",
-      "name": "Radio Caca",
-      "symbol": "RACA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17841/large/ez44_BSs_400x400.jpg?1696517365"
-    },
-    {
-      "chainId": 1,
       "address": "0xc328a59e7321747aebbc49fd28d1b32c1af8d3b2",
       "name": "Phil",
       "symbol": "PHIL",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/39975/large/yr0kMUrz_400x400.jpg?1724971221"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9f0c013016e8656bc256f948cd4b79ab25c7b94d",
+      "name": "mETH Protocol",
+      "symbol": "COOK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50969/large/Logomark-Gradient_Official.png?1729620221"
+    },
+    {
+      "chainId": 1,
+      "address": "0x853d955acef822db058eb8505911ed77f175b99e",
+      "name": "Frax",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1696513182"
     },
     {
       "chainId": 1,
@@ -2476,30 +2460,6 @@
     },
     {
       "chainId": 1,
-      "address": "0xb59490ab09a0f526cc7305822ac65f2ab12f9723",
-      "name": "Litentry",
-      "symbol": "LIT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13825/large/logo_200x200.png?1696513568"
-    },
-    {
-      "chainId": 1,
-      "address": "0x24fcfc492c1393274b6bcd568ac9e225bec93584",
-      "name": "Heroes of Mavia",
-      "symbol": "MAVIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33895/large/2023-12-20_21.21.41_%281%29.jpg?1703230771"
-    },
-    {
-      "chainId": 1,
-      "address": "0x572975ff6d5136c81c8d7448b6361ef9eefe1ab0",
-      "name": "Wrapped Staked USDT",
-      "symbol": "WSTUSDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31160/large/wstusdt.jpeg?1696529988"
-    },
-    {
-      "chainId": 1,
       "address": "0x1121acc14c63f3c872bfca497d10926a6098aac5",
       "name": "Department Of Government Efficiency",
       "symbol": "DOGE",
@@ -2508,11 +2468,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xe355de6a6043b0580ff5a26b46051a4809b12793",
-      "name": "4EVERLAND",
-      "symbol": "4EVER",
+      "address": "0x3be7bf1a5f23bd8336787d0289b70602f1940875",
+      "name": "VIDT DAO",
+      "symbol": "VIDT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52783/large/4everland.jpg?1734287106"
+      "logoURI": "https://assets.coingecko.com/coins/images/27552/large/VIDTDAO_logo.png?1696526588"
     },
     {
       "chainId": 1,
@@ -2524,11 +2484,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xe77f6acd24185e149e329c1c0f479201b9ec2f4b",
-      "name": "Zeebu",
-      "symbol": "ZBU",
+      "address": "0x572975ff6d5136c81c8d7448b6361ef9eefe1ab0",
+      "name": "Wrapped Staked USDT",
+      "symbol": "WSTUSDT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31145/large/200x200_Front_token.png?1696529974"
+      "logoURI": "https://assets.coingecko.com/coins/images/31160/large/wstusdt.jpeg?1696529988"
     },
     {
       "chainId": 1,
@@ -2540,19 +2500,35 @@
     },
     {
       "chainId": 1,
-      "address": "0x4b9278b94a1112cad404048903b8d343a810b07e",
-      "name": "Hifi Finance",
-      "symbol": "HIFI",
+      "address": "0xd9d920aa40f578ab794426f5c90f6c731d159def",
+      "name": "Solv Protocol SolvBTC BBN",
+      "symbol": "SOLVBTCBBN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28712/large/hft.png?1696527693"
+      "logoURI": "https://assets.coingecko.com/coins/images/39384/large/unnamed.png?1721961640"
     },
     {
       "chainId": 1,
-      "address": "0x56072c95faa701256059aa122697b133aded9279",
-      "name": "Sky",
-      "symbol": "SKY",
+      "address": "0x12bb890508c125661e03b09ec06e404bc9289040",
+      "name": "Radio Caca",
+      "symbol": "RACA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39925/large/sky.jpg?1724827980"
+      "logoURI": "https://assets.coingecko.com/coins/images/17841/large/ez44_BSs_400x400.jpg?1696517365"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe355de6a6043b0580ff5a26b46051a4809b12793",
+      "name": "4EVERLAND",
+      "symbol": "4EVER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52783/large/4everland.jpg?1734287106"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb59490ab09a0f526cc7305822ac65f2ab12f9723",
+      "name": "Litentry",
+      "symbol": "LIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13825/large/logo_200x200.png?1696513568"
     },
     {
       "chainId": 1,
@@ -2564,83 +2540,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x4385328cc4d643ca98dfea734360c0f596c83449",
-      "name": "tomiNet",
-      "symbol": "TOMI",
+      "address": "0x03dde9e5bb31ee40a471476e2fccf75c67921062",
+      "name": "EML Protocol",
+      "symbol": "EML",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28730/large/logo_for_token.png?1696527710"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa91ac63d040deb1b7a5e4d4134ad23eb0ba07e14",
-      "name": "Bella Protocol",
-      "symbol": "BEL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12478/large/Bella.png?1696512296"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
-      "name": "Bone ShibaSwap",
-      "symbol": "BONE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16916/large/bone_icon.png?1696516487"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
-      "name": "Request",
-      "symbol": "REQ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1031/large/Request_icon_green.png?1696502140"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd9d920aa40f578ab794426f5c90f6c731d159def",
-      "name": "Solv Protocol SolvBTC BBN",
-      "symbol": "SOLVBTCBBN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39384/large/unnamed.png?1721961640"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0c7d5ae016f806603cb1782bea29ac69471cab9c",
-      "name": "Bifrost",
-      "symbol": "BFC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4639/large/BFC_Symbol.png?1696505208"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe9689028ede16c2fdfe3d11855d28f8e3fc452a3",
-      "name": "Imaginary Ones",
-      "symbol": "BUBBLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37706/large/imaginary_ones.jpeg?1715255717"
-    },
-    {
-      "chainId": 1,
-      "address": "0x25931894a86d47441213199621f1f2994e1c39aa",
-      "name": "ChainGPT",
-      "symbol": "CGPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29306/large/200x200.png?1696528257"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc03fbf20a586fa89c2a5f6f941458e1fbc40c661",
-      "name": "COMBO",
-      "symbol": "COMBO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4932/large/COMBO.jpg?1696505472"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5dc60c4d5e75d22588fa17ffeb90a63e535efce0",
-      "name": "dKargo",
-      "symbol": "DKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11875/large/DKA_ticker.png?1732553189"
+      "logoURI": "https://assets.coingecko.com/coins/images/30950/large/EML_LOGO.png?1696529788"
     },
     {
       "chainId": 1,
@@ -2652,27 +2556,51 @@
     },
     {
       "chainId": 1,
-      "address": "0x9d1a7a3191102e9f900faa10540837ba84dcbae7",
-      "name": "Eurite",
-      "symbol": "EURI",
+      "address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
+      "name": "Bone ShibaSwap",
+      "symbol": "BONE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39952/large/EURI.jpg?1724902829"
+      "logoURI": "https://assets.coingecko.com/coins/images/16916/large/bone_icon.png?1696516487"
     },
     {
       "chainId": 1,
-      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
-      "name": "World Mobile Token",
-      "symbol": "WMTX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
+      "address": "0xa91ac63d040deb1b7a5e4d4134ad23eb0ba07e14",
+      "name": "Bella Protocol",
+      "symbol": "BEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12478/large/Bella.png?1696512296"
     },
     {
       "chainId": 1,
-      "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
-      "name": "AirSwap",
-      "symbol": "AST",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/1019/large/Airswap.png?1696502130"
+      "address": "0x56072c95faa701256059aa122697b133aded9279",
+      "name": "Sky",
+      "symbol": "SKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39925/large/sky.jpg?1724827980"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4b9278b94a1112cad404048903b8d343a810b07e",
+      "name": "Hifi Finance",
+      "symbol": "HIFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28712/large/hft.png?1696527693"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0c7d5ae016f806603cb1782bea29ac69471cab9c",
+      "name": "Bifrost",
+      "symbol": "BFC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4639/large/BFC_Symbol.png?1696505208"
+    },
+    {
+      "chainId": 1,
+      "address": "0x25931894a86d47441213199621f1f2994e1c39aa",
+      "name": "ChainGPT",
+      "symbol": "CGPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29306/large/200x200.png?1696528257"
     },
     {
       "chainId": 1,
@@ -2684,43 +2612,27 @@
     },
     {
       "chainId": 1,
-      "address": "0xf8ebf4849f1fa4faf0dff2106a173d3a6cb2eb3a",
-      "name": "Troll",
-      "symbol": "TROLL",
+      "address": "0x9ff58067bd8d239000010c154c6983a325df138e",
+      "name": "Propchain",
+      "symbol": "PROPC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29897/large/TROLL.jpeg?1696528821"
+      "logoURI": "https://assets.coingecko.com/coins/images/30451/large/prop_%281%29.png?1702322253"
     },
     {
       "chainId": 1,
-      "address": "0xd2ba23de8a19316a638dc1e7a9adda1d74233368",
-      "name": "Quickswap",
-      "symbol": "QUICK",
+      "address": "0x5dc60c4d5e75d22588fa17ffeb90a63e535efce0",
+      "name": "dKargo",
+      "symbol": "DKA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25393/large/quickswap.png?1696524525"
+      "logoURI": "https://assets.coingecko.com/coins/images/11875/large/DKA_ticker.png?1732553189"
     },
     {
       "chainId": 1,
-      "address": "0xa9e8acf069c58aec8825542845fd754e41a9489a",
-      "name": "PepeCoin",
-      "symbol": "PEPECOIN",
+      "address": "0xe9689028ede16c2fdfe3d11855d28f8e3fc452a3",
+      "name": "Imaginary Ones",
+      "symbol": "BUBBLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30219/large/pepecoin.jpeg?1696529130"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc555d625828c4527d477e595ff1dd5801b4a600e",
-      "name": "MON",
-      "symbol": "MON",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37395/large/WhatsApp_Image_2024-02-27_at_18.34.45_01762153.jpg?1716261730"
-    },
-    {
-      "chainId": 1,
-      "address": "0xe50e009ddb1a4d8ec668eac9d8b2df1f96348707",
-      "name": "Ctrl",
-      "symbol": "CTRL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50886/large/_CTRL_logo_.png?1732678338"
+      "logoURI": "https://assets.coingecko.com/coins/images/37706/large/imaginary_ones.jpeg?1715255717"
     },
     {
       "chainId": 1,
@@ -2732,11 +2644,59 @@
     },
     {
       "chainId": 1,
+      "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
+      "name": "AirSwap",
+      "symbol": "AST",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/1019/large/Airswap.png?1696502130"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa9e8acf069c58aec8825542845fd754e41a9489a",
+      "name": "PepeCoin",
+      "symbol": "PEPECOIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30219/large/pepecoin.jpeg?1696529130"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
+      "name": "World Mobile Token",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
+      "name": "Request",
+      "symbol": "REQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1031/large/Request_icon_green.png?1696502140"
+    },
+    {
+      "chainId": 1,
       "address": "0xf94e7d0710709388bce3161c32b4eea56d3f91cc",
       "name": "Destra Network",
       "symbol": "DSYNC",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/35996/large/Destra_Network.png?1710316001"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc555d625828c4527d477e595ff1dd5801b4a600e",
+      "name": "MON",
+      "symbol": "MON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37395/large/WhatsApp_Image_2024-02-27_at_18.34.45_01762153.jpg?1716261730"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf8ebf4849f1fa4faf0dff2106a173d3a6cb2eb3a",
+      "name": "Troll",
+      "symbol": "TROLL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29897/large/TROLL.jpeg?1696528821"
     },
     {
       "chainId": 1,
@@ -2748,19 +2708,19 @@
     },
     {
       "chainId": 1,
+      "address": "0xe50e009ddb1a4d8ec668eac9d8b2df1f96348707",
+      "name": "Ctrl",
+      "symbol": "CTRL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50886/large/_CTRL_logo_.png?1732678338"
+    },
+    {
+      "chainId": 1,
       "address": "0x908ddb096bfb3acb19e2280aad858186ea4935c4",
       "name": "Eesee",
       "symbol": "ESE",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/35182/large/Eesee.jpg?1707796753"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdd3b11ef34cd511a2da159034a05fcb94d806686",
-      "name": "Rekt",
-      "symbol": "REKT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51727/large/rektcion_trans_200px.png?1731910587"
     },
     {
       "chainId": 1,
@@ -2772,27 +2732,27 @@
     },
     {
       "chainId": 1,
-      "address": "0x72e4f9f808c49a2a61de9c5896298920dc4eeea9",
-      "name": "HarryPotterObamaSonic10Inu  ETH ",
-      "symbol": "BITCOIN",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+      "address": "0x4385328cc4d643ca98dfea734360c0f596c83449",
+      "name": "tomiNet",
+      "symbol": "TOMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28730/large/logo_for_token.png?1696527710"
     },
     {
       "chainId": 1,
-      "address": "0x1495bc9e44af1f8bcb62278d2bec4540cf0c05ea",
-      "name": "Zero1 Labs",
-      "symbol": "DEAI",
+      "address": "0xdd3b11ef34cd511a2da159034a05fcb94d806686",
+      "name": "Rekt",
+      "symbol": "REKT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36315/large/512x512-xion-ava03.png?1711092111"
+      "logoURI": "https://assets.coingecko.com/coins/images/51727/large/rektcion_trans_200px.png?1731910587"
     },
     {
       "chainId": 1,
-      "address": "0x0391d2021f89dc339f60fff84546ea23e337750f",
-      "name": "BarnBridge",
-      "symbol": "BOND",
+      "address": "0xd2ba23de8a19316a638dc1e7a9adda1d74233368",
+      "name": "Quickswap",
+      "symbol": "QUICK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12811/large/barnbridge.jpg?1696512604"
+      "logoURI": "https://assets.coingecko.com/coins/images/25393/large/quickswap.png?1696524525"
     },
     {
       "chainId": 1,
@@ -2804,6 +2764,22 @@
     },
     {
       "chainId": 1,
+      "address": "0x0391d2021f89dc339f60fff84546ea23e337750f",
+      "name": "BarnBridge",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/large/barnbridge.jpg?1696512604"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1495bc9e44af1f8bcb62278d2bec4540cf0c05ea",
+      "name": "Zero1 Labs",
+      "symbol": "DEAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36315/large/512x512-xion-ava03.png?1711092111"
+    },
+    {
+      "chainId": 1,
       "address": "0x32b77729cd87f1ef2bea4c650c16f89f08472c69",
       "name": "DeBox",
       "symbol": "BOX",
@@ -2812,27 +2788,35 @@
     },
     {
       "chainId": 1,
-      "address": "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
-      "name": "Boba Network",
-      "symbol": "BOBA",
+      "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
+      "name": "Bancor Network",
+      "symbol": "BNT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20285/large/Boba-200x200---white.png?1696519690"
+      "logoURI": "https://assets.coingecko.com/coins/images/736/large/Bancor_Token.png?1710479159"
     },
     {
       "chainId": 1,
-      "address": "0x68749665ff8d2d112fa859aa293f07a622782f38",
-      "name": "Tether Gold",
-      "symbol": "XAUT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/10481/large/Tether_Gold.png?1696510471"
+      "address": "0x9d1a7a3191102e9f900faa10540837ba84dcbae7",
+      "name": "Eurite",
+      "symbol": "EURI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39952/large/EURI.jpg?1724902829"
     },
     {
       "chainId": 1,
-      "address": "0x38e382f74dfb84608f3c1f10187f6bef5951de93",
-      "name": "Multibit",
-      "symbol": "MUBI",
+      "address": "0xc5d27f27f08d1fd1e3ebbaa50b3442e6c0d50439",
+      "name": "RWAX",
+      "symbol": "APP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33051/large/multi.jpg?1700473994"
+      "logoURI": "https://assets.coingecko.com/coins/images/34492/large/rwax-token.png?1730443514"
+    },
+    {
+      "chainId": 1,
+      "address": "0x72e4f9f808c49a2a61de9c5896298920dc4eeea9",
+      "name": "HarryPotterObamaSonic10Inu  ETH ",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
     },
     {
       "chainId": 1,
@@ -2844,11 +2828,147 @@
     },
     {
       "chainId": 1,
+      "address": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
+      "name": "Cookie DAO",
+      "symbol": "COOKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38450/large/cookie_token_logo_200x200.png?1733194528"
+    },
+    {
+      "chainId": 1,
+      "address": "0x174c47d6a4e548ed2b7d369dc0ffb2e60a6ac0f8",
+      "name": "Amulet Protocol",
+      "symbol": "AMU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/34716/large/AMT200x200.png?1705904544"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
+      "name": "Wrapped Fantom",
+      "symbol": "WFTM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16036/large/Fantom.png?1696515646"
+    },
+    {
+      "chainId": 1,
+      "address": "0x68749665ff8d2d112fa859aa293f07a622782f38",
+      "name": "Tether Gold",
+      "symbol": "XAUT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/10481/large/Tether_Gold.png?1696510471"
+    },
+    {
+      "chainId": 1,
+      "address": "0x61e90a50137e1f645c9ef4a0d3a4f01477738406",
+      "name": "League of Kingdoms",
+      "symbol": "LOKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22572/large/loka_64pix.png?1696521891"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc98d64da73a6616c42117b582e832812e7b8d57f",
+      "name": "RSS3",
+      "symbol": "RSS3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23575/large/rss3.jpeg?1718351333"
+    },
+    {
+      "chainId": 1,
+      "address": "0x38e382f74dfb84608f3c1f10187f6bef5951de93",
+      "name": "Multibit",
+      "symbol": "MUBI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33051/large/multi.jpg?1700473994"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8236a87084f8b84306f72007f36f2618a5634494",
+      "name": "Lombard Staked BTC",
+      "symbol": "LBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39969/large/LBTC_Logo.png?1724959872"
+    },
+    {
+      "chainId": 1,
+      "address": "0x823556202e86763853b40e9cde725f412e294689",
+      "name": "Altered State Machine",
+      "symbol": "ASTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24893/large/ASTO-Token.png?1732899741"
+    },
+    {
+      "chainId": 1,
+      "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
+      "name": "dForce",
+      "symbol": "DF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9709/large/xlGxxIjI_400x400.jpg?1696509776"
+    },
+    {
+      "chainId": 1,
       "address": "0xf4fb9bf10e489ea3edb03e094939341399587b0c",
       "name": "AirDAO",
       "symbol": "AMB",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/1041/large/amb.png?1696502148"
+    },
+    {
+      "chainId": 1,
+      "address": "0x28561b8a2360f463011c16b6cc0b0cbef8dbbcad",
+      "name": "MOO DENG",
+      "symbol": "MOODENG",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/50348/large/1000000612.jpg?1727248974"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbef26bd568e421d6708cca55ad6e35f8bfa0c406",
+      "name": "bitsCrunch Token",
+      "symbol": "BCUT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34832/large/logo-256_%281%29.png?1710244462"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a9bdcff37ab68b95a53435adfd8892e86084f93",
+      "name": "Alpha Quark",
+      "symbol": "AQT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12872/large/alpha_quark_logo.png?1696512660"
+    },
+    {
+      "chainId": 1,
+      "address": "0x83e6f1e41cdd28eaceb20cb649155049fac3d5aa",
+      "name": "Polkastarter",
+      "symbol": "POLS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12648/large/Group_11_%281%29_1.png?1725563541"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0bb217e40f8a5cb79adf04e1aab60e5abd0dfc1e",
+      "name": "SWFTCOIN",
+      "symbol": "SWFTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2346/large/SWFTCoin.jpg?1696503223"
+    },
+    {
+      "chainId": 1,
+      "address": "0xff56cc6b1e6ded347aa0b7676c85ab0b3d08b0fa",
+      "name": "Orbs",
+      "symbol": "ORBS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4630/large/Orbs.jpg?1696505200"
+    },
+    {
+      "chainId": 1,
+      "address": "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
+      "name": "Boba Network",
+      "symbol": "BOBA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20285/large/Boba-200x200---white.png?1696519690"
     },
     {
       "chainId": 1,
@@ -2868,211 +2988,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xff56cc6b1e6ded347aa0b7676c85ab0b3d08b0fa",
-      "name": "Orbs",
-      "symbol": "ORBS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4630/large/Orbs.jpg?1696505200"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc5d27f27f08d1fd1e3ebbaa50b3442e6c0d50439",
-      "name": "RWAX",
-      "symbol": "APP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34492/large/rwax-token.png?1730443514"
-    },
-    {
-      "chainId": 1,
-      "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
-      "name": "dForce",
-      "symbol": "DF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9709/large/xlGxxIjI_400x400.jpg?1696509776"
-    },
-    {
-      "chainId": 1,
-      "address": "0x623cd3a3edf080057892aaf8d773bbb7a5c9b6e9",
-      "name": "Sekuya Multiverse",
-      "symbol": "SKYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38096/large/SKYA_Logo_200x200.png?1731909478"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa89e2871a850e0e6fd8f0018ec1fc62fa75440d4",
-      "name": "Ready to Fight",
-      "symbol": "RTF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37322/large/Frame_21313315692.png?1714002508"
-    },
-    {
-      "chainId": 1,
-      "address": "0x823556202e86763853b40e9cde725f412e294689",
-      "name": "Altered State Machine",
-      "symbol": "ASTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24893/large/ASTO-Token.png?1732899741"
-    },
-    {
-      "chainId": 1,
-      "address": "0x174c47d6a4e548ed2b7d369dc0ffb2e60a6ac0f8",
-      "name": "Amulet Protocol",
-      "symbol": "AMU",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/34716/large/AMT200x200.png?1705904544"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6e79b51959cf968d87826592f46f819f92466615",
-      "name": "Hoppy",
-      "symbol": "HOPPY",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37197/large/Hoppy_200x200_.png?1724175711"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbbc2ae13b23d715c30720f079fcd9b4a74093505",
-      "name": "Ethernity Chain",
-      "symbol": "ERN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14238/large/logo_black.png?1715198164"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
-      "name": "Cookie DAO",
-      "symbol": "COOKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38450/large/cookie_token_logo_200x200.png?1733194528"
-    },
-    {
-      "chainId": 1,
-      "address": "0x68bbed6a47194eff1cf514b50ea91895597fc91e",
-      "name": "ANDY ETH",
-      "symbol": "ANDY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35910/large/IMG_20240309_044840_797.jpg?1710179397"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8236a87084f8b84306f72007f36f2618a5634494",
-      "name": "Lombard Staked BTC",
-      "symbol": "LBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39969/large/LBTC_Logo.png?1724959872"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2a9bdcff37ab68b95a53435adfd8892e86084f93",
-      "name": "Alpha Quark",
-      "symbol": "AQT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12872/large/alpha_quark_logo.png?1696512660"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc98d64da73a6616c42117b582e832812e7b8d57f",
-      "name": "RSS3",
-      "symbol": "RSS3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23575/large/rss3.jpeg?1718351333"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0bb217e40f8a5cb79adf04e1aab60e5abd0dfc1e",
-      "name": "SWFTCOIN",
-      "symbol": "SWFTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/2346/large/SWFTCoin.jpg?1696503223"
-    },
-    {
-      "chainId": 1,
-      "address": "0x61e90a50137e1f645c9ef4a0d3a4f01477738406",
-      "name": "League of Kingdoms",
-      "symbol": "LOKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22572/large/loka_64pix.png?1696521891"
-    },
-    {
-      "chainId": 1,
       "address": "0xfc82bb4ba86045af6f327323a46e80412b91b27d",
       "name": "Prom",
       "symbol": "PROM",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/8825/large/Ticker.png?1696508978"
-    },
-    {
-      "chainId": 1,
-      "address": "0x28561b8a2360f463011c16b6cc0b0cbef8dbbcad",
-      "name": "MOO DENG",
-      "symbol": "MOODENG",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/50348/large/1000000612.jpg?1727248974"
-    },
-    {
-      "chainId": 1,
-      "address": "0x83e6f1e41cdd28eaceb20cb649155049fac3d5aa",
-      "name": "Polkastarter",
-      "symbol": "POLS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12648/large/Group_11_%281%29_1.png?1725563541"
-    },
-    {
-      "chainId": 1,
-      "address": "0x97a9a15168c22b3c137e6381037e1499c8ad0978",
-      "name": "Data Ownership Protocol",
-      "symbol": "DOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36706/large/DOP-Round-200x200.png?1720836160"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9ee8c380e1926730ad89e91665ff27063b13c90a",
-      "name": "Coupon Assets",
-      "symbol": "CA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32202/large/ca.jpg?1696746380"
-    },
-    {
-      "chainId": 1,
-      "address": "0x62b9c7356a2dc64a1969e19c23e4f579f9810aa7",
-      "name": "Convex CRV",
-      "symbol": "CVXCRV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15586/large/convex-crv.png?1696515222"
-    },
-    {
-      "chainId": 1,
-      "address": "0x825459139c897d769339f295e962396c4f9e4a4d",
-      "name": "GameBuild",
-      "symbol": "GAME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37789/large/Gamebuild-logo-200.png?1715586834"
-    },
-    {
-      "chainId": 1,
-      "address": "0xd01409314acb3b245cea9500ece3f6fd4d70ea30",
-      "name": "LTO Network",
-      "symbol": "LTO",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/6068/large/lto.png?1696506473"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa2120b9e674d3fc3875f415a7df52e382f141225",
-      "name": "Automata",
-      "symbol": "ATA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15985/large/ATA_Icon_%28Profile_2%29.png?1720487988"
-    },
-    {
-      "chainId": 1,
-      "address": "0xea26c4ac16d4a5a106820bc8aee85fd0b7b2b664",
-      "name": "QuarkChain",
-      "symbol": "QKC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3849/large/QuarkChain.jpg?1730964236"
     },
     {
       "chainId": 1,
@@ -3084,75 +3004,27 @@
     },
     {
       "chainId": 1,
-      "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
-      "name": "UniLend Finance",
-      "symbol": "UFT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12819/large/UniLend_Finance_logo_PNG.png?1696512611"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4123a133ae3c521fd134d7b13a2dec35b56c2463",
-      "name": "Open Custody Protocol",
-      "symbol": "OPEN",
+      "address": "0xd01409314acb3b245cea9500ece3f6fd4d70ea30",
+      "name": "LTO Network",
+      "symbol": "LTO",
       "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/17541/large/OPEN-Token-Black.png?1712837762"
+      "logoURI": "https://assets.coingecko.com/coins/images/6068/large/lto.png?1696506473"
     },
     {
       "chainId": 1,
-      "address": "0xcab254f1a32343f11ab41fbde90ecb410cde348a",
-      "name": "Froge",
-      "symbol": "FROGE",
+      "address": "0xa89e2871a850e0e6fd8f0018ec1fc62fa75440d4",
+      "name": "Ready to Fight",
+      "symbol": "RTF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33216/large/frog.jpeg?1701087620"
+      "logoURI": "https://assets.coingecko.com/coins/images/37322/large/Frame_21313315692.png?1714002508"
     },
     {
       "chainId": 1,
-      "address": "0x42476f744292107e34519f9c357927074ea3f75d",
-      "name": "Loom Network  NEW ",
-      "symbol": "LOOM",
+      "address": "0x97a9a15168c22b3c137e6381037e1499c8ad0978",
+      "name": "Data Ownership Protocol",
+      "symbol": "DOP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14735/large/LOOM.png?1696514405"
-    },
-    {
-      "chainId": 1,
-      "address": "0x94a8b4ee5cd64c79d0ee816f467ea73009f51aa0",
-      "name": "Realio Network Token",
-      "symbol": "RIO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12206/large/Rio.png?1696512042"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa3d4bee77b05d4a0c943877558ce21a763c4fa29",
-      "name": "The Root Network",
-      "symbol": "ROOT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/33122/large/6T1Tapl__400x400.jpg?1700740439"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbef26bd568e421d6708cca55ad6e35f8bfa0c406",
-      "name": "bitsCrunch Token",
-      "symbol": "BCUT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34832/large/logo-256_%281%29.png?1710244462"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbf5495efe5db9ce00f80364c8b423567e58d2110",
-      "name": "Renzo Restaked ETH",
-      "symbol": "EZETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4c11249814f11b9346808179cf06e71ac328c1b5",
-      "name": "Oraichain",
-      "symbol": "ORAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12931/large/orai.png?1696512718"
+      "logoURI": "https://assets.coingecko.com/coins/images/36706/large/DOP-Round-200x200.png?1720836160"
     },
     {
       "chainId": 1,
@@ -3164,75 +3036,19 @@
     },
     {
       "chainId": 1,
-      "address": "0x0c90c57aaf95a3a87eadda6ec3974c99d786511f",
-      "name": "HanChain",
-      "symbol": "HAN",
+      "address": "0x9ee8c380e1926730ad89e91665ff27063b13c90a",
+      "name": "Coupon Assets",
+      "symbol": "CA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27374/large/logo_200.png?1696526418"
+      "logoURI": "https://assets.coingecko.com/coins/images/32202/large/ca.jpg?1696746380"
     },
     {
       "chainId": 1,
-      "address": "0xa1290d69c65a6fe4df752f95823fae25cb99e5a7",
-      "name": "Kelp DAO Restaked ETH",
-      "symbol": "RSETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33800/large/Icon___Dark.png?1702991855"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbba39fd2935d5769116ce38d46a71bde9cf03099",
-      "name": "Choise ai",
-      "symbol": "CHO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25935/large/CHO_%282%29.png?1721039541"
-    },
-    {
-      "chainId": 1,
-      "address": "0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44",
-      "name": "Wrapped TAO",
-      "symbol": "WTAO",
+      "address": "0x6e79b51959cf968d87826592f46f819f92466615",
+      "name": "Hoppy",
+      "symbol": "HOPPY",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/29087/large/wtao.png?1696528051"
-    },
-    {
-      "chainId": 1,
-      "address": "0x06450dee7fd2fb8e39061434babcfc05599a6fb8",
-      "name": "XEN Crypto",
-      "symbol": "XEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27713/large/Xen.jpeg?1696526739"
-    },
-    {
-      "chainId": 1,
-      "address": "0x865377367054516e17014ccded1e7d814edc9ce4",
-      "name": "DOLA",
-      "symbol": "DOLA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
-    },
-    {
-      "chainId": 1,
-      "address": "0x27c70cd1946795b66be9d954418546998b546634",
-      "name": "Doge Killer",
-      "symbol": "LEASH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15802/large/Leash.png?1696515425"
-    },
-    {
-      "chainId": 1,
-      "address": "0xbe1a001fe942f96eea22ba08783140b9dcc09d28",
-      "name": "Beta Finance",
-      "symbol": "BETA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18715/large/beta_finance.jpg?1696518183"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
-      "name": "Pax Dollar",
-      "symbol": "USDP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/6013/large/Pax_Dollar.png?1696506427"
+      "logoURI": "https://assets.coingecko.com/coins/images/37197/large/Hoppy_200x200_.png?1724175711"
     },
     {
       "chainId": 1,
@@ -3244,11 +3060,59 @@
     },
     {
       "chainId": 1,
+      "address": "0x42476f744292107e34519f9c357927074ea3f75d",
+      "name": "Loom Network  NEW ",
+      "symbol": "LOOM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14735/large/LOOM.png?1696514405"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4123a133ae3c521fd134d7b13a2dec35b56c2463",
+      "name": "Open Custody Protocol",
+      "symbol": "OPEN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17541/large/OPEN-Token-Black.png?1712837762"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
+      "name": "UniLend Finance",
+      "symbol": "UFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12819/large/UniLend_Finance_logo_PNG.png?1696512611"
+    },
+    {
+      "chainId": 1,
+      "address": "0x623cd3a3edf080057892aaf8d773bbb7a5c9b6e9",
+      "name": "Sekuya Multiverse",
+      "symbol": "SKYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38096/large/SKYA_Logo_200x200.png?1731909478"
+    },
+    {
+      "chainId": 1,
       "address": "0x44971abf0251958492fee97da3e5c5ada88b9185",
       "name": "BasedAI",
       "symbol": "BASEDAI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/36607/large/1000004475.png?1711964332"
+    },
+    {
+      "chainId": 1,
+      "address": "0xea26c4ac16d4a5a106820bc8aee85fd0b7b2b664",
+      "name": "QuarkChain",
+      "symbol": "QKC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3849/large/QuarkChain.jpg?1730964236"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa3d4bee77b05d4a0c943877558ce21a763c4fa29",
+      "name": "The Root Network",
+      "symbol": "ROOT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/33122/large/6T1Tapl__400x400.jpg?1700740439"
     },
     {
       "chainId": 1,
@@ -3260,19 +3124,99 @@
     },
     {
       "chainId": 1,
-      "address": "0xca5b0ae1d104030a9b8f879523508efd86c14483",
-      "name": "TYBENG",
-      "symbol": "TYBENG",
+      "address": "0x4c11249814f11b9346808179cf06e71ac328c1b5",
+      "name": "Oraichain",
+      "symbol": "ORAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31022/large/NVoa_mZ6_400x400.jpg?1721805735"
+      "logoURI": "https://assets.coingecko.com/coins/images/12931/large/orai.png?1696512718"
     },
     {
       "chainId": 1,
-      "address": "0x590f820444fa3638e022776752c5eef34e2f89a6",
-      "name": "Alephium",
-      "symbol": "ALPH",
+      "address": "0x94a8b4ee5cd64c79d0ee816f467ea73009f51aa0",
+      "name": "Realio Network Token",
+      "symbol": "RIO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21598/large/Alephium-Logo_200x200_listing.png?1696520959"
+      "logoURI": "https://assets.coingecko.com/coins/images/12206/large/Rio.png?1696512042"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0c90c57aaf95a3a87eadda6ec3974c99d786511f",
+      "name": "HanChain",
+      "symbol": "HAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27374/large/logo_200.png?1696526418"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2120b9e674d3fc3875f415a7df52e382f141225",
+      "name": "Automata",
+      "symbol": "ATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15985/large/ATA_Icon_%28Profile_2%29.png?1720487988"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2085073878152ac3090ea13d1e41bd69e60dc99",
+      "name": "Escoin",
+      "symbol": "ELG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13566/large/escoin-200.png?1696513320"
+    },
+    {
+      "chainId": 1,
+      "address": "0x06450dee7fd2fb8e39061434babcfc05599a6fb8",
+      "name": "XEN Crypto",
+      "symbol": "XEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27713/large/Xen.jpeg?1696526739"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
+      "name": "OriginTrail",
+      "symbol": "TRAC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1877/large/TRAC.jpg?1696502873"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbf5495efe5db9ce00f80364c8b423567e58d2110",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
+      "name": "Pax Dollar",
+      "symbol": "USDP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6013/large/Pax_Dollar.png?1696506427"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe1a001fe942f96eea22ba08783140b9dcc09d28",
+      "name": "Beta Finance",
+      "symbol": "BETA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18715/large/beta_finance.jpg?1696518183"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbbc2ae13b23d715c30720f079fcd9b4a74093505",
+      "name": "Ethernity Chain",
+      "symbol": "ERN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14238/large/logo_black.png?1715198164"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbba39fd2935d5769116ce38d46a71bde9cf03099",
+      "name": "Choise ai",
+      "symbol": "CHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25935/large/CHO_%282%29.png?1721039541"
     },
     {
       "chainId": 1,
@@ -3284,19 +3228,67 @@
     },
     {
       "chainId": 1,
-      "address": "0x33333333fede34409fb7f67c6585047e1f653333",
-      "name": "ORA Coin",
-      "symbol": "ORA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51812/large/ORA_Token.png?1732029092"
-    },
-    {
-      "chainId": 1,
       "address": "0x2c974b2d0ba1716e644c1fc59982a89ddd2ff724",
       "name": "Viberate",
       "symbol": "VIB",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/983/large/Viberate.png?1696502096"
+    },
+    {
+      "chainId": 1,
+      "address": "0xca5b0ae1d104030a9b8f879523508efd86c14483",
+      "name": "TYBENG",
+      "symbol": "TYBENG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31022/large/NVoa_mZ6_400x400.jpg?1721805735"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcab254f1a32343f11ab41fbde90ecb410cde348a",
+      "name": "Froge",
+      "symbol": "FROGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33216/large/frog.jpeg?1701087620"
+    },
+    {
+      "chainId": 1,
+      "address": "0x27c70cd1946795b66be9d954418546998b546634",
+      "name": "Doge Killer",
+      "symbol": "LEASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15802/large/Leash.png?1696515425"
+    },
+    {
+      "chainId": 1,
+      "address": "0x68bbed6a47194eff1cf514b50ea91895597fc91e",
+      "name": "ANDY ETH",
+      "symbol": "ANDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35910/large/IMG_20240309_044840_797.jpg?1710179397"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8802269d1283cdb2a5a329649e5cb4cdcee91ab6",
+      "name": "Fight to MAGA",
+      "symbol": "FIGHT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/39208/large/photo_2024-07-14_03-15-23.jpg?1721101331"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3ffeea07a27fab7ad1df5297fa75e77a43cb5790",
+      "name": "PeiPei",
+      "symbol": "PEIPEI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38512/large/PeiPei.png?1718315778"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44",
+      "name": "Wrapped TAO",
+      "symbol": "WTAO",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/29087/large/wtao.png?1696528051"
     },
     {
       "chainId": 1,
@@ -3308,19 +3300,11 @@
     },
     {
       "chainId": 1,
-      "address": "0xc9bca88b04581699fab5aa276ccaff7df957cbbf",
-      "name": "Ethervista",
-      "symbol": "VISTA",
+      "address": "0x33333333fede34409fb7f67c6585047e1f653333",
+      "name": "ORA Coin",
+      "symbol": "ORA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40014/large/ethervista.jpg?1725289970"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8802269d1283cdb2a5a329649e5cb4cdcee91ab6",
-      "name": "Fight to MAGA",
-      "symbol": "FIGHT",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/39208/large/photo_2024-07-14_03-15-23.jpg?1721101331"
+      "logoURI": "https://assets.coingecko.com/coins/images/51812/large/ORA_Token.png?1732029092"
     },
     {
       "chainId": 1,
@@ -3348,171 +3332,35 @@
     },
     {
       "chainId": 1,
-      "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
-      "name": "Wrapped Fantom",
-      "symbol": "WFTM",
+      "address": "0x5e8422345238f34275888049021821e8e08caa1f",
+      "name": "Frax Ether",
+      "symbol": "FRXETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16036/large/Fantom.png?1696515646"
+      "logoURI": "https://assets.coingecko.com/coins/images/28284/large/frxETH_icon.png?1696527284"
     },
     {
       "chainId": 1,
-      "address": "0xa2085073878152ac3090ea13d1e41bd69e60dc99",
-      "name": "Escoin",
-      "symbol": "ELG",
+      "address": "0xc03fbf20a586fa89c2a5f6f941458e1fbc40c661",
+      "name": "COMBO",
+      "symbol": "COMBO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13566/large/escoin-200.png?1696513320"
+      "logoURI": "https://assets.coingecko.com/coins/images/4932/large/COMBO.jpg?1696505472"
     },
     {
       "chainId": 1,
-      "address": "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f",
-      "name": "GHO",
-      "symbol": "GHO",
+      "address": "0x590f820444fa3638e022776752c5eef34e2f89a6",
+      "name": "Alephium",
+      "symbol": "ALPH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30663/large/gho-token-logo.png?1720517092"
+      "logoURI": "https://assets.coingecko.com/coins/images/21598/large/Alephium-Logo_200x200_listing.png?1696520959"
     },
     {
       "chainId": 1,
-      "address": "0x3ffeea07a27fab7ad1df5297fa75e77a43cb5790",
-      "name": "PeiPei",
-      "symbol": "PEIPEI",
+      "address": "0xc9bca88b04581699fab5aa276ccaff7df957cbbf",
+      "name": "Ethervista",
+      "symbol": "VISTA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38512/large/PeiPei.png?1718315778"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2a3bff78b79a009976eea096a51a948a3dc00e34",
-      "name": "Wilder World",
-      "symbol": "WILD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15407/large/wld-logo.png?1712273448"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9cb1aeafcc8a9406632c5b084246ea72f62d37b6",
-      "name": "LBK",
-      "symbol": "LBK",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/9492/large/lbk.jpeg?1696509578"
-    },
-    {
-      "chainId": 1,
-      "address": "0x3b991130eae3cca364406d718da22fa1c3e7c256",
-      "name": "Shrub",
-      "symbol": "SHRUB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38880/large/photo_2024-11-13_23.58.11.png?1731575427"
-    },
-    {
-      "chainId": 1,
-      "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
-      "name": "Telcoin",
-      "symbol": "TEL",
-      "decimals": 2,
-      "logoURI": "https://assets.coingecko.com/coins/images/1899/large/tel.png?1696502892"
-    },
-    {
-      "chainId": 1,
-      "address": "0xda987c655ebc38c801db64a8608bc1aa56cd9a31",
-      "name": "Synternet",
-      "symbol": "SYNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38888/large/_SYNT.png?1719380207"
-    },
-    {
-      "chainId": 1,
-      "address": "0x26c8afbbfe1ebaca03c2bb082e69d0476bffe099",
-      "name": "Cellframe",
-      "symbol": "CELL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14465/large/cellframe-coingecko.png?1696514152"
-    },
-    {
-      "chainId": 1,
-      "address": "0x40e3d1a4b2c47d9aa61261f5606136ef73e28042",
-      "name": "OpenServ",
-      "symbol": "SERV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51430/large/tw_profile_picture_logomark_%284%29.png?1731195650"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
-      "name": "OX Coin",
-      "symbol": "OX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
-    },
-    {
-      "chainId": 1,
-      "address": "0x13e4b8cffe704d3de6f19e52b201d92c21ec18bd",
-      "name": "ParallelAI",
-      "symbol": "PAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50394/large/IMG_20240926_230930_523.jpg?1727589698"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfb19075d77a0f111796fb259819830f4780f1429",
-      "name": "Fenerbah e",
-      "symbol": "FB",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17711/large/FB_Logo.png?1696517238"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6aa56e1d98b3805921c170eb4b3fe7d4fda6d89b",
-      "name": "MAGA",
-      "symbol": "TRUMP",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/31498/large/Maga-Trump-Logo-200px.png?1696530309"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9f9c8ec3534c3ce16f928381372bfbfbfb9f4d24",
-      "name": "GraphLinq Chain",
-      "symbol": "GLQ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14474/large/Logo_Dex_4_correct__%282%29.png?1712018526"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc0b68eb52c89e3fffa62d78012ac8b661bfaa323",
-      "name": "Vixco",
-      "symbol": "VIX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15405/large/vixco.png?1696515051"
-    },
-    {
-      "chainId": 1,
-      "address": "0x628a3b2e302c7e896acc432d2d0dd22b6cb9bc88",
-      "name": "LimeWire",
-      "symbol": "LMWR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30356/large/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
-    },
-    {
-      "chainId": 1,
-      "address": "0x678e840c640f619e17848045d23072844224dd37",
-      "name": "Cratos",
-      "symbol": "CRTS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17322/large/cratos.png?1696516876"
-    },
-    {
-      "chainId": 1,
-      "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
-      "name": "OriginTrail",
-      "symbol": "TRAC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1877/large/TRAC.jpg?1696502873"
-    },
-    {
-      "chainId": 1,
-      "address": "0xba41ddf06b7ffd89d1267b5a93bfef2424eb2003",
-      "name": "Mythos",
-      "symbol": "MYTH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28045/large/Mythos_Logos_200x200.png?1696527059"
+      "logoURI": "https://assets.coingecko.com/coins/images/40014/large/ethervista.jpg?1725289970"
     },
     {
       "chainId": 1,
@@ -3524,14 +3372,6 @@
     },
     {
       "chainId": 1,
-      "address": "0xf8c4a95c92b0d0121d1d20f4575073b37883d663",
-      "name": "Tubes",
-      "symbol": "TUBES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37984/large/TUBES.jpg?1716205639"
-    },
-    {
-      "chainId": 1,
       "address": "0xa469b7ee9ee773642b3e93e842e5d9b5baa10067",
       "name": "Anzen USDz",
       "symbol": "USDZ",
@@ -3540,11 +3380,171 @@
     },
     {
       "chainId": 1,
-      "address": "0xa2cd3d43c775978a96bdbf12d733d5a1ed94fb18",
-      "name": "Onyxcoin",
-      "symbol": "XCN",
+      "address": "0x3b991130eae3cca364406d718da22fa1c3e7c256",
+      "name": "Shrub",
+      "symbol": "SHRUB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24210/large/onyxlogo.jpg?1696523397"
+      "logoURI": "https://assets.coingecko.com/coins/images/38880/large/photo_2024-11-13_23.58.11.png?1731575427"
+    },
+    {
+      "chainId": 1,
+      "address": "0x865377367054516e17014ccded1e7d814edc9ce4",
+      "name": "DOLA",
+      "symbol": "DOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
+    },
+    {
+      "chainId": 1,
+      "address": "0xda987c655ebc38c801db64a8608bc1aa56cd9a31",
+      "name": "Synternet",
+      "symbol": "SYNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38888/large/_SYNT.png?1719380207"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2a3bff78b79a009976eea096a51a948a3dc00e34",
+      "name": "Wilder World",
+      "symbol": "WILD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15407/large/wld-logo.png?1712273448"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9cb1aeafcc8a9406632c5b084246ea72f62d37b6",
+      "name": "LBK",
+      "symbol": "LBK",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/9492/large/lbk.jpeg?1696509578"
+    },
+    {
+      "chainId": 1,
+      "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
+      "name": "Telcoin",
+      "symbol": "TEL",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/1899/large/tel.png?1696502892"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc0b68eb52c89e3fffa62d78012ac8b661bfaa323",
+      "name": "Vixco",
+      "symbol": "VIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15405/large/vixco.png?1696515051"
+    },
+    {
+      "chainId": 1,
+      "address": "0x13e4b8cffe704d3de6f19e52b201d92c21ec18bd",
+      "name": "ParallelAI",
+      "symbol": "PAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50394/large/IMG_20240926_230930_523.jpg?1727589698"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6aa56e1d98b3805921c170eb4b3fe7d4fda6d89b",
+      "name": "MAGA",
+      "symbol": "TRUMP",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/31498/large/Maga-Trump-Logo-200px.png?1696530309"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa1290d69c65a6fe4df752f95823fae25cb99e5a7",
+      "name": "Kelp DAO Restaked ETH",
+      "symbol": "RSETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33800/large/Icon___Dark.png?1702991855"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3da932456d082cba208feb0b096d49b202bf89c8",
+      "name": "Dego Finance",
+      "symbol": "DEGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12503/large/Token.png?1733381203"
+    },
+    {
+      "chainId": 1,
+      "address": "0x26c8afbbfe1ebaca03c2bb082e69d0476bffe099",
+      "name": "Cellframe",
+      "symbol": "CELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14465/large/cellframe-coingecko.png?1696514152"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9f9c8ec3534c3ce16f928381372bfbfbfb9f4d24",
+      "name": "GraphLinq Chain",
+      "symbol": "GLQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14474/large/Logo_Dex_4_correct__%282%29.png?1712018526"
+    },
+    {
+      "chainId": 1,
+      "address": "0x678e840c640f619e17848045d23072844224dd37",
+      "name": "Cratos",
+      "symbol": "CRTS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17322/large/cratos.png?1696516876"
+    },
+    {
+      "chainId": 1,
+      "address": "0x62b9c7356a2dc64a1969e19c23e4f579f9810aa7",
+      "name": "Convex CRV",
+      "symbol": "CVXCRV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15586/large/convex-crv.png?1696515222"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba41ddf06b7ffd89d1267b5a93bfef2424eb2003",
+      "name": "Mythos",
+      "symbol": "MYTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28045/large/Mythos_Logos_200x200.png?1696527059"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf8c4a95c92b0d0121d1d20f4575073b37883d663",
+      "name": "Tubes",
+      "symbol": "TUBES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37984/large/TUBES.jpg?1716205639"
+    },
+    {
+      "chainId": 1,
+      "address": "0x40e3d1a4b2c47d9aa61261f5606136ef73e28042",
+      "name": "OpenServ",
+      "symbol": "SERV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51430/large/tw_profile_picture_logomark_%284%29.png?1731195650"
+    },
+    {
+      "chainId": 1,
+      "address": "0x628a3b2e302c7e896acc432d2d0dd22b6cb9bc88",
+      "name": "LimeWire",
+      "symbol": "LMWR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30356/large/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
+    },
+    {
+      "chainId": 1,
+      "address": "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f",
+      "name": "GHO",
+      "symbol": "GHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30663/large/gho-token-logo.png?1720517092"
     },
     {
       "chainId": 1,
@@ -3556,51 +3556,11 @@
     },
     {
       "chainId": 1,
-      "address": "0x728f30fa2f100742c7949d1961804fa8e0b1387d",
-      "name": "GamerCoin",
-      "symbol": "GHX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14714/large/ghx_icon.png?1696514385"
-    },
-    {
-      "chainId": 1,
       "address": "0x4c6e2c495b974b8d4220e370f23c7e0e1da9b644",
       "name": "Smiley Coin",
       "symbol": "SMILEY",
       "decimals": 9,
       "logoURI": "https://assets.coingecko.com/coins/images/30809/large/photo_2023-06-21_03-25-14.jpg?1696529666"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
-      "name": "DFI money",
-      "symbol": "YFII",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11902/large/YFII-logo.78631676.png?1696511768"
-    },
-    {
-      "chainId": 1,
-      "address": "0x7d8146cf21e8d7cbe46054e01588207b51198729",
-      "name": "BOB Token",
-      "symbol": "BOB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29929/large/bob.png?1696528857"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6f40d4a6237c257fff2db00fa0510deeecd303eb",
-      "name": "Fluid",
-      "symbol": "FLUID",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14688/large/Logo_1_%28brighter%29.png?1734430693"
-    },
-    {
-      "chainId": 1,
-      "address": "0x046bad07658f3b6cad9a396cfcbc1243af452ec1",
-      "name": "ArchLoot",
-      "symbol": "AL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28919/large/7.png?1696527894"
     },
     {
       "chainId": 1,
@@ -3620,6 +3580,14 @@
     },
     {
       "chainId": 1,
+      "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
+      "name": "DFI money",
+      "symbol": "YFII",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11902/large/YFII-logo.78631676.png?1696511768"
+    },
+    {
+      "chainId": 1,
       "address": "0x4fc15c91a9c4a9efb404174464687e8e128730c2",
       "name": "STAT",
       "symbol": "STAT",
@@ -3628,323 +3596,35 @@
     },
     {
       "chainId": 1,
-      "address": "0x408e41876cccdc0f92210600ef50372656052a38",
-      "name": "Ren",
-      "symbol": "REN",
+      "address": "0xa2cd3d43c775978a96bdbf12d733d5a1ed94fb18",
+      "name": "Onyxcoin",
+      "symbol": "XCN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3139/large/REN.png?1696503862"
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/large/onyxlogo.jpg?1696523397"
     },
     {
       "chainId": 1,
-      "address": "0x64d0f55cd8c7133a9d7102b13987235f486f2224",
-      "name": "SwissBorg",
-      "symbol": "BORG",
+      "address": "0x728f30fa2f100742c7949d1961804fa8e0b1387d",
+      "name": "GamerCoin",
+      "symbol": "GHX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2117/large/YJUrRy7r_400x400.png?1696503083"
+      "logoURI": "https://assets.coingecko.com/coins/images/14714/large/ghx_icon.png?1696514385"
     },
     {
       "chainId": 1,
-      "address": "0x046eee2cc3188071c02bfc1745a6b17c656e3f3d",
-      "name": "Rollbit Coin",
-      "symbol": "RLB",
+      "address": "0x046bad07658f3b6cad9a396cfcbc1243af452ec1",
+      "name": "ArchLoot",
+      "symbol": "AL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24552/large/unziL6wO_400x400.jpg?1696523729"
+      "logoURI": "https://assets.coingecko.com/coins/images/28919/large/7.png?1696527894"
     },
     {
       "chainId": 1,
-      "address": "0xdab396ccf3d84cf2d07c4454e10c8a6f5b008d2b",
-      "name": "Goldfinch",
-      "symbol": "GFI",
+      "address": "0x7d8146cf21e8d7cbe46054e01588207b51198729",
+      "name": "BOB Token",
+      "symbol": "BOB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19081/large/GOLDFINCH.png?1696518531"
-    },
-    {
-      "chainId": 1,
-      "address": "0x226bb599a12c826476e3a771454697ea52e9e220",
-      "name": "Propy",
-      "symbol": "PRO",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/869/large/propy.png?1696502002"
-    },
-    {
-      "chainId": 1,
-      "address": "0xacd2c239012d17beb128b0944d49015104113650",
-      "name": "Karrat",
-      "symbol": "KARRAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37237/large/SmallLogo.png?1714755426"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa0ef786bf476fe0810408caba05e536ac800ff86",
-      "name": "Myria",
-      "symbol": "MYRIA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29273/large/myria.png?1696528226"
-    },
-    {
-      "chainId": 1,
-      "address": "0x03aa6298f1370642642415edc0db8b957783e8d6",
-      "name": "NetMind Token",
-      "symbol": "NMT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35328/large/NMT-logo.png?1708267799"
-    },
-    {
-      "chainId": 1,
-      "address": "0x4c7fe8f97db97cbccc76989ab742afc66ca6e75c",
-      "name": "RYO Coin",
-      "symbol": "RYO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39352/large/Asset_3.png_ryo_logo.png?1721887842"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9ff58067bd8d239000010c154c6983a325df138e",
-      "name": "Propchain",
-      "symbol": "PROPC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30451/large/prop_%281%29.png?1702322253"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0f51bb10119727a7e5ea3538074fb341f56b09ad",
-      "name": "DAO Maker",
-      "symbol": "DAO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13915/large/4.jpg?1727532864"
-    },
-    {
-      "chainId": 1,
-      "address": "0x558e7139800f8bc119f68d23a6126fffd43a66a6",
-      "name": "U2U Network",
-      "symbol": "U2U",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32963/large/Logo_U2U.jpeg?1734261244"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf6801c3e4108ead0deb216a3295338a582734c24",
-      "name": "LifeBankChain",
-      "symbol": "LBC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39183/large/LBC_LOGO.jpg?1720850935"
-    },
-    {
-      "chainId": 1,
-      "address": "0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
-      "name": "Kyber Network Crystal Legacy",
-      "symbol": "KNCL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/947/large/logo-kncl.png?1696502063"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
-      "name": "Cream",
-      "symbol": "CREAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11976/large/Cream.png?1696511834"
-    },
-    {
-      "chainId": 1,
-      "address": "0xfc4b4ec763722b71eb1d729749b447a9645f5f30",
-      "name": "DumbMoney",
-      "symbol": "GME",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/32058/large/DumbMoney_-_GME_-_Official_Logo_200x200px.png?1696530855"
-    },
-    {
-      "chainId": 1,
-      "address": "0xc064f4f215b6a1e4e7f39bd8530c4de0fc43ee9d",
-      "name": "LeisureMeta",
-      "symbol": "LM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25761/large/SVG_16533804486374586M.jpg?1696524846"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0bc37bea9068a86c221b8bd71ea6228260dad5a2",
-      "name": "Upland",
-      "symbol": "SPARKLET",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39257/large/UPLAND.png?1721382041"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb31ef9e52d94d4120eb44fe1ddfde5b4654a6515",
-      "name": "DOSE",
-      "symbol": "DOSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18847/large/dose.PNG?1696518308"
-    },
-    {
-      "chainId": 1,
-      "address": "0xb056c38f6b7dc4064367403e26424cd2c60655e1",
-      "name": "CEEK Smart VR",
-      "symbol": "CEEK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2581/large/ceek-smart-vr-token-logo.png?1696503385"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6",
-      "name": "USDD",
-      "symbol": "USDD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25380/large/UUSD.jpg?1696524513"
-    },
-    {
-      "chainId": 1,
-      "address": "0xa831a4e181f25d3b35949e582ff27cc44e703f37",
-      "name": "ALEX Lab",
-      "symbol": "ALEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25837/large/ALEX_Token.png?1696524922"
-    },
-    {
-      "chainId": 1,
-      "address": "0x74232704659ef37c08995e386a2e26cc27a8d7b1",
-      "name": "Strike",
-      "symbol": "STRIKE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14607/large/Jw-36llq_400x400.jpg?1696514286"
-    },
-    {
-      "chainId": 1,
-      "address": "0x32b86b99441480a7e5bd3a26c124ec2373e3f015",
-      "name": "Bad Idea AI",
-      "symbol": "BAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30871/large/BadIdea-Logo_Icon-Emblem.png?1723167526"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5ca381bbfb58f0092df149bd3d243b08b9a8386e",
-      "name": "Moonchain",
-      "symbol": "MXC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4604/large/M_1-modified.png?1712206949"
-    },
-    {
-      "chainId": 1,
-      "address": "0x8be3460a480c80728a8c4d7a5d5303c85ba7b3b9",
-      "name": "Ethena Staked ENA",
-      "symbol": "SENA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50235/large/ena.png?1726630994"
-    },
-    {
-      "chainId": 1,
-      "address": "0xadd5e881984783dd432f80381fb52f45b53f3e70",
-      "name": "Vite",
-      "symbol": "VITE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4513/large/VITE_new_logo_200px.png?1709175957"
-    },
-    {
-      "chainId": 1,
-      "address": "0x9aab071b4129b083b01cb5a0cb513ce7eca26fa5",
-      "name": "Hunt",
-      "symbol": "HUNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7989/large/HUNT.png?1696508215"
-    },
-    {
-      "chainId": 1,
-      "address": "0x967fb0d760ed3ce53afe2f0a071674cccae73550",
-      "name": "XANA",
-      "symbol": "XETA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24379/large/XANA_Silver_Logo_%281%29.png?1729504384"
-    },
-    {
-      "chainId": 1,
-      "address": "0x2e44f3f609ff5aa4819b323fd74690f07c3607c4",
-      "name": "PinLink",
-      "symbol": "PIN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51611/large/200x00.png?1731616756"
-    },
-    {
-      "chainId": 1,
-      "address": "0x939069722d568b5498ccba4356e800eaefefd2a5",
-      "name": "Finanx AI",
-      "symbol": "FNXAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51119/large/200x200.png?1730126766"
-    },
-    {
-      "chainId": 1,
-      "address": "0xcb76314c2540199f4b844d4ebbc7998c604880ca",
-      "name": "Strawberry AI",
-      "symbol": "BERRY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39700/large/photo_2024-08-13_20-13-39.jpg?1723690584"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf5581dfefd8fb0e4aec526be659cfab1f8c781da",
-      "name": "HOPR",
-      "symbol": "HOPR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14061/large/Shared_HOPR_logo_512px.png?1696513786"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0001a500a6b18995b03f44bb040a5ffc28e45cb0",
-      "name": "Autonolas",
-      "symbol": "OLAS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31099/large/OLAS-token.png?1696529930"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf1c9acdc66974dfb6decb12aa385b9cd01190e38",
-      "name": "StakeWise Staked ETH",
-      "symbol": "OSETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33117/large/Frame_27513839.png?1700732599"
-    },
-    {
-      "chainId": 1,
-      "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
-      "name": "PARSIQ",
-      "symbol": "PRQ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11973/large/DsNgK0O.png?1696511831"
-    },
-    {
-      "chainId": 1,
-      "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
-      "name": "Liquity USD",
-      "symbol": "LUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1696514341"
-    },
-    {
-      "chainId": 1,
-      "address": "0x6b0b3a982b4634ac68dd83a4dbf02311ce324181",
-      "name": "Artificial Liquid Intelligence",
-      "symbol": "ALI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22062/large/ALI-v2.webp?1728501978"
-    },
-    {
-      "chainId": 1,
-      "address": "0xf107edabf59ba696e38de62ad5327415bd4d4236",
-      "name": "CatSlap",
-      "symbol": "SLAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51985/large/Cat_Slap_200x200_Logo_1.png?1732292609"
-    },
-    {
-      "chainId": 1,
-      "address": "0x0305f515fa978cf87226cf8a9776d25bcfb2cc0b",
-      "name": "Pepe 2 0",
-      "symbol": "PEPE20",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30853/large/PEPE_2.0.png?1707684909"
+      "logoURI": "https://assets.coingecko.com/coins/images/29929/large/bob.png?1696528857"
     },
     {
       "chainId": 1,
@@ -3956,11 +3636,227 @@
     },
     {
       "chainId": 1,
-      "address": "0xec463d00aa4da76fb112cd2e4ac1c6bef02da6ea",
-      "name": "Heurist",
-      "symbol": "HEU",
+      "address": "0x64d0f55cd8c7133a9d7102b13987235f486f2224",
+      "name": "SwissBorg",
+      "symbol": "BORG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51361/large/200X200.png?1733764636"
+      "logoURI": "https://assets.coingecko.com/coins/images/2117/large/YJUrRy7r_400x400.png?1696503083"
+    },
+    {
+      "chainId": 1,
+      "address": "0x226bb599a12c826476e3a771454697ea52e9e220",
+      "name": "Propy",
+      "symbol": "PRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/869/large/propy.png?1696502002"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6f40d4a6237c257fff2db00fa0510deeecd303eb",
+      "name": "Fluid",
+      "symbol": "FLUID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14688/large/Logo_1_%28brighter%29.png?1734430693"
+    },
+    {
+      "chainId": 1,
+      "address": "0x408e41876cccdc0f92210600ef50372656052a38",
+      "name": "Ren",
+      "symbol": "REN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3139/large/REN.png?1696503862"
+    },
+    {
+      "chainId": 1,
+      "address": "0x32b86b99441480a7e5bd3a26c124ec2373e3f015",
+      "name": "Bad Idea AI",
+      "symbol": "BAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30871/large/BadIdea-Logo_Icon-Emblem.png?1723167526"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfc4b4ec763722b71eb1d729749b447a9645f5f30",
+      "name": "DumbMoney",
+      "symbol": "GME",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/32058/large/DumbMoney_-_GME_-_Official_Logo_200x200px.png?1696530855"
+    },
+    {
+      "chainId": 1,
+      "address": "0x03aa6298f1370642642415edc0db8b957783e8d6",
+      "name": "NetMind Token",
+      "symbol": "NMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35328/large/NMT-logo.png?1708267799"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f51bb10119727a7e5ea3538074fb341f56b09ad",
+      "name": "DAO Maker",
+      "symbol": "DAO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13915/large/4.jpg?1727532864"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb31ef9e52d94d4120eb44fe1ddfde5b4654a6515",
+      "name": "DOSE",
+      "symbol": "DOSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18847/large/dose.PNG?1696518308"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf6801c3e4108ead0deb216a3295338a582734c24",
+      "name": "LifeBankChain",
+      "symbol": "LBC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39183/large/LBC_LOGO.jpg?1720850935"
+    },
+    {
+      "chainId": 1,
+      "address": "0x967fb0d760ed3ce53afe2f0a071674cccae73550",
+      "name": "XANA",
+      "symbol": "XETA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24379/large/XANA_Silver_Logo_%281%29.png?1729504384"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0ef786bf476fe0810408caba05e536ac800ff86",
+      "name": "Myria",
+      "symbol": "MYRIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29273/large/myria.png?1696528226"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf1c9acdc66974dfb6decb12aa385b9cd01190e38",
+      "name": "StakeWise Staked ETH",
+      "symbol": "OSETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33117/large/Frame_27513839.png?1700732599"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8be3460a480c80728a8c4d7a5d5303c85ba7b3b9",
+      "name": "Ethena Staked ENA",
+      "symbol": "SENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50235/large/ena.png?1726630994"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdab396ccf3d84cf2d07c4454e10c8a6f5b008d2b",
+      "name": "Goldfinch",
+      "symbol": "GFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19081/large/GOLDFINCH.png?1696518531"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c7fe8f97db97cbccc76989ab742afc66ca6e75c",
+      "name": "RYO Coin",
+      "symbol": "RYO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39352/large/Asset_3.png_ryo_logo.png?1721887842"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaa247c0d81b83812e1abf8bab078e4540d87e3fb",
+      "name": "Meson Network",
+      "symbol": "MSN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34981/large/meson-token-icon200.png?1714275908"
+    },
+    {
+      "chainId": 1,
+      "address": "0x74232704659ef37c08995e386a2e26cc27a8d7b1",
+      "name": "Strike",
+      "symbol": "STRIKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14607/large/Jw-36llq_400x400.jpg?1696514286"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2e44f3f609ff5aa4819b323fd74690f07c3607c4",
+      "name": "PinLink",
+      "symbol": "PIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51611/large/200x00.png?1731616756"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2e9d63788249371f1dfc918a52f8d799f4a38c94",
+      "name": "Tokemak",
+      "symbol": "TOKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17495/large/tokemak-avatar-200px-black.png?1696517036"
+    },
+    {
+      "chainId": 1,
+      "address": "0x046eee2cc3188071c02bfc1745a6b17c656e3f3d",
+      "name": "Rollbit Coin",
+      "symbol": "RLB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24552/large/unziL6wO_400x400.jpg?1696523729"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0bc37bea9068a86c221b8bd71ea6228260dad5a2",
+      "name": "Upland",
+      "symbol": "SPARKLET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39257/large/UPLAND.png?1721382041"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
+      "name": "Kyber Network Crystal Legacy",
+      "symbol": "KNCL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/947/large/logo-kncl.png?1696502063"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6",
+      "name": "USDD",
+      "symbol": "USDD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25380/large/UUSD.jpg?1696524513"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9aab071b4129b083b01cb5a0cb513ce7eca26fa5",
+      "name": "Hunt",
+      "symbol": "HUNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7989/large/HUNT.png?1696508215"
+    },
+    {
+      "chainId": 1,
+      "address": "0x939069722d568b5498ccba4356e800eaefefd2a5",
+      "name": "Finanx AI",
+      "symbol": "FNXAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51119/large/200x200.png?1730126766"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6b0b3a982b4634ac68dd83a4dbf02311ce324181",
+      "name": "Artificial Liquid Intelligence",
+      "symbol": "ALI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22062/large/ALI-v2.webp?1728501978"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0001a500a6b18995b03f44bb040a5ffc28e45cb0",
+      "name": "Autonolas",
+      "symbol": "OLAS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31099/large/OLAS-token.png?1696529930"
     },
     {
       "chainId": 1,
@@ -3972,6 +3868,22 @@
     },
     {
       "chainId": 1,
+      "address": "0xadd5e881984783dd432f80381fb52f45b53f3e70",
+      "name": "Vite",
+      "symbol": "VITE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4513/large/VITE_new_logo_200px.png?1709175957"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc064f4f215b6a1e4e7f39bd8530c4de0fc43ee9d",
+      "name": "LeisureMeta",
+      "symbol": "LM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25761/large/SVG_16533804486374586M.jpg?1696524846"
+    },
+    {
+      "chainId": 1,
       "address": "0x3567aa22cd3ab9aef23d7e18ee0d7cf16974d7e6",
       "name": "Sharpe AI",
       "symbol": "SAI",
@@ -3980,11 +3892,51 @@
     },
     {
       "chainId": 1,
-      "address": "0xcbde0453d4e7d748077c1b0ac2216c011dd2f406",
-      "name": "Terminus",
-      "symbol": "TERMINUS",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/50307/large/terminus.jpg?1727057343"
+      "address": "0xf107edabf59ba696e38de62ad5327415bd4d4236",
+      "name": "CatSlap",
+      "symbol": "SLAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51985/large/Cat_Slap_200x200_Logo_1.png?1732292609"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+      "name": "Liquity USD",
+      "symbol": "LUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1696514341"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf5581dfefd8fb0e4aec526be659cfab1f8c781da",
+      "name": "HOPR",
+      "symbol": "HOPR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14061/large/Shared_HOPR_logo_512px.png?1696513786"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5ca381bbfb58f0092df149bd3d243b08b9a8386e",
+      "name": "Moonchain",
+      "symbol": "MXC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4604/large/M_1-modified.png?1712206949"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0921799cb1d702148131024d18fcde022129dc73",
+      "name": "LightLink",
+      "symbol": "LL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35357/large/lightlink-ticker-200.png?1708362303"
+    },
+    {
+      "chainId": 1,
+      "address": "0xacd2c239012d17beb128b0944d49015104113650",
+      "name": "Karrat",
+      "symbol": "KARRAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37237/large/SmallLogo.png?1714755426"
     },
     {
       "chainId": 1,
@@ -3996,11 +3948,51 @@
     },
     {
       "chainId": 1,
-      "address": "0x59f4f336bf3d0c49dbfba4a74ebd2a6ace40539a",
-      "name": "Catcoin",
-      "symbol": "CAT",
+      "address": "0x19e1f2f837a3b90ebd0730cb6111189be0e1b6d6",
+      "name": "La ka",
+      "symbol": "LAIKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39364/large/logo_laika.jpg?1721895773"
+    },
+    {
+      "chainId": 1,
+      "address": "0x839e71613f9aa06e5701cf6de63e303616b0dde3",
+      "name": "VVS Finance",
+      "symbol": "VVS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20210/large/8glAYOTM_400x400.jpg?1696519620"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcbde0453d4e7d748077c1b0ac2216c011dd2f406",
+      "name": "Terminus",
+      "symbol": "TERMINUS",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/25279/large/cat5.png?1696524419"
+      "logoURI": "https://assets.coingecko.com/coins/images/50307/large/terminus.jpg?1727057343"
+    },
+    {
+      "chainId": 1,
+      "address": "0x558e7139800f8bc119f68d23a6126fffd43a66a6",
+      "name": "U2U Network",
+      "symbol": "U2U",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32963/large/Logo_U2U.jpeg?1734261244"
+    },
+    {
+      "chainId": 1,
+      "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
+      "name": "PARSIQ",
+      "symbol": "PRQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11973/large/DsNgK0O.png?1696511831"
+    },
+    {
+      "chainId": 1,
+      "address": "0x42726d074bba68ccc15200442b72afa2d495a783",
+      "name": "Isiklar Coin",
+      "symbol": "ISIKC",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/10992/large/logo_%2866%29.png?1696510941"
     },
     {
       "chainId": 1,
@@ -4009,7 +4001,15 @@
       "symbol": "PARAM",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/37697/large/param200.png?1715234889"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2565ae0385659badcada1031db704442e1b69982",
+      "name": "Assemble Protocol",
+      "symbol": "ASM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11605/large/ASM_512X512_white.png?1717463859"
     }
   ],
-  "timestamp": "2024-12-17T18:12:41.610Z"
+  "timestamp": "2024-12-17T20:31:06.649Z"
 }

--- a/src/public/CoinGecko.42161.json
+++ b/src/public/CoinGecko.42161.json
@@ -5,9 +5,9 @@
     "defi"
   ],
   "version": {
-    "major": 0,
+    "major": 1,
     "minor": 0,
-    "patch": 1
+    "patch": 0
   },
   "tokens": [
     {
@@ -60,19 +60,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
-      "name": "Arbitrum",
-      "symbol": "ARB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16547/large/arb.jpg?1721358242"
-    },
-    {
-      "chainId": 42161,
       "address": "0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0",
       "name": "Uniswap",
       "symbol": "UNI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/12504/large/uniswap-logo.png?1720676669"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+      "name": "Arbitrum",
+      "symbol": "ARB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16547/large/arb.jpg?1721358242"
     },
     {
       "chainId": 42161,
@@ -108,19 +108,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60",
-      "name": "Lido DAO",
-      "symbol": "LDO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1696513326"
-    },
-    {
-      "chainId": 42161,
       "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
       "name": "Arbitrum Bridged USDT  Arbitrum ",
       "symbol": "USDT",
       "decimals": 6,
       "logoURI": "https://assets.coingecko.com/coins/images/35073/large/logo.png?1707292836"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60",
+      "name": "Lido DAO",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1696513326"
     },
     {
       "chainId": 42161,
@@ -164,11 +164,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x0c880f6761f1af8d9aa9c466984b80dab9a8c9e8",
-      "name": "Pendle",
-      "symbol": "PENDLE",
+      "address": "0x9623063377ad1b27544c965ccd7342f7ea7e88c7",
+      "name": "The Graph",
+      "symbol": "GRT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/large/Graph_Token.png?1696513159"
     },
     {
       "chainId": 42161,
@@ -180,67 +180,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x354a6da3fcde098f8389cad84b0182725c6c91de",
-      "name": "Compound",
-      "symbol": "COMP",
+      "address": "0x0c880f6761f1af8d9aa9c466984b80dab9a8c9e8",
+      "name": "Pendle",
+      "symbol": "PENDLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10775/large/COMP.png?1696510737"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9623063377ad1b27544c965ccd7342f7ea7e88c7",
-      "name": "The Graph",
-      "symbol": "GRT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13397/large/Graph_Token.png?1696513159"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x53691596d1bce8cea565b84d4915e69e03d9c99d",
-      "name": "Across Protocol",
-      "symbol": "ACX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xca5ca9083702c56b481d1eec86f1776fdbd2e594",
-      "name": "Reserve Rights",
-      "symbol": "RSR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
-      "name": "CARV",
-      "symbol": "CARV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x289ba1701c2f088cf0faf8b3705246331cb8a839",
-      "name": "Livepeer",
-      "symbol": "LPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7137/large/badge-logo-circuit-green.png?1719357686"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
-      "name": "Arbitrum Bridged USDC  Arbitrum ",
-      "symbol": "USDCE",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/30691/large/usdc.png?1696529560"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9f07f8a82cb1af1466252e505b7b7ddee103bc91",
-      "name": "Degen  Base ",
-      "symbol": "DEGEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
+      "logoURI": "https://assets.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
     },
     {
       "chainId": 42161,
@@ -252,11 +196,59 @@
     },
     {
       "chainId": 42161,
-      "address": "0xd58d345fd9c82262e087d2d0607624b410d88242",
-      "name": "Tellor Tributes",
-      "symbol": "TRB",
+      "address": "0x354a6da3fcde098f8389cad84b0182725c6c91de",
+      "name": "Compound",
+      "symbol": "COMP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9644/large/Blk_icon_current.png?1696509713"
+      "logoURI": "https://assets.coingecko.com/coins/images/10775/large/COMP.png?1696510737"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x53691596d1bce8cea565b84d4915e69e03d9c99d",
+      "name": "Across Protocol",
+      "symbol": "ACX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+      "name": "CARV",
+      "symbol": "CARV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+      "name": "Arbitrum Bridged USDC  Arbitrum ",
+      "symbol": "USDCE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/30691/large/usdc.png?1696529560"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xca5ca9083702c56b481d1eec86f1776fdbd2e594",
+      "name": "Reserve Rights",
+      "symbol": "RSR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x289ba1701c2f088cf0faf8b3705246331cb8a839",
+      "name": "Livepeer",
+      "symbol": "LPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/large/badge-logo-circuit-green.png?1719357686"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9f07f8a82cb1af1466252e505b7b7ddee103bc91",
+      "name": "Degen  Base ",
+      "symbol": "DEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
     },
     {
       "chainId": 42161,
@@ -265,6 +257,14 @@
       "symbol": "LQTY",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/14665/large/logo_V2.png?1725437146"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd58d345fd9c82262e087d2d0607624b410d88242",
+      "name": "Tellor Tributes",
+      "symbol": "TRB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/large/Blk_icon_current.png?1696509713"
     },
     {
       "chainId": 42161,
@@ -308,14 +308,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0xcafcd85d8ca7ad1e1c6f82f651fa15e33aefd07b",
-      "name": "WOO",
-      "symbol": "WOO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
-    },
-    {
-      "chainId": 42161,
       "address": "0x46d0ce7de6247b0a95f67b43b589b4041bae7fbe",
       "name": "Loopring",
       "symbol": "LRC",
@@ -324,11 +316,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xaeaeed23478c3a4b798e4ed40d8b7f41366ae861",
-      "name": "Ankr Network",
-      "symbol": "ANKR",
+      "address": "0xcafcd85d8ca7ad1e1c6f82f651fa15e33aefd07b",
+      "name": "WOO",
+      "symbol": "WOO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1696504928"
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
     },
     {
       "chainId": 42161,
@@ -337,30 +329,6 @@
       "symbol": "AXL",
       "decimals": 6,
       "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg?1696526329"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa68ec98d7ca870cf1dd0b00ebbb7c4bf60a8e74d",
-      "name": "Biconomy",
-      "symbol": "BICO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21061/large/biconomy_logo.jpg?1696520444"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6694340fc020c5e6b96567843da2df01b2ce1eb6",
-      "name": "Stargate Finance",
-      "symbol": "STG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7",
-      "name": "Frax Share",
-      "symbol": "FXS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1696513183"
     },
     {
       "chainId": 42161,
@@ -380,11 +348,35 @@
     },
     {
       "chainId": 42161,
-      "address": "0x3082cc23568ea640225c2467653db90e9250aaa0",
-      "name": "Radiant Capital",
-      "symbol": "RDNT",
+      "address": "0xa68ec98d7ca870cf1dd0b00ebbb7c4bf60a8e74d",
+      "name": "Biconomy",
+      "symbol": "BICO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/large/biconomy_logo.jpg?1696520444"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6694340fc020c5e6b96567843da2df01b2ce1eb6",
+      "name": "Stargate Finance",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaeaeed23478c3a4b798e4ed40d8b7f41366ae861",
+      "name": "Ankr Network",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1696504928"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7",
+      "name": "Frax Share",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1696513183"
     },
     {
       "chainId": 42161,
@@ -393,6 +385,14 @@
       "symbol": "RETH",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/20764/large/reth.png?1696520159"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3082cc23568ea640225c2467653db90e9250aaa0",
+      "name": "Radiant Capital",
+      "symbol": "RDNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
     },
     {
       "chainId": 42161,
@@ -412,27 +412,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xb766039cc6db368759c1e56b79affe831d0cc507",
-      "name": "Rocket Pool",
-      "symbol": "RPL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
-    },
-    {
-      "chainId": 42161,
       "address": "0x4e200fe2f3efb977d5fd9c430a41531fb04d97b8",
       "name": "Orderly Network",
       "symbol": "ORDER",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/38501/large/Orderly_Network_Coingecko_200*200.png?1717751359"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x35751007a407ca6feffe80b3cb397736d2cf4dbe",
-      "name": "Wrapped eETH",
-      "symbol": "WEETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
     },
     {
       "chainId": 42161,
@@ -452,27 +436,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0xda661fa59320b808c5a6d23579fcfedf1fd3cf36",
-      "name": "Mobox",
-      "symbol": "MBOX",
+      "address": "0xb766039cc6db368759c1e56b79affe831d0cc507",
+      "name": "Rocket Pool",
+      "symbol": "RPL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14751/large/mobox.PNG?1696514420"
+      "logoURI": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
     },
     {
       "chainId": 42161,
-      "address": "0x753d224bcf9aafacd81558c32341416df61d3dac",
-      "name": "Perpetual Protocol",
-      "symbol": "PERP",
+      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
+      "name": "Telos",
+      "symbol": "TLOS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x319f865b287fcc10b30d8ce6144e8b6d1b476999",
-      "name": "Cartesi",
-      "symbol": "CTSI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
+      "logoURI": "https://assets.coingecko.com/coins/images/7588/large/tlos_png.png?1722391289"
     },
     {
       "chainId": 42161,
@@ -484,11 +460,35 @@
     },
     {
       "chainId": 42161,
-      "address": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
-      "name": "Telos",
-      "symbol": "TLOS",
+      "address": "0x319f865b287fcc10b30d8ce6144e8b6d1b476999",
+      "name": "Cartesi",
+      "symbol": "CTSI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/7588/large/tlos_png.png?1722391289"
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/large/Cartesi_Logo.png?1696510982"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x753d224bcf9aafacd81558c32341416df61d3dac",
+      "name": "Perpetual Protocol",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/large/60d18e06844a844ad75901a9_mark_only_03.png?1696512205"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35751007a407ca6feffe80b3cb397736d2cf4dbe",
+      "name": "Wrapped eETH",
+      "symbol": "WEETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xda661fa59320b808c5a6d23579fcfedf1fd3cf36",
+      "name": "Mobox",
+      "symbol": "MBOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14751/large/mobox.PNG?1696514420"
     },
     {
       "chainId": 42161,
@@ -524,11 +524,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x3a8b787f78d775aecfeea15706d4221b40f345ab",
-      "name": "Celer Network",
-      "symbol": "CELR",
+      "address": "0xc1eb7689147c81ac840d4ff0d298489fc7986d52",
+      "name": "Venus",
+      "symbol": "XVS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4379/large/Celr.png?1696504978"
+      "logoURI": "https://assets.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
     },
     {
       "chainId": 42161,
@@ -540,19 +540,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x3e6648c5a70a150a88bce65f4ad4d506fe15d2af",
-      "name": "Spell",
-      "symbol": "SPELL",
+      "address": "0x3a8b787f78d775aecfeea15706d4221b40f345ab",
+      "name": "Celer Network",
+      "symbol": "CELR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15861/large/abracadabra-3.png?1696515477"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc1eb7689147c81ac840d4ff0d298489fc7986d52",
-      "name": "Venus",
-      "symbol": "XVS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/large/Celr.png?1696504978"
     },
     {
       "chainId": 42161,
@@ -564,19 +556,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x178412e79c25968a32e89b11f63b33f733770c2a",
-      "name": "Frax Ether",
-      "symbol": "FRXETH",
+      "address": "0x3e6648c5a70a150a88bce65f4ad4d506fe15d2af",
+      "name": "Spell",
+      "symbol": "SPELL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28284/large/frxETH_icon.png?1696527284"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
-      "name": "Axelar Bridged USDC",
-      "symbol": "AXLUSDC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/26476/large/uausdc_D_3x.png?1696525548"
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/large/abracadabra-3.png?1696515477"
     },
     {
       "chainId": 42161,
@@ -585,6 +569,14 @@
       "symbol": "SYN",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/18024/large/synapse_social_icon.png?1696517540"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
+      "name": "Axelar Bridged USDC",
+      "symbol": "AXLUSDC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26476/large/uausdc_D_3x.png?1696525548"
     },
     {
       "chainId": 42161,
@@ -604,14 +596,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0x09e18590e8f76b6cf471b3cd75fe1a1a9d2b2c2b",
-      "name": "ArbDoge AI",
-      "symbol": "AIDOGE",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29852/large/photo_2023-04-18_14-25-28.jpg?1696528778"
-    },
-    {
-      "chainId": 42161,
       "address": "0x2b65f9d2e4b84a2df6ff0525741b75d1276a9c2f",
       "name": "Staked USD0",
       "symbol": "USD0++",
@@ -620,11 +604,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
-      "name": "MakerDAO Arbitrum Bridged DAI  Arbitrum",
-      "symbol": "DAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39790/large/dai.png?1724111653"
+      "address": "0x09e18590e8f76b6cf471b3cd75fe1a1a9d2b2c2b",
+      "name": "ArbDoge AI",
+      "symbol": "AIDOGE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29852/large/photo_2023-04-18_14-25-28.jpg?1696528778"
     },
     {
       "chainId": 42161,
@@ -636,14 +620,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0x1c43d05be7e5b54d506e3ddb6f0305e8a66cd04e",
-      "name": "ZTX",
-      "symbol": "ZTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32340/large/CoinGecko_200_x_200.jpg?1697466589"
-    },
-    {
-      "chainId": 42161,
       "address": "0x346c574c56e1a4aaa8dc88cda8f7eb12b39947ab",
       "name": "Solv Protocol SolvBTC BBN",
       "symbol": "SOLVBTCBBN",
@@ -652,11 +628,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
-      "name": "World Mobile Token",
-      "symbol": "WMTX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
+      "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+      "name": "MakerDAO Arbitrum Bridged DAI  Arbitrum",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39790/large/dai.png?1724111653"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1c43d05be7e5b54d506e3ddb6f0305e8a66cd04e",
+      "name": "ZTX",
+      "symbol": "ZTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32340/large/CoinGecko_200_x_200.jpg?1697466589"
     },
     {
       "chainId": 42161,
@@ -665,6 +649,14 @@
       "symbol": "LOGX",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/50226/large/Token_200px.png?1726556358"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
+      "name": "World Mobile Token",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
     },
     {
       "chainId": 42161,
@@ -684,14 +676,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0xf3c091ed43de9c270593445163a41a876a0bb3dd",
-      "name": "Orbs",
-      "symbol": "ORBS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/4630/large/Orbs.jpg?1696505200"
-    },
-    {
-      "chainId": 42161,
       "address": "0xae6aab43c4f3e0cea4ab83752c278f8debaba689",
       "name": "dForce",
       "symbol": "DF",
@@ -700,27 +684,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x6a9896837021ea3ed83f623f655c119c54abe02c",
-      "name": "ChainBounty",
-      "symbol": "BOUNTY",
+      "address": "0xf3c091ed43de9c270593445163a41a876a0bb3dd",
+      "name": "Orbs",
+      "symbol": "ORBS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3369/large/Chainbounty_logomark_256px.png?1731462528"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x18c11fd286c5ec11c3b683caa813b77f5163a122",
-      "name": "Gains Network",
-      "symbol": "GNS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19737/large/logo.png?1696519161"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
-      "name": "Renzo Restaked ETH",
-      "symbol": "EZETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
+      "logoURI": "https://assets.coingecko.com/coins/images/4630/large/Orbs.jpg?1696505200"
     },
     {
       "chainId": 42161,
@@ -732,11 +700,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x6a7661795c374c0bfc635934efaddff3a7ee23b6",
-      "name": "DOLA",
-      "symbol": "DOLA",
+      "address": "0x18c11fd286c5ec11c3b683caa813b77f5163a122",
+      "name": "Gains Network",
+      "symbol": "GNS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
+      "logoURI": "https://assets.coingecko.com/coins/images/19737/large/logo.png?1696519161"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6a9896837021ea3ed83f623f655c119c54abe02c",
+      "name": "ChainBounty",
+      "symbol": "BOUNTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3369/large/Chainbounty_logomark_256px.png?1731462528"
     },
     {
       "chainId": 42161,
@@ -745,6 +721,38 @@
       "symbol": "SDEX",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/29470/large/SDEX_logo_transparent_outside_240x240.png?1696930070"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x178412e79c25968a32e89b11f63b33f733770c2a",
+      "name": "Frax Ether",
+      "symbol": "FRXETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28284/large/frxETH_icon.png?1696527284"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6a7661795c374c0bfc635934efaddff3a7ee23b6",
+      "name": "DOLA",
+      "symbol": "DOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
     },
     {
       "chainId": 42161,
@@ -772,27 +780,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
-      "name": "OX Coin",
-      "symbol": "OX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
-    },
-    {
-      "chainId": 42161,
       "address": "0xcaa38bcc8fb3077975bbe217acfaa449e6596a84",
       "name": "DAO Maker",
       "symbol": "DAO",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/13915/large/4.jpg?1727532864"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf4d48ce3ee1ac3651998971541badbb9a14d7234",
-      "name": "Cream",
-      "symbol": "CREAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11976/large/Cream.png?1696511834"
     },
     {
       "chainId": 42161,
@@ -820,35 +812,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x4425742f1ec8d98779690b5a3a6276db85ddc01a",
-      "name": "Own The Doge",
-      "symbol": "DOG",
+      "address": "0xf4d48ce3ee1ac3651998971541badbb9a14d7234",
+      "name": "Cream",
+      "symbol": "CREAM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18111/large/Doge.png?1696517615"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x95146881b86b3ee99e63705ec87afe29fcc044d9",
-      "name": "Vertex",
-      "symbol": "VRTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27927/large/vrtx.png?1696526947"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x95ab45875cffdba1e5f451b950bc2e42c0053f39",
-      "name": "Staked Frax Ether",
-      "symbol": "SFRXETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28285/large/sfrxETH_icon.png?1696527285"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb0ecc6ac0073c063dcfc026ccdc9039cae2998e1",
-      "name": "A3S",
-      "symbol": "AA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32133/large/A3S.jpg?1696588511"
+      "logoURI": "https://assets.coingecko.com/coins/images/11976/large/Cream.png?1696511834"
     },
     {
       "chainId": 42161,
@@ -860,11 +828,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0xf929de51d91c77e42f5090069e0ad7a09e513c73",
-      "name": "ShapeShift FOX",
-      "symbol": "FOX",
+      "address": "0xb0ecc6ac0073c063dcfc026ccdc9039cae2998e1",
+      "name": "A3S",
+      "symbol": "AA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/9988/large/fox_token.png?1728373561"
+      "logoURI": "https://assets.coingecko.com/coins/images/32133/large/A3S.jpg?1696588511"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x95ab45875cffdba1e5f451b950bc2e42c0053f39",
+      "name": "Staked Frax Ether",
+      "symbol": "SFRXETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28285/large/sfrxETH_icon.png?1696527285"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x95146881b86b3ee99e63705ec87afe29fcc044d9",
+      "name": "Vertex",
+      "symbol": "VRTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27927/large/vrtx.png?1696526947"
     },
     {
       "chainId": 42161,
@@ -876,19 +860,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xa23e44aea714fbbc08ef28340d78067b9a8cad73",
-      "name": "Lybra",
-      "symbol": "LBR",
+      "address": "0xf929de51d91c77e42f5090069e0ad7a09e513c73",
+      "name": "ShapeShift FOX",
+      "symbol": "FOX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29958/large/New_LBR_V2.png?1696528884"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x772598e9e62155d7fdfe65fdf01eb5a53a8465be",
-      "name": "Empyreal",
-      "symbol": "EMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31374/large/logomainblacktransparent.png?1719953450"
+      "logoURI": "https://assets.coingecko.com/coins/images/9988/large/fox_token.png?1728373561"
     },
     {
       "chainId": 42161,
@@ -900,6 +876,22 @@
     },
     {
       "chainId": 42161,
+      "address": "0xa23e44aea714fbbc08ef28340d78067b9a8cad73",
+      "name": "Lybra",
+      "symbol": "LBR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29958/large/New_LBR_V2.png?1696528884"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4425742f1ec8d98779690b5a3a6276db85ddc01a",
+      "name": "Own The Doge",
+      "symbol": "DOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18111/large/Doge.png?1696517615"
+    },
+    {
+      "chainId": 42161,
       "address": "0x93fa0b88c0c78e45980fa74cdd87469311b7b3e4",
       "name": "XBorg",
       "symbol": "XBG",
@@ -908,11 +900,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
-      "name": "Bridged USDe",
-      "symbol": "USDE",
+      "address": "0x3d9907f9a368ad0a51be60f7da3b97cf940982d8",
+      "name": "Camelot Token",
+      "symbol": "GRAIL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39962/large/usde.png?1724952425"
+      "logoURI": "https://assets.coingecko.com/coins/images/28416/large/vj5DIMhP_400x400.jpeg?1696527414"
     },
     {
       "chainId": 42161,
@@ -932,30 +924,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0x3b58a4c865b568a2f6a957c264f6b50cba35d8ce",
-      "name": "SuperWalk GRND",
-      "symbol": "GRND",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27186/large/GRND_3x.png?1696526235"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3d9907f9a368ad0a51be60f7da3b97cf940982d8",
-      "name": "Camelot Token",
-      "symbol": "GRAIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28416/large/vj5DIMhP_400x400.jpeg?1696527414"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3124678d62d2aa1f615b54525310fbfda6dcf7ae",
-      "name": "Sensay",
-      "symbol": "SNSY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36121/large/sensay.jpeg?1710495398"
-    },
-    {
-      "chainId": 42161,
       "address": "0x8b0e6f19ee57089f7649a455d89d7bc6314d04e8",
       "name": "Dream Machine Token",
       "symbol": "DMT",
@@ -964,179 +932,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
-      "name": "Pocket Network",
-      "symbol": "POKT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x12275dcb9048680c4be40942ea4d92c74c63b844",
-      "name": "Electronic USD",
-      "symbol": "EUSD",
+      "address": "0x3b58a4c865b568a2f6a957c264f6b50cba35d8ce",
+      "name": "SuperWalk GRND",
+      "symbol": "GRND",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28445/large/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0c5fa0e07949f941a6c2c29a008252db1527d6ee",
-      "name": "Opulous",
-      "symbol": "OPUL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16548/large/opulous.PNG?1696516110"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
-      "name": "Gyroscope GYD",
-      "symbol": "GYD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8",
-      "name": "Everclear",
-      "symbol": "NEXT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31293/large/photo_2024-06-03_12-14-59.png?1717638614"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd77b108d4f6cefaa0cae9506a934e825becca46e",
-      "name": "WINR Protocol",
-      "symbol": "WINR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29340/large/WINR.png?1696528290"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf0cb2dc0db5e6c66b9a70ac27b06b878da017028",
-      "name": "Olympus",
-      "symbol": "OHM",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/14483/large/token_OHM_%281%29.png?1696514169"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6d7187220f769bde541ff51dd37ee07416f861d2",
-      "name": "Nostra",
-      "symbol": "NSTR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28282/large/Nostra_200x200b.png?1719434526"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
-      "name": "Mountain Protocol USD",
-      "symbol": "USDM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31719/large/usdm.png?1696530540"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x386601d1e55c48e759bbf57c56015aad0d7f1b56",
-      "name": "Worldwide USD",
-      "symbol": "WUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6b021b3f68491974be6d4009fee61a4e3c708fd6",
-      "name": "Fuse",
-      "symbol": "FUSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbc011a12da28e8f0f528d9ee5e7039e22f91cf18",
-      "name": "Swell Ethereum",
-      "symbol": "SWETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30326/large/_lB7zEtS_400x400.jpg?1696529227"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa970af1a584579b618be4d69ad6f73459d112f95",
-      "name": "sUSD",
-      "symbol": "SUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/5013/large/sUSD.png?1696505546"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa5312c3e42a82d459162b2a3bd7ffc4f9099b911",
-      "name": "GALAXIS Token",
-      "symbol": "GALAXIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36221/large/500x500.png?1714755244"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
-      "name": "Port3 Network",
-      "symbol": "PORT3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33383/large/port3-bc-200x200.png?1710075114"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x580e933d90091b9ce380740e3a4a39c67eb85b4c",
-      "name": "GameSwift",
-      "symbol": "GSWIFT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30949/large/GameSwift_Token.png?1696529788"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x35e050d3c0ec2d29d269a8ecea763a183bdf9a9d",
-      "name": "Ondo US Dollar Yield",
-      "symbol": "USDY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31700/large/usdy_%281%29.png?1696530524"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x5575552988a3a80504bbaeb1311674fcfd40ad4b",
-      "name": "Sperax",
-      "symbol": "SPA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12232/large/sperax_logo.jpg?1696512065"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x02f92800f57bcd74066f5709f1daa1a4302df875",
-      "name": "Peapods Finance",
-      "symbol": "PEAS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33711/large/NAzHgbTW_400x400.png?1702856653"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa4f63404b58c3efd9db6d53352bd386ffa174e5a",
-      "name": "Miracle Play",
-      "symbol": "MPT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32653/large/MPT.png?1698895300"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2172fad929e857ddfd7ddc31e24904438434cb0b",
-      "name": "Babypie Wrapped BTC",
-      "symbol": "MBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/50314/large/mbtc_%281%29.png?1727079604"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe22c452bd2ade15dfc8ad98286bc6bdf0c9219b7",
-      "name": "Polytrade",
-      "symbol": "TRADE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16416/large/Logo_colored_200.png?1696516012"
+      "logoURI": "https://assets.coingecko.com/coins/images/27186/large/GRND_3x.png?1696526235"
     },
     {
       "chainId": 42161,
@@ -1148,27 +948,203 @@
     },
     {
       "chainId": 42161,
+      "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+      "name": "Bridged USDe",
+      "symbol": "USDE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39962/large/usde.png?1724952425"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3124678d62d2aa1f615b54525310fbfda6dcf7ae",
+      "name": "Sensay",
+      "symbol": "SNSY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36121/large/sensay.jpeg?1710495398"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6d7187220f769bde541ff51dd37ee07416f861d2",
+      "name": "Nostra",
+      "symbol": "NSTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28282/large/Nostra_200x200b.png?1719434526"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x772598e9e62155d7fdfe65fdf01eb5a53a8465be",
+      "name": "Empyreal",
+      "symbol": "EMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31374/large/logomainblacktransparent.png?1719953450"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x764a726d9ced0433a8d7643335919deb03a9a935",
+      "name": "Pocket Network",
+      "symbol": "POKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0c5fa0e07949f941a6c2c29a008252db1527d6ee",
+      "name": "Opulous",
+      "symbol": "OPUL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16548/large/opulous.PNG?1696516110"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x386601d1e55c48e759bbf57c56015aad0d7f1b56",
+      "name": "Worldwide USD",
+      "symbol": "WUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf0cb2dc0db5e6c66b9a70ac27b06b878da017028",
+      "name": "Olympus",
+      "symbol": "OHM",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/14483/large/token_OHM_%281%29.png?1696514169"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa970af1a584579b618be4d69ad6f73459d112f95",
+      "name": "sUSD",
+      "symbol": "SUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/large/sUSD.png?1696505546"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6b021b3f68491974be6d4009fee61a4e3c708fd6",
+      "name": "Fuse",
+      "symbol": "FUSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8",
+      "name": "Everclear",
+      "symbol": "NEXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31293/large/photo_2024-06-03_12-14-59.png?1717638614"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
+      "name": "Gyroscope GYD",
+      "symbol": "GYD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+      "name": "Mountain Protocol USD",
+      "symbol": "USDM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31719/large/usdm.png?1696530540"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd77b108d4f6cefaa0cae9506a934e825becca46e",
+      "name": "WINR Protocol",
+      "symbol": "WINR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29340/large/WINR.png?1696528290"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35e050d3c0ec2d29d269a8ecea763a183bdf9a9d",
+      "name": "Ondo US Dollar Yield",
+      "symbol": "USDY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31700/large/usdy_%281%29.png?1696530524"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x580e933d90091b9ce380740e3a4a39c67eb85b4c",
+      "name": "GameSwift",
+      "symbol": "GSWIFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30949/large/GameSwift_Token.png?1696529788"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbc011a12da28e8f0f528d9ee5e7039e22f91cf18",
+      "name": "Swell Ethereum",
+      "symbol": "SWETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30326/large/_lB7zEtS_400x400.jpg?1696529227"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa5312c3e42a82d459162b2a3bd7ffc4f9099b911",
+      "name": "GALAXIS Token",
+      "symbol": "GALAXIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36221/large/500x500.png?1714755244"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe22c452bd2ade15dfc8ad98286bc6bdf0c9219b7",
+      "name": "Polytrade",
+      "symbol": "TRADE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16416/large/Logo_colored_200.png?1696516012"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb4357054c3da8d46ed642383f03139ac7f090343",
+      "name": "Port3 Network",
+      "symbol": "PORT3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33383/large/port3-bc-200x200.png?1710075114"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa4f63404b58c3efd9db6d53352bd386ffa174e5a",
+      "name": "Miracle Play",
+      "symbol": "MPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32653/large/MPT.png?1698895300"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x02f92800f57bcd74066f5709f1daa1a4302df875",
+      "name": "Peapods Finance",
+      "symbol": "PEAS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33711/large/NAzHgbTW_400x400.png?1702856653"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2172fad929e857ddfd7ddc31e24904438434cb0b",
+      "name": "Babypie Wrapped BTC",
+      "symbol": "MBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/50314/large/mbtc_%281%29.png?1727079604"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5575552988a3a80504bbaeb1311674fcfd40ad4b",
+      "name": "Sperax",
+      "symbol": "SPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12232/large/sperax_logo.jpg?1696512065"
+    },
+    {
+      "chainId": 42161,
       "address": "0xa61f74247455a40b01b0559ff6274441fafa22a3",
       "name": "Magpie",
       "symbol": "MGP",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/27972/large/MagpieLogo.png?1696526991"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x88a269df8fe7f53e590c561954c52fccc8ec0cfb",
-      "name": "Ninja Squad Token",
-      "symbol": "NST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22248/large/nst-logo-200x200.png?1711559985"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x046029f68b0e00ebec2e394d17f70ec848fcf1d2",
-      "name": "Stable com USD3",
-      "symbol": "USD3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39865/large/2024-04-stable_com-usd3_coin.png?1724379520"
     },
     {
       "chainId": 42161,
@@ -1180,19 +1156,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0xd6cf874e24a9f5f43075142101a6b13735cdd424",
-      "name": "CoinbarPay",
-      "symbol": "CBPAY",
+      "address": "0x046029f68b0e00ebec2e394d17f70ec848fcf1d2",
+      "name": "Stable com USD3",
+      "symbol": "USD3",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38794/large/cbpay-icon_resized2.png?1729148991"
+      "logoURI": "https://assets.coingecko.com/coins/images/39865/large/2024-04-stable_com-usd3_coin.png?1724379520"
     },
     {
       "chainId": 42161,
-      "address": "0xe10d4a4255d2d35c9e23e2c4790e073046fbaf5c",
-      "name": "LandX Governance Token",
-      "symbol": "LNDX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/33565/large/LNDX-200.png?1702445947"
+      "address": "0x88a269df8fe7f53e590c561954c52fccc8ec0cfb",
+      "name": "Ninja Squad Token",
+      "symbol": "NST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22248/large/nst-logo-200x200.png?1711559985"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x12275dcb9048680c4be40942ea4d92c74c63b844",
+      "name": "Electronic USD",
+      "symbol": "EUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28445/large/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
     },
     {
       "chainId": 42161,
@@ -1204,11 +1188,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
-      "name": "Ignition FBTC",
-      "symbol": "FBTC",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/39182/large/FBTC_LOGO.png?1720850455"
+      "address": "0xd6cf874e24a9f5f43075142101a6b13735cdd424",
+      "name": "CoinbarPay",
+      "symbol": "CBPAY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38794/large/cbpay-icon_resized2.png?1729148991"
     },
     {
       "chainId": 42161,
@@ -1228,35 +1212,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x9f6abbf0ba6b5bfa27f4deb6597cc6ec20573fda",
-      "name": "Ferrum Network",
-      "symbol": "FRM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8251/large/FRM.png?1696508455"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9e758b8a98a42d612b3d38b66a22074dc03d7370",
-      "name": "Symbiosis",
-      "symbol": "SIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20805/large/SymbiosisFinance_logo-150x150.jpeg?1696520198"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2680e82fb8beb5a153a67fe687ffa67abb6b9013",
-      "name": "Swarm Markets",
-      "symbol": "SMT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17488/large/swarm-SMT-token-symbol_200x200.png?1696517029"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x60d01ec2d5e98ac51c8b4cf84dfcce98d527c747",
-      "name": "iZUMi Finance",
-      "symbol": "IZI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21791/large/izumi-logo-symbol.png?1696521144"
+      "address": "0xe10d4a4255d2d35c9e23e2c4790e073046fbaf5c",
+      "name": "LandX Governance Token",
+      "symbol": "LNDX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/33565/large/LNDX-200.png?1702445947"
     },
     {
       "chainId": 42161,
@@ -1268,27 +1228,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x51c601dc278eb2cfea8e52c4caa35b3d6a9a2c26",
-      "name": "Chainge",
-      "symbol": "XCHNG",
+      "address": "0x221c5799209132766a01c4cbed0d28600d282b41",
+      "name": "Bitrium",
+      "symbol": "BTRM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16526/large/chainge.jpeg?1708099639"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe80772eaf6e2e18b651f160bc9158b2a5cafca65",
-      "name": "Overnight fi USD   Arbitrum One ",
-      "symbol": "USD+",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39630/large/usd_plus.png?1723181710"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe0ee18eacafddaeb38f8907c74347c44385578ab",
-      "name": "AxonDAO Governance Token",
-      "symbol": "AXGT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35290/large/AXGT-logo-7.png?1708076161"
+      "logoURI": "https://assets.coingecko.com/coins/images/39118/large/20240709-160716.png?1720593799"
     },
     {
       "chainId": 42161,
@@ -1300,30 +1244,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0xb08d8becab1bf76a9ce3d2d5fa946f65ec1d3e83",
-      "name": "GammaSwap",
-      "symbol": "GS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29222/large/newLogo2.png?1731702645"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xadd5620057336f868eae78a451c503ae7b576bad",
-      "name": "enqAI",
-      "symbol": "ENQAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29908/large/icon.png?1702507913"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca",
-      "name": "Kujira",
-      "symbol": "KUJI",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/20685/large/kuji-200x200.png?1696520085"
-    },
-    {
-      "chainId": 42161,
       "address": "0x10aaed289a7b1b0155bf4b86c862f297e84465e0",
       "name": "Rubic",
       "symbol": "RBC",
@@ -1332,11 +1252,43 @@
     },
     {
       "chainId": 42161,
-      "address": "0x24ef78c7092d255ed14a0281ac1800c359af3afe",
-      "name": "Rabbit Wallet",
-      "symbol": "RAB",
+      "address": "0x9e758b8a98a42d612b3d38b66a22074dc03d7370",
+      "name": "Symbiosis",
+      "symbol": "SIS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29433/large/200x200.png?1696528381"
+      "logoURI": "https://assets.coingecko.com/coins/images/20805/large/SymbiosisFinance_logo-150x150.jpeg?1696520198"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51c601dc278eb2cfea8e52c4caa35b3d6a9a2c26",
+      "name": "Chainge",
+      "symbol": "XCHNG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16526/large/chainge.jpeg?1708099639"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9f6abbf0ba6b5bfa27f4deb6597cc6ec20573fda",
+      "name": "Ferrum Network",
+      "symbol": "FRM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8251/large/FRM.png?1696508455"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2680e82fb8beb5a153a67fe687ffa67abb6b9013",
+      "name": "Swarm Markets",
+      "symbol": "SMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17488/large/swarm-SMT-token-symbol_200x200.png?1696517029"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe0ee18eacafddaeb38f8907c74347c44385578ab",
+      "name": "AxonDAO Governance Token",
+      "symbol": "AXGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35290/large/AXGT-logo-7.png?1708076161"
     },
     {
       "chainId": 42161,
@@ -1348,19 +1300,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
-      "name": "Seedworld",
-      "symbol": "SWORLD",
+      "address": "0xb08d8becab1bf76a9ce3d2d5fa946f65ec1d3e83",
+      "name": "GammaSwap",
+      "symbol": "GS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51000/large/IMG_2798.PNG?1729685531"
+      "logoURI": "https://assets.coingecko.com/coins/images/29222/large/newLogo2.png?1731702645"
     },
     {
       "chainId": 42161,
-      "address": "0x221c5799209132766a01c4cbed0d28600d282b41",
-      "name": "Bitrium",
-      "symbol": "BTRM",
+      "address": "0xe80772eaf6e2e18b651f160bc9158b2a5cafca65",
+      "name": "Overnight fi USD   Arbitrum One ",
+      "symbol": "USD+",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39630/large/usd_plus.png?1723181710"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x24ef78c7092d255ed14a0281ac1800c359af3afe",
+      "name": "Rabbit Wallet",
+      "symbol": "RAB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39118/large/20240709-160716.png?1720593799"
+      "logoURI": "https://assets.coingecko.com/coins/images/29433/large/200x200.png?1696528381"
     },
     {
       "chainId": 42161,
@@ -1372,11 +1332,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0xacc51ffdef63fb0c014c882267c3a17261a5ed50",
-      "name": "Stryke",
-      "symbol": "SYK",
+      "address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
+      "name": "Ignition FBTC",
+      "symbol": "FBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/39182/large/FBTC_LOGO.png?1720850455"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x60d01ec2d5e98ac51c8b4cf84dfcce98d527c747",
+      "name": "iZUMi Finance",
+      "symbol": "IZI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36531/large/stryke.jpeg?1711704094"
+      "logoURI": "https://assets.coingecko.com/coins/images/21791/large/izumi-logo-symbol.png?1696521144"
     },
     {
       "chainId": 42161,
@@ -1388,11 +1356,35 @@
     },
     {
       "chainId": 42161,
+      "address": "0xadd5620057336f868eae78a451c503ae7b576bad",
+      "name": "enqAI",
+      "symbol": "ENQAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29908/large/icon.png?1702507913"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xacc51ffdef63fb0c014c882267c3a17261a5ed50",
+      "name": "Stryke",
+      "symbol": "SYK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36531/large/stryke.jpeg?1711704094"
+    },
+    {
+      "chainId": 42161,
       "address": "0xd6b3d81868770083307840f513a3491960b95cb6",
       "name": "Credbull",
       "symbol": "CBL",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/39396/large/2024-11-15_06.09.28.jpg?1731735429"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca",
+      "name": "Kujira",
+      "symbol": "KUJI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20685/large/kuji-200x200.png?1696520085"
     },
     {
       "chainId": 42161,
@@ -1404,6 +1396,14 @@
     },
     {
       "chainId": 42161,
+      "address": "0xfa296fca3c7dba4a92a42ec0b5e2138da3b29050",
+      "name": "AiShiba",
+      "symbol": "SHIBAI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29898/large/Fotor_AI%EF%BC%882%EF%BC%89.png?1696528822"
+    },
+    {
+      "chainId": 42161,
       "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
       "name": "Wagmi",
       "symbol": "WAGMI",
@@ -1412,11 +1412,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0xfa296fca3c7dba4a92a42ec0b5e2138da3b29050",
-      "name": "AiShiba",
-      "symbol": "SHIBAI",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29898/large/Fotor_AI%EF%BC%882%EF%BC%89.png?1696528822"
+      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
+      "name": "Seedworld",
+      "symbol": "SWORLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51000/large/IMG_2798.PNG?1729685531"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
+      "name": "Osaka Protocol",
+      "symbol": "OSAK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30911/large/OSAK_LOGO_200x200.png?1723662197"
     },
     {
       "chainId": 42161,
@@ -1428,11 +1436,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xfa5ed56a203466cbbc2430a43c66b9d8723528e7",
-      "name": "EURA",
-      "symbol": "EURA",
+      "address": "0x24404dc041d74cd03cfe28855f555559390c931b",
+      "name": "r CryptoCurrency Moons",
+      "symbol": "MOON",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19479/large/agEUR-4.png?1710726218"
+      "logoURI": "https://assets.coingecko.com/coins/images/11222/large/Moons.png?1696511153"
     },
     {
       "chainId": 42161,
@@ -1441,6 +1449,14 @@
       "symbol": "BAMA",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/36686/large/photo_2024-03-31_14-20-41.jpg?1712073912"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x088cd8f5ef3652623c22d48b1605dcfe860cd704",
+      "name": "Vela Token",
+      "symbol": "VELA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28739/large/VELA_logo_-_no_background.png?1696527719"
     },
     {
       "chainId": 42161,
@@ -1460,19 +1476,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0xbfd5206962267c7b4b4a8b3d76ac2e1b2a5c4d5e",
-      "name": "Osaka Protocol",
-      "symbol": "OSAK",
+      "address": "0xdcbf4cb83d27c408b30dd7f39bfcabd7176b1ba3",
+      "name": "OpenOcean",
+      "symbol": "OOE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30911/large/OSAK_LOGO_200x200.png?1723662197"
+      "logoURI": "https://assets.coingecko.com/coins/images/17014/large/ooe_log.png?1696516578"
     },
     {
       "chainId": 42161,
-      "address": "0x088cd8f5ef3652623c22d48b1605dcfe860cd704",
-      "name": "Vela Token",
-      "symbol": "VELA",
+      "address": "0x18c14c2d707b2212e17d1579789fc06010cfca23",
+      "name": "ETHPlus",
+      "symbol": "ETH+",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28739/large/VELA_logo_-_no_background.png?1696527719"
+      "logoURI": "https://assets.coingecko.com/coins/images/38061/large/ETH__Logo.png?1716440789"
     },
     {
       "chainId": 42161,
@@ -1484,43 +1500,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x0534d7272a8e4f24d269b56605f2bf6cf3271891",
-      "name": "U Coin",
-      "symbol": "U",
+      "address": "0xfa5ed56a203466cbbc2430a43c66b9d8723528e7",
+      "name": "EURA",
+      "symbol": "EURA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51359/large/coingecko.png?1730877953"
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/large/agEUR-4.png?1710726218"
     },
     {
       "chainId": 42161,
-      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
-      "name": "Truflation",
-      "symbol": "TRUF",
-      "decimals": 15,
-      "logoURI": "https://assets.coingecko.com/coins/images/36642/large/truflation.jpg?1733315818"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdcbf4cb83d27c408b30dd7f39bfcabd7176b1ba3",
-      "name": "OpenOcean",
-      "symbol": "OOE",
+      "address": "0x999faf0af2ff109938eefe6a7bf91ca56f0d07e1",
+      "name": "Ledgity Token",
+      "symbol": "LDY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17014/large/ooe_log.png?1696516578"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x330bd769382cfc6d50175903434ccc8d206dcae5",
-      "name": "Kleros",
-      "symbol": "PNK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/3833/large/kleros.png?1696504500"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4a24b101728e07a52053c13fb4db2bcf490cabc3",
-      "name": "Arbius",
-      "symbol": "AIUS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35246/large/arbius-200x-logo.png?1707987961"
+      "logoURI": "https://assets.coingecko.com/coins/images/35046/large/ldy-token.png?1707204910"
     },
     {
       "chainId": 42161,
@@ -1540,11 +1532,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
-      "name": "Dexalot",
-      "symbol": "ALOT",
+      "address": "0x4a24b101728e07a52053c13fb4db2bcf490cabc3",
+      "name": "Arbius",
+      "symbol": "AIUS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24188/large/logo_200x200.png?1696523376"
+      "logoURI": "https://assets.coingecko.com/coins/images/35246/large/arbius-200x-logo.png?1707987961"
     },
     {
       "chainId": 42161,
@@ -1556,6 +1548,14 @@
     },
     {
       "chainId": 42161,
+      "address": "0x0534d7272a8e4f24d269b56605f2bf6cf3271891",
+      "name": "U Coin",
+      "symbol": "U",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51359/large/coingecko.png?1730877953"
+    },
+    {
+      "chainId": 42161,
       "address": "0x06e90a57d1ece8752d6ce92d1ad348ead5eae4f4",
       "name": "Real Smurf Cat",
       "symbol": "SMURFCAT",
@@ -1564,59 +1564,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x18c14c2d707b2212e17d1579789fc06010cfca23",
-      "name": "ETHPlus",
-      "symbol": "ETH+",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38061/large/ETH__Logo.png?1716440789"
+      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
+      "name": "Truflation",
+      "symbol": "TRUF",
+      "decimals": 15,
+      "logoURI": "https://assets.coingecko.com/coins/images/36642/large/truflation.jpg?1733315818"
     },
     {
       "chainId": 42161,
-      "address": "0x999faf0af2ff109938eefe6a7bf91ca56f0d07e1",
-      "name": "Ledgity Token",
-      "symbol": "LDY",
+      "address": "0x330bd769382cfc6d50175903434ccc8d206dcae5",
+      "name": "Kleros",
+      "symbol": "PNK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35046/large/ldy-token.png?1707204910"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
-      "name": "Ankr Staked ETH",
-      "symbol": "ANKRETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13403/large/aETHc.png?1696513165"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x13278cd824d33a7adb9f0a9a84aca7c0d2deebf7",
-      "name": "Tarot",
-      "symbol": "TAROT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31800/large/TAROT.jpg?1696530615"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xadf5dd3e51bf28ab4f07e684ecf5d00691818790",
-      "name": "ICHI",
-      "symbol": "ICHI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13119/large/ICHI_%28Round%29.jpg?1696512907"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf3527ef8de265eaa3716fb312c12847bfba66cef",
-      "name": "usdx money USDX",
-      "symbol": "USDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50360/large/USDX200px.png?1731906044"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3212dc0f8c834e4de893532d27cc9b6001684db0",
-      "name": "Pear Protocol",
-      "symbol": "PEAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50484/large/pearlogo.jpg?1727897446"
+      "logoURI": "https://assets.coingecko.com/coins/images/3833/large/kleros.png?1696504500"
     },
     {
       "chainId": 42161,
@@ -1628,94 +1588,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0xedd6ca8a4202d4a36611e2fff109648c4863ae19",
-      "name": "Maha",
-      "symbol": "MAHA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13404/large/black.png?1724679606"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a",
-      "name": "Alchemix USD",
-      "symbol": "ALUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14114/large/Alchemix_USD.png?1696513835"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc4cbd54ffa7a6a142fd73554cc6c23dd95cd8e01",
-      "name": " GAME Token",
-      "symbol": "GAME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38429/large/_GAME_Token.png?1717497071"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8697841b82c71fcbd9e58c15f6de68cd1c63fd02",
-      "name": "NutCoin",
-      "symbol": "NUT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37569/large/icon-2_200x200.png?1714886224"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xc760f9782f8cea5b06d862574464729537159966",
-      "name": "Contango",
-      "symbol": "TANGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50721/large/400x400_-_Tango_%281%29.png?1729251498"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7f7d7806f4eb90d63b0b278daf32a2db2c2001bd",
-      "name": "BonusBlock",
-      "symbol": "BONUS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36364/large/Coingecko_logo.png?1711336118"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7be5dd337cc6ce3e474f64e2a92a566445290864",
-      "name": "OpenLeverage",
-      "symbol": "OLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26098/large/256x256_OLE_Token_Logo.png?1696525189"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x02cea97794d2cfb5f560e1ff4e9c59d1bec75969",
-      "name": "VNX Swiss Franc",
-      "symbol": "VCHF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29547/large/VNXCHF_%282%29.png?1696528488"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x83d6c8c06ac276465e4c92e7ac8c23740f435140",
-      "name": "HMX",
-      "symbol": "HMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31206/large/HMXlogo_CG.png?1696530033"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
-      "name": "Nya",
-      "symbol": "NYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40082/large/nya.jpg?1725523655"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x092baadb7def4c3981454dd9c0a0d7ff07bcfc86",
-      "name": "MorpheusAI",
-      "symbol": "MOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37969/large/MOR200X200.png?1716327119"
-    },
-    {
-      "chainId": 42161,
       "address": "0x619c82392cb6e41778b7d088860fea8447941f4c",
       "name": "Army of Fortune Gem",
       "symbol": "AFG",
@@ -1724,27 +1596,35 @@
     },
     {
       "chainId": 42161,
-      "address": "0x4e51ac49bc5e2d87e0ef713e9e5ab2d71ef4f336",
-      "name": "Celo  Wormhole ",
-      "symbol": "CELO",
+      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
+      "name": "Dexalot",
+      "symbol": "ALOT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32400/large/celo_wh.png?1698055352"
+      "logoURI": "https://assets.coingecko.com/coins/images/24188/large/logo_200x200.png?1696523376"
     },
     {
       "chainId": 42161,
-      "address": "0xdb40357fbc1eb1038c5df94c1cd7b7fd3f434480",
-      "name": "SpunkySDX",
-      "symbol": "SSDX",
+      "address": "0x3212dc0f8c834e4de893532d27cc9b6001684db0",
+      "name": "Pear Protocol",
+      "symbol": "PEAR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52469/large/spunkysdx.png?1733412208"
+      "logoURI": "https://assets.coingecko.com/coins/images/50484/large/pearlogo.jpg?1727897446"
     },
     {
       "chainId": 42161,
-      "address": "0x3bd2dfd03bc7c3011ed7fb8c4d0949b382726cee",
-      "name": "Roobee",
-      "symbol": "ROOBEE",
+      "address": "0xadf5dd3e51bf28ab4f07e684ecf5d00691818790",
+      "name": "ICHI",
+      "symbol": "ICHI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/8791/large/Group_11.png?1696508946"
+      "logoURI": "https://assets.coingecko.com/coins/images/13119/large/ICHI_%28Round%29.jpg?1696512907"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xedd6ca8a4202d4a36611e2fff109648c4863ae19",
+      "name": "Maha",
+      "symbol": "MAHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13404/large/black.png?1724679606"
     },
     {
       "chainId": 42161,
@@ -1756,6 +1636,54 @@
     },
     {
       "chainId": 42161,
+      "address": "0xc4cbd54ffa7a6a142fd73554cc6c23dd95cd8e01",
+      "name": " GAME Token",
+      "symbol": "GAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38429/large/_GAME_Token.png?1717497071"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13278cd824d33a7adb9f0a9a84aca7c0d2deebf7",
+      "name": "Tarot",
+      "symbol": "TAROT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31800/large/TAROT.jpg?1696530615"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc760f9782f8cea5b06d862574464729537159966",
+      "name": "Contango",
+      "symbol": "TANGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50721/large/400x400_-_Tango_%281%29.png?1729251498"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a",
+      "name": "Alchemix USD",
+      "symbol": "ALUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14114/large/Alchemix_USD.png?1696513835"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f7d7806f4eb90d63b0b278daf32a2db2c2001bd",
+      "name": "BonusBlock",
+      "symbol": "BONUS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36364/large/Coingecko_logo.png?1711336118"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf3527ef8de265eaa3716fb312c12847bfba66cef",
+      "name": "usdx money USDX",
+      "symbol": "USDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50360/large/USDX200px.png?1731906044"
+    },
+    {
+      "chainId": 42161,
       "address": "0x847503fbf003ce8b005546aa3c03b80b7c2f9771",
       "name": "Byte",
       "symbol": "BYTE",
@@ -1764,43 +1692,67 @@
     },
     {
       "chainId": 42161,
-      "address": "0x24404dc041d74cd03cfe28855f555559390c931b",
-      "name": "r CryptoCurrency Moons",
-      "symbol": "MOON",
+      "address": "0x8697841b82c71fcbd9e58c15f6de68cd1c63fd02",
+      "name": "NutCoin",
+      "symbol": "NUT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11222/large/Moons.png?1696511153"
+      "logoURI": "https://assets.coingecko.com/coins/images/37569/large/icon-2_200x200.png?1714886224"
     },
     {
       "chainId": 42161,
-      "address": "0x60bf4e7cf16ff34513514b968483b54beff42a81",
-      "name": "ViciCoin",
-      "symbol": "VCNT",
+      "address": "0x3bd2dfd03bc7c3011ed7fb8c4d0949b382726cee",
+      "name": "Roobee",
+      "symbol": "ROOBEE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31305/large/ViciCoin_-_small.png?1696530124"
+      "logoURI": "https://assets.coingecko.com/coins/images/8791/large/Group_11.png?1696508946"
     },
     {
       "chainId": 42161,
-      "address": "0x2b41806cbf1ffb3d9e31a9ece6b738bf9d6f645f",
-      "name": "ENO",
-      "symbol": "ENO",
+      "address": "0x83d6c8c06ac276465e4c92e7ac8c23740f435140",
+      "name": "HMX",
+      "symbol": "HMX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26501/large/Logo_%281%29.png?1709565574"
+      "logoURI": "https://assets.coingecko.com/coins/images/31206/large/HMXlogo_CG.png?1696530033"
     },
     {
       "chainId": 42161,
-      "address": "0xb6093b61544572ab42a0e43af08abafd41bf25a6",
-      "name": "WeatherXM",
-      "symbol": "WXM",
+      "address": "0xdb40357fbc1eb1038c5df94c1cd7b7fd3f434480",
+      "name": "SpunkySDX",
+      "symbol": "SSDX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38154/large/weatherxm-network-logo.png?1716668976"
+      "logoURI": "https://assets.coingecko.com/coins/images/52469/large/spunkysdx.png?1733412208"
     },
     {
       "chainId": 42161,
-      "address": "0x431402e8b9de9aa016c743880e04e517074d8cec",
-      "name": "Hegic",
-      "symbol": "HEGIC",
+      "address": "0x7be5dd337cc6ce3e474f64e2a92a566445290864",
+      "name": "OpenLeverage",
+      "symbol": "OLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12454/large/new.png?1696512274"
+      "logoURI": "https://assets.coingecko.com/coins/images/26098/large/256x256_OLE_Token_Logo.png?1696525189"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e51ac49bc5e2d87e0ef713e9e5ab2d71ef4f336",
+      "name": "Celo  Wormhole ",
+      "symbol": "CELO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32400/large/celo_wh.png?1698055352"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x02cea97794d2cfb5f560e1ff4e9c59d1bec75969",
+      "name": "VNX Swiss Franc",
+      "symbol": "VCHF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29547/large/VNXCHF_%282%29.png?1696528488"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
+      "name": "Ankr Staked ETH",
+      "symbol": "ANKRETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13403/large/aETHc.png?1696513165"
     },
     {
       "chainId": 42161,
@@ -1812,11 +1764,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x1d987200df3b744cfa9c14f713f5334cb4bc4d5d",
-      "name": "REKT",
-      "symbol": "REKT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29954/large/New_Project_%288%29.png?1696528881"
+      "address": "0x6c511dc18572d31c2c3f7b1505cb2bbc08282fcc",
+      "name": "Aipocalypto",
+      "symbol": "AIPO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51400/large/aipo.png?1731084580"
     },
     {
       "chainId": 42161,
@@ -1828,11 +1780,59 @@
     },
     {
       "chainId": 42161,
-      "address": "0x6c511dc18572d31c2c3f7b1505cb2bbc08282fcc",
-      "name": "Aipocalypto",
-      "symbol": "AIPO",
+      "address": "0x7f850b0ab1988dd17b69ac564c1e2857949e4dee",
+      "name": "Lift Dollar",
+      "symbol": "USDL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51400/large/aipo.png?1731084580"
+      "logoURI": "https://assets.coingecko.com/coins/images/38484/large/USDL-Token-200px.png?1725022887"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x092baadb7def4c3981454dd9c0a0d7ff07bcfc86",
+      "name": "MorpheusAI",
+      "symbol": "MOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37969/large/MOR200X200.png?1716327119"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x431402e8b9de9aa016c743880e04e517074d8cec",
+      "name": "Hegic",
+      "symbol": "HEGIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12454/large/new.png?1696512274"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2b41806cbf1ffb3d9e31a9ece6b738bf9d6f645f",
+      "name": "ENO",
+      "symbol": "ENO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26501/large/Logo_%281%29.png?1709565574"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x60bf4e7cf16ff34513514b968483b54beff42a81",
+      "name": "ViciCoin",
+      "symbol": "VCNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31305/large/ViciCoin_-_small.png?1696530124"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb6093b61544572ab42a0e43af08abafd41bf25a6",
+      "name": "WeatherXM",
+      "symbol": "WXM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38154/large/weatherxm-network-logo.png?1716668976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x965d00aa7abc62ca10132e641d08593435ac811d",
+      "name": "KAP Games",
+      "symbol": "KAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27682/large/KAP_Logo.png?1696526710"
     },
     {
       "chainId": 42161,
@@ -1844,19 +1844,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x11bf4f05eb28b802ed3ab672594decb20ffe2313",
-      "name": "Aurory",
-      "symbol": "AURY",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/19324/large/Ico_Blanc_%281%29.png?1713464485"
+      "address": "0x1d987200df3b744cfa9c14f713f5334cb4bc4d5d",
+      "name": "REKT",
+      "symbol": "REKT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29954/large/New_Project_%288%29.png?1696528881"
     },
     {
       "chainId": 42161,
-      "address": "0x3269a3c00ab86c753856fd135d97b87facb0d848",
-      "name": "Florence Finance Medici",
-      "symbol": "FFM",
+      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
+      "name": "Nya",
+      "symbol": "NYA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34382/large/M_PNG_200x200_copy.png?1704779326"
+      "logoURI": "https://assets.coingecko.com/coins/images/40082/large/nya.jpg?1725523655"
     },
     {
       "chainId": 42161,
@@ -1865,6 +1865,14 @@
       "symbol": "GRAI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/30427/large/GRAI_Token.png?1696529315"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3269a3c00ab86c753856fd135d97b87facb0d848",
+      "name": "Florence Finance Medici",
+      "symbol": "FFM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34382/large/M_PNG_200x200_copy.png?1704779326"
     },
     {
       "chainId": 42161,
@@ -1884,30 +1892,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0x6fd58f5a2f3468e35feb098b5f59f04157002407",
-      "name": "POGAI",
-      "symbol": "POGAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30116/large/pogai.jpeg?1696529039"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4883c8f0529f37e40ebea870f3c13cdfad5d01f8",
-      "name": "VNX EURO",
-      "symbol": "VEUR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29351/large/VNXEUR_%281%29.png?1696528300"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0000206329b97db379d5e1bf586bbdb969c63274",
-      "name": "USDA",
-      "symbol": "USDA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34510/large/agUSD-coingecko.png?1705288392"
-    },
-    {
-      "chainId": 42161,
       "address": "0x9e20461bc2c4c980f62f1b279d71734207a6a356",
       "name": "OmniCat",
       "symbol": "OMNI",
@@ -1924,11 +1908,35 @@
     },
     {
       "chainId": 42161,
+      "address": "0x0000206329b97db379d5e1bf586bbdb969c63274",
+      "name": "USDA",
+      "symbol": "USDA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34510/large/agUSD-coingecko.png?1705288392"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11bf4f05eb28b802ed3ab672594decb20ffe2313",
+      "name": "Aurory",
+      "symbol": "AURY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19324/large/Ico_Blanc_%281%29.png?1713464485"
+    },
+    {
+      "chainId": 42161,
       "address": "0xa0995d43901551601060447f9abf93ebc277cec2",
       "name": "HIPPOP",
       "symbol": "HIP",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/37854/large/KakaoTalk_Image_2024-05-14-16-50-31.png?1715781999"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4883c8f0529f37e40ebea870f3c13cdfad5d01f8",
+      "name": "VNX EURO",
+      "symbol": "VEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29351/large/VNXEUR_%281%29.png?1696528300"
     },
     {
       "chainId": 42161,
@@ -1964,19 +1972,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x55678cd083fcdc2947a0df635c93c838c89454a3",
-      "name": "Tokenlon",
-      "symbol": "LON",
+      "address": "0x429fed88f10285e61b12bdf00848315fbdfcc341",
+      "name": "THORWallet DEX",
+      "symbol": "TGT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13454/large/lon_logo.png?1696513217"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0cbd6fadcf8096cc9a43d90b45f65826102e3ece",
-      "name": "CheckDot",
-      "symbol": "CDT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20370/large/token-200x200_%281%29.png?1696519781"
+      "logoURI": "https://assets.coingecko.com/coins/images/21843/large/tgt_logo.png?1696521198"
     },
     {
       "chainId": 42161,
@@ -1988,43 +1988,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0xd45e486a90ebb84e9336d371a35dcb021424b96c",
-      "name": "Superpower Squad",
-      "symbol": "SQUAD",
+      "address": "0xf6dae0d2be4993b00a2673360820af6bafd53887",
+      "name": "Launchpool",
+      "symbol": "LPOOL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28466/large/SQUAD200X200.png?1696527460"
+      "logoURI": "https://assets.coingecko.com/coins/images/14041/large/dGUvV0HQ_400x400.jpg?1696513767"
     },
     {
       "chainId": 42161,
-      "address": "0xbe5acfd64358805616b5cbd5277b9a85011d7cf1",
-      "name": "Pichi Finance",
-      "symbol": "PCH",
+      "address": "0x0cbd6fadcf8096cc9a43d90b45f65826102e3ece",
+      "name": "CheckDot",
+      "symbol": "CDT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39683/large/Group_1000003884.png?1723654999"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x429fed88f10285e61b12bdf00848315fbdfcc341",
-      "name": "THORWallet DEX",
-      "symbol": "TGT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21843/large/tgt_logo.png?1696521198"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3096e7bfd0878cc65be71f8899bc4cfb57187ba3",
-      "name": "Xend Finance",
-      "symbol": "RWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14496/large/WeChat_Image_20210325163206.png?1696514181"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb299751b088336e165da313c33e3195b8c6663a6",
-      "name": "StarHeroes",
-      "symbol": "STAR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34147/large/Screenshot_2024-03-08_180444.png?1709892309"
+      "logoURI": "https://assets.coingecko.com/coins/images/20370/large/token-200x200_%281%29.png?1696519781"
     },
     {
       "chainId": 42161,
@@ -2036,19 +2012,43 @@
     },
     {
       "chainId": 42161,
-      "address": "0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418",
-      "name": "Ramses Exchange",
-      "symbol": "RAM",
+      "address": "0xbe5acfd64358805616b5cbd5277b9a85011d7cf1",
+      "name": "Pichi Finance",
+      "symbol": "PCH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29420/large/newram.png?1708427055"
+      "logoURI": "https://assets.coingecko.com/coins/images/39683/large/Group_1000003884.png?1723654999"
     },
     {
       "chainId": 42161,
-      "address": "0xc9c4fd7579133701fa2769b6955e7e56bb386db1",
-      "name": "Bridge Oracle",
-      "symbol": "BRG",
+      "address": "0xb299751b088336e165da313c33e3195b8c6663a6",
+      "name": "StarHeroes",
+      "symbol": "STAR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12512/large/brg.png?1696512327"
+      "logoURI": "https://assets.coingecko.com/coins/images/34147/large/Screenshot_2024-03-08_180444.png?1709892309"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x55678cd083fcdc2947a0df635c93c838c89454a3",
+      "name": "Tokenlon",
+      "symbol": "LON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13454/large/lon_logo.png?1696513217"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xca4e51f6ad4afd9d1068e5899de9dd7d73f3463d",
+      "name": "Aark Digital",
+      "symbol": "AARK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37813/large/aark.png?1715599394"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3096e7bfd0878cc65be71f8899bc4cfb57187ba3",
+      "name": "Xend Finance",
+      "symbol": "RWA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14496/large/WeChat_Image_20210325163206.png?1696514181"
     },
     {
       "chainId": 42161,
@@ -2068,35 +2068,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x188fb5f5ae5bbe4154d5778f2bbb2fb985c94d25",
-      "name": "OpenBlox",
-      "symbol": "OBX",
+      "address": "0xd45e486a90ebb84e9336d371a35dcb021424b96c",
+      "name": "Superpower Squad",
+      "symbol": "SQUAD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26150/large/OBX_token-black_background_preview.png?1696525239"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xca4e51f6ad4afd9d1068e5899de9dd7d73f3463d",
-      "name": "Aark Digital",
-      "symbol": "AARK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37813/large/aark.png?1715599394"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
-      "name": "MUX Protocol",
-      "symbol": "MCB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11796/large/mux.jpg?1696511672"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf6dae0d2be4993b00a2673360820af6bafd53887",
-      "name": "Launchpool",
-      "symbol": "LPOOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14041/large/dGUvV0HQ_400x400.jpg?1696513767"
+      "logoURI": "https://assets.coingecko.com/coins/images/28466/large/SQUAD200X200.png?1696527460"
     },
     {
       "chainId": 42161,
@@ -2105,6 +2081,22 @@
       "symbol": "ALTR",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/38301/large/altr.jpg?1717034749"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xeb4d25db65dcef52380c99ba7e1344c820ecb1fc",
+      "name": "X World Games",
+      "symbol": "XWG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17847/large/200_200_%281%29_%281%29.png?1696790226"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418",
+      "name": "Ramses Exchange",
+      "symbol": "RAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29420/large/newram.png?1708427055"
     },
     {
       "chainId": 42161,
@@ -2124,51 +2116,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x1bc8bf18256d8b45d8367aac50fe2e24fc6aa8ca",
-      "name": "Vestate",
-      "symbol": "VES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35475/large/IMG_0759.png?1708772732"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xeb4d25db65dcef52380c99ba7e1344c820ecb1fc",
-      "name": "X World Games",
-      "symbol": "XWG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17847/large/200_200_%281%29_%281%29.png?1696790226"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
-      "name": "Magic Internet Money  Arbitrum ",
-      "symbol": "MIM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37324/large/mim.png?1714016666"
-    },
-    {
-      "chainId": 42161,
       "address": "0xfb930d1a28990820c98144201637c99bea8cb91c",
       "name": "Bumper",
       "symbol": "BUMP",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/17822/large/Bumper_-__Icon_-_256x256.png?1715280092"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x965d00aa7abc62ca10132e641d08593435ac811d",
-      "name": "KAP Games",
-      "symbol": "KAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27682/large/KAP_Logo.png?1696526710"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb1bc21f748ae2be95674876710bc6d78235480e0",
-      "name": "Hord",
-      "symbol": "HORD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14972/large/HORD_TOKEN_%281%29_1.png?1705414356"
     },
     {
       "chainId": 42161,
@@ -2180,11 +2132,43 @@
     },
     {
       "chainId": 42161,
-      "address": "0x8cf7e3aa6faf6ae180e5ec3f0fb95081c2086ebe",
-      "name": "SX Network",
-      "symbol": "SX",
+      "address": "0xb1bc21f748ae2be95674876710bc6d78235480e0",
+      "name": "Hord",
+      "symbol": "HORD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34934/large/sx-ntework.jpeg?1706699134"
+      "logoURI": "https://assets.coingecko.com/coins/images/14972/large/HORD_TOKEN_%281%29_1.png?1705414356"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1bc8bf18256d8b45d8367aac50fe2e24fc6aa8ca",
+      "name": "Vestate",
+      "symbol": "VES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35475/large/IMG_0759.png?1708772732"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x188fb5f5ae5bbe4154d5778f2bbb2fb985c94d25",
+      "name": "OpenBlox",
+      "symbol": "OBX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26150/large/OBX_token-black_background_preview.png?1696525239"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb64e280e9d1b5dbec4accedb2257a87b400db149",
+      "name": "Level",
+      "symbol": "LVL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28628/large/Token.png?1696527613"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbc4c97fb9befaa8b41448e1dfcc5236da543217f",
+      "name": "SpaceCatch",
+      "symbol": "CATCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36632/large/Logomark_colours.png?1712022405"
     },
     {
       "chainId": 42161,
@@ -2193,6 +2177,14 @@
       "symbol": "RING",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/9443/large/RING.png?1696509535"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1c986661170c1834db49c3830130d4038eeeb866",
+      "name": "Aperture Finance",
+      "symbol": "APTR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37940/large/icon_white.png?1715967425"
     },
     {
       "chainId": 42161,
@@ -2212,27 +2204,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x3d15fd46ce9e551498328b1c83071d9509e2c3a0",
-      "name": "Universal ETH",
-      "symbol": "UNIETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28477/large/uniETH_200.png?1696527471"
-    },
-    {
-      "chainId": 42161,
       "address": "0x711b771c7c443ebb695e4b3495c337fdaf37be11",
       "name": "Dackie USD",
       "symbol": "DCKUSD",
       "decimals": 6,
       "logoURI": "https://assets.coingecko.com/coins/images/39966/large/Dackie_USD_Stablecoin.png?1724957262"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x000000000026839b3f4181f2cf69336af6153b99",
-      "name": "Reboot",
-      "symbol": "GG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31228/large/gg_cyan_black_square.png?1703749951"
     },
     {
       "chainId": 42161,
@@ -2260,19 +2236,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xe85b662fe97e8562f4099d8a1d5a92d4b453bf30",
-      "name": "Thales",
-      "symbol": "THALES",
+      "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+      "name": "MUX Protocol",
+      "symbol": "MCB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18388/large/CLVZJN_C_400x400.png?1696517879"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1dd6b5f9281c6b4f043c02a83a46c2772024636c",
-      "name": "Lumi Finance LUAUSD",
-      "symbol": "LUAUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33503/large/LUAUSD.png?1702038709"
+      "logoURI": "https://assets.coingecko.com/coins/images/11796/large/mux.jpg?1696511672"
     },
     {
       "chainId": 42161,
@@ -2284,14 +2252,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0x0341c0c0ec423328621788d4854119b97f44e391",
-      "name": "Silo Finance",
-      "symbol": "SILO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21454/large/y0iYKZOv_400x400.png?1696520816"
-    },
-    {
-      "chainId": 42161,
       "address": "0x45d9831d8751b2325f3dbf48db748723726e1c8c",
       "name": "EverValue Coin",
       "symbol": "EVA",
@@ -2300,27 +2260,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0xbc4c97fb9befaa8b41448e1dfcc5236da543217f",
-      "name": "SpaceCatch",
-      "symbol": "CATCH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36632/large/Logomark_colours.png?1712022405"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb64e280e9d1b5dbec4accedb2257a87b400db149",
-      "name": "Level",
-      "symbol": "LVL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28628/large/Token.png?1696527613"
-    },
-    {
-      "chainId": 42161,
       "address": "0x7c8a1a80fdd00c9cccd6ebd573e9ecb49bfa2a59",
       "name": "AI CODE",
       "symbol": "AICODE",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/30057/large/AICODE.png?1696528979"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0341c0c0ec423328621788d4854119b97f44e391",
+      "name": "Silo Finance",
+      "symbol": "SILO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21454/large/y0iYKZOv_400x400.png?1696520816"
     },
     {
       "chainId": 42161,
@@ -2340,11 +2292,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x1a5b0aaf478bf1fda7b934c76e7692d722982a6d",
-      "name": "Buffer Token",
-      "symbol": "BFR",
+      "address": "0xf061956612b3dc79fd285d3d51bc128f2ea87740",
+      "name": "YfDAI finance",
+      "symbol": "YF-DAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18540/large/Qk6pjeZ3_400x400.jpg?1696518020"
+      "logoURI": "https://assets.coingecko.com/coins/images/12385/large/1619048513068.png?1696512208"
     },
     {
       "chainId": 42161,
@@ -2353,6 +2305,14 @@
       "symbol": "ARBS",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/30565/large/Arb-Logo_Circle_DARK_LOGO_ONLY.png?1696529436"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2ac2b254bc18cd4999f64773a966e4f4869c34ee",
+      "name": "Penpie",
+      "symbol": "PNP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30760/large/PNP_Token.png?1696529629"
     },
     {
       "chainId": 42161,
@@ -2372,19 +2332,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0x2ac2b254bc18cd4999f64773a966e4f4869c34ee",
-      "name": "Penpie",
-      "symbol": "PNP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30760/large/PNP_Token.png?1696529629"
+      "address": "0x2b089381f53525451fe5115f23e9d2cc92d7ff1d",
+      "name": "Digital Reserve Currency",
+      "symbol": "DRC",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/12802/large/DRC_Logo.jpg?1696512595"
     },
     {
       "chainId": 42161,
-      "address": "0x569deb225441fd18bde18aed53e2ec7eb4e10d93",
-      "name": "Your Futures Exchange",
-      "symbol": "YFX",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/15654/large/yfx.PNG?1696515285"
+      "address": "0xc9c4fd7579133701fa2769b6955e7e56bb386db1",
+      "name": "Bridge Oracle",
+      "symbol": "BRG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12512/large/brg.png?1696512327"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8cf7e3aa6faf6ae180e5ec3f0fb95081c2086ebe",
+      "name": "SX Network",
+      "symbol": "SX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34934/large/sx-ntework.jpeg?1706699134"
     },
     {
       "chainId": 42161,
@@ -2396,11 +2364,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x43c25f828390de5a3648864eb485cc523e039e67",
-      "name": "Hello Pets",
-      "symbol": "PET",
+      "address": "0x000000000026839b3f4181f2cf69336af6153b99",
+      "name": "Reboot",
+      "symbol": "GG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14354/large/hello_pets.jpg?1696514040"
+      "logoURI": "https://assets.coingecko.com/coins/images/31228/large/gg_cyan_black_square.png?1703749951"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x569deb225441fd18bde18aed53e2ec7eb4e10d93",
+      "name": "Your Futures Exchange",
+      "symbol": "YFX",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/15654/large/yfx.PNG?1696515285"
     },
     {
       "chainId": 42161,
@@ -2412,75 +2388,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x5117f4ad0bc70dbb3b05bf39a1ec1ee40dd67654",
-      "name": "Avive",
-      "symbol": "AVIVE",
+      "address": "0x43c25f828390de5a3648864eb485cc523e039e67",
+      "name": "Hello Pets",
+      "symbol": "PET",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33697/large/avive_token.png?1702814979"
+      "logoURI": "https://assets.coingecko.com/coins/images/14354/large/hello_pets.jpg?1696514040"
     },
     {
       "chainId": 42161,
-      "address": "0xf061956612b3dc79fd285d3d51bc128f2ea87740",
-      "name": "YfDAI finance",
-      "symbol": "YF-DAI",
+      "address": "0x1a5b0aaf478bf1fda7b934c76e7692d722982a6d",
+      "name": "Buffer Token",
+      "symbol": "BFR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12385/large/1619048513068.png?1696512208"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x2b089381f53525451fe5115f23e9d2cc92d7ff1d",
-      "name": "Digital Reserve Currency",
-      "symbol": "DRC",
-      "decimals": 0,
-      "logoURI": "https://assets.coingecko.com/coins/images/12802/large/DRC_Logo.jpg?1696512595"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x71eeba415a523f5c952cc2f06361d5443545ad28",
-      "name": "XDAO",
-      "symbol": "XDAO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27363/large/token_2.png?1696526408"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3404149e9ee6f17fb41db1ce593ee48fbdcd9506",
-      "name": "Hydranet",
-      "symbol": "HDN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25177/large/HDXdarkblueInv.png?1696524322"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdc8184ba488e949815d4aafb35b3c56ad03b4179",
-      "name": "Roseon",
-      "symbol": "ROSX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29698/large/roseon.png?1696528631"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbfeb8b6813491bb4fb823b8f451b62ef535420d1",
-      "name": "Zunami USD",
-      "symbol": "ZUNUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37809/large/zunUSD_200x200.png?1715591997"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x47c337bd5b9344a6f3d6f58c474d9d8cd419d8ca",
-      "name": "DackieSwap",
-      "symbol": "DACKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30752/large/dackieswap_large.png?1707290196"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x1c986661170c1834db49c3830130d4038eeeb866",
-      "name": "Aperture Finance",
-      "symbol": "APTR",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37940/large/icon_white.png?1715967425"
+      "logoURI": "https://assets.coingecko.com/coins/images/18540/large/Qk6pjeZ3_400x400.jpg?1696518020"
     },
     {
       "chainId": 42161,
@@ -2492,11 +2412,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0xad4b9c1fbf4923061814dd9d5732eb703faa53d4",
-      "name": "Wicrypt",
-      "symbol": "WNT",
+      "address": "0x71eeba415a523f5c952cc2f06361d5443545ad28",
+      "name": "XDAO",
+      "symbol": "XDAO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21223/large/wicrypt.PNG?1696520597"
+      "logoURI": "https://assets.coingecko.com/coins/images/27363/large/token_2.png?1696526408"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdc8184ba488e949815d4aafb35b3c56ad03b4179",
+      "name": "Roseon",
+      "symbol": "ROSX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29698/large/roseon.png?1696528631"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5117f4ad0bc70dbb3b05bf39a1ec1ee40dd67654",
+      "name": "Avive",
+      "symbol": "AVIVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33697/large/avive_token.png?1702814979"
     },
     {
       "chainId": 42161,
@@ -2508,51 +2444,35 @@
     },
     {
       "chainId": 42161,
-      "address": "0x1b7ad346b6ff2d196daa8e78aed86baa6d7e3b02",
-      "name": "VitAI",
-      "symbol": "VITAI",
+      "address": "0x47c337bd5b9344a6f3d6f58c474d9d8cd419d8ca",
+      "name": "DackieSwap",
+      "symbol": "DACKIE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52350/large/aadadsadasdas.png?1733162989"
+      "logoURI": "https://assets.coingecko.com/coins/images/30752/large/dackieswap_large.png?1707290196"
     },
     {
       "chainId": 42161,
-      "address": "0x7a2c1b8e26c48a5b73816b7ec826fd4053f5f34b",
-      "name": "GoSleep ZZZ",
-      "symbol": "ZZZ",
+      "address": "0xe85b662fe97e8562f4099d8a1d5a92d4b453bf30",
+      "name": "Thales",
+      "symbol": "THALES",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29901/large/ZZZ200_200.png?1696528830"
+      "logoURI": "https://assets.coingecko.com/coins/images/18388/large/CLVZJN_C_400x400.png?1696517879"
     },
     {
       "chainId": 42161,
-      "address": "0xc3abc47863524ced8daf3ef98d74dd881e131c38",
-      "name": "Lumi Finance",
-      "symbol": "LUA",
+      "address": "0x3404149e9ee6f17fb41db1ce593ee48fbdcd9506",
+      "name": "Hydranet",
+      "symbol": "HDN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33502/large/LUA.png?1702038548"
+      "logoURI": "https://assets.coingecko.com/coins/images/25177/large/HDXdarkblueInv.png?1696524322"
     },
     {
       "chainId": 42161,
-      "address": "0x51fc0f6660482ea73330e414efd7808811a57fa2",
-      "name": "Premia",
-      "symbol": "PREMIA",
+      "address": "0x3d15fd46ce9e551498328b1c83071d9509e2c3a0",
+      "name": "Universal ETH",
+      "symbol": "UNIETH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13962/large/apple-touch-icon.png?1696513698"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x34229b3f16fbcdfa8d8d9d17c0852f9496f4c7bb",
-      "name": "IPOR",
-      "symbol": "IPOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png?1696527376"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb829b68f57cc546da7e5806a929e53be32a4625d",
-      "name": "Axelar Wrapped Ether",
-      "symbol": "AXLETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28171/large/weth-wei_D_3x.png?1696527174"
+      "logoURI": "https://assets.coingecko.com/coins/images/28477/large/uniETH_200.png?1696527471"
     },
     {
       "chainId": 42161,
@@ -2564,11 +2484,67 @@
     },
     {
       "chainId": 42161,
+      "address": "0x7a2c1b8e26c48a5b73816b7ec826fd4053f5f34b",
+      "name": "GoSleep ZZZ",
+      "symbol": "ZZZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29901/large/ZZZ200_200.png?1696528830"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfeb8b6813491bb4fb823b8f451b62ef535420d1",
+      "name": "Zunami USD",
+      "symbol": "ZUNUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37809/large/zunUSD_200x200.png?1715591997"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc3abc47863524ced8daf3ef98d74dd881e131c38",
+      "name": "Lumi Finance",
+      "symbol": "LUA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33502/large/LUA.png?1702038548"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xad4b9c1fbf4923061814dd9d5732eb703faa53d4",
+      "name": "Wicrypt",
+      "symbol": "WNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21223/large/wicrypt.PNG?1696520597"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51fc0f6660482ea73330e414efd7808811a57fa2",
+      "name": "Premia",
+      "symbol": "PREMIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13962/large/apple-touch-icon.png?1696513698"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1dd6b5f9281c6b4f043c02a83a46c2772024636c",
+      "name": "Lumi Finance LUAUSD",
+      "symbol": "LUAUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33503/large/LUAUSD.png?1702038709"
+    },
+    {
+      "chainId": 42161,
       "address": "0x9cce9ae579142e372a8959285e3a5a2e211904f7",
       "name": "DGWToken",
       "symbol": "DGW",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/39642/large/1000146817.jpg?1723410321"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb829b68f57cc546da7e5806a929e53be32a4625d",
+      "name": "Axelar Wrapped Ether",
+      "symbol": "AXLETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28171/large/weth-wei_D_3x.png?1696527174"
     },
     {
       "chainId": 42161,
@@ -2580,19 +2556,19 @@
     },
     {
       "chainId": 42161,
+      "address": "0x1b7ad346b6ff2d196daa8e78aed86baa6d7e3b02",
+      "name": "VitAI",
+      "symbol": "VITAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52350/large/aadadsadasdas.png?1733162989"
+    },
+    {
+      "chainId": 42161,
       "address": "0x7fb7ede54259cb3d4e1eaf230c7e2b1ffc951e9a",
       "name": "Numa",
       "symbol": "NUMA",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/35807/large/numa200.png?1709845645"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x589d35656641d6ab57a545f08cf473ecd9b6d5f7",
-      "name": "GYEN",
-      "symbol": "GYEN",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/14191/large/icon_gyen_200_200.png?1696513909"
     },
     {
       "chainId": 42161,
@@ -2604,19 +2580,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xbcf339df10d78f2b44aa760ead0f715a7a7d7269",
-      "name": "Guardian GUARD",
-      "symbol": "GUARD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17995/large/LS_wolfDen_logo.0025_Light_200x200.png?1696517512"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3de81ce90f5a27c5e6a5adb04b54aba488a6d14e",
-      "name": "DeltaPrime",
-      "symbol": "PRIME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39234/large/PRIME.jpg?1721240215"
+      "address": "0x589d35656641d6ab57a545f08cf473ecd9b6d5f7",
+      "name": "GYEN",
+      "symbol": "GYEN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14191/large/icon_gyen_200_200.png?1696513909"
     },
     {
       "chainId": 42161,
@@ -2628,35 +2596,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
-      "name": "Overnight Finance",
-      "symbol": "OVN",
+      "address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
+      "name": "Magic Internet Money  Arbitrum ",
+      "symbol": "MIM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31970/large/OVN.png?1696959174"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
-      "name": "Gains Network USDC",
-      "symbol": "GUSDC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39042/large/logo_gUSDC.png?1720066451"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xcf934e2402a5e072928a39a956964eb8f2b5b79c",
-      "name": "PoolTogether",
-      "symbol": "POOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14003/large/PoolTogether.png?1696513732"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4debfb9ed639144cf1e401674af361ffffcefb58",
-      "name": "CADAI",
-      "symbol": "CADAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38713/large/CADAI_Token_Logo.png?1718404394"
+      "logoURI": "https://assets.coingecko.com/coins/images/37324/large/mim.png?1714016666"
     },
     {
       "chainId": 42161,
@@ -2668,11 +2612,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0xbea0005b8599265d41256905a9b3073d397812e4",
-      "name": "Bean",
-      "symbol": "BEAN",
+      "address": "0x3de81ce90f5a27c5e6a5adb04b54aba488a6d14e",
+      "name": "DeltaPrime",
+      "symbol": "PRIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39234/large/PRIME.jpg?1721240215"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+      "name": "Gains Network USDC",
+      "symbol": "GUSDC",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/18447/large/bean-logo-coingecko.png?1696517934"
+      "logoURI": "https://assets.coingecko.com/coins/images/39042/large/logo_gUSDC.png?1720066451"
     },
     {
       "chainId": 42161,
@@ -2681,6 +2633,14 @@
       "symbol": "CRDS",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/33084/large/cradles_icon.png?1700601703"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb00eaedb98f1e30ad545703d8ff14b24d109514f",
+      "name": "Yaku",
+      "symbol": "YAKU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26785/large/yaku_logo.png?1706636424"
     },
     {
       "chainId": 42161,
@@ -2697,6 +2657,14 @@
       "symbol": "WEFI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/30540/large/wefi.png?1696529412"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbcf339df10d78f2b44aa760ead0f715a7a7d7269",
+      "name": "Guardian GUARD",
+      "symbol": "GUARD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17995/large/LS_wolfDen_logo.0025_Light_200x200.png?1696517512"
     },
     {
       "chainId": 42161,
@@ -2724,35 +2692,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0x498c620c7c91c6eba2e3cd5485383f41613b7eb6",
-      "name": "Alongside Crypto Market Index",
-      "symbol": "AMKT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28496/large/22999.png?1696527488"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb00eaedb98f1e30ad545703d8ff14b24d109514f",
-      "name": "Yaku",
-      "symbol": "YAKU",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/26785/large/yaku_logo.png?1706636424"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x93ca0d85837ff83158cd14d65b169cdb223b1921",
-      "name": "Eclipse Fi",
-      "symbol": "ECLIP",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/31815/large/ECLIP_token_logo.png?1696530629"
-    },
-    {
-      "chainId": 42161,
       "address": "0x872bad41cfc8ba731f811fea8b2d0b9fd6369585",
       "name": "BattleFly",
       "symbol": "GFLY",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/28828/large/GFLY_LOGO.png?1696527804"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4debfb9ed639144cf1e401674af361ffffcefb58",
+      "name": "CADAI",
+      "symbol": "CADAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38713/large/CADAI_Token_Logo.png?1718404394"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x34229b3f16fbcdfa8d8d9d17c0852f9496f4c7bb",
+      "name": "IPOR",
+      "symbol": "IPOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png?1696527376"
     },
     {
       "chainId": 42161,
@@ -2764,19 +2724,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x155f0dd04424939368972f4e1838687d6a831151",
-      "name": "ArbiDoge",
-      "symbol": "ADOGE",
+      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
+      "name": "Overnight Finance",
+      "symbol": "OVN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18333/large/Screen-Shot-2021-09-04-at-11-59-16-AM.png?1696517824"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xde70aed3d14d39b4955147efcf272334bdb75ab5",
-      "name": "YachtingVerse",
-      "symbol": "YACHT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32858/large/aMmNwBTH_400x400.jpg?1699666370"
+      "logoURI": "https://assets.coingecko.com/coins/images/31970/large/OVN.png?1696959174"
     },
     {
       "chainId": 42161,
@@ -2788,38 +2740,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0x07e49d5de43dda6162fa28d24d5935c151875283",
-      "name": "CVI",
-      "symbol": "GOVI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13875/large/GOVI.png?1696513619"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8038f3c971414fd1fc220ba727f2d4a0fc98cb65",
-      "name": "dHEDGE DAO",
-      "symbol": "DHT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12508/large/dht.png?1696512323"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb52bd62ee0cf462fa9ccbda4bf27fe84d9ab6cf7",
-      "name": "Clipper SAIL",
-      "symbol": "SAIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31380/large/SAIL-Logo.png?1696530197"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd3188e0df68559c0b63361f6160c57ad88b239d8",
-      "name": "Astra DAO",
-      "symbol": "ASTRADAO",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/32870/large/ASTRADAO.jpg?1699673097"
-    },
-    {
-      "chainId": 42161,
       "address": "0x602eb0d99a5e3e76d1510372c4d2020e12eaea8a",
       "name": "TridentDAO",
       "symbol": "PSI",
@@ -2828,107 +2748,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0xdce765f021410b3266aa0053c93cb4535f1e12e0",
-      "name": "peg eUSD",
-      "symbol": "PEUSD",
+      "address": "0xde70aed3d14d39b4955147efcf272334bdb75ab5",
+      "name": "YachtingVerse",
+      "symbol": "YACHT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31521/large/peUSD_200x200.png?1696530331"
+      "logoURI": "https://assets.coingecko.com/coins/images/32858/large/aMmNwBTH_400x400.jpg?1699666370"
     },
     {
       "chainId": 42161,
-      "address": "0x88266f9eb705f5282a2507a9c418821a2ac9f8bd",
-      "name": "Nutcash",
-      "symbol": "NCASH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52578/large/nutcash_200x200_beige_circle.png?1733692905"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbfbcfe8873fe28dfa25f1099282b088d52bbad9c",
-      "name": "Equilibria Finance",
-      "symbol": "EQB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30645/large/QLLK8pmR_400x400.jpg?1696529516"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x79ead7a012d97ed8deece279f9bc39e264d7eef9",
-      "name": "Bonsai",
-      "symbol": "BONSAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37883/large/bonsai.jpeg?1715840730"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6dd963c510c2d2f09d5eddb48ede45fed063eb36",
-      "name": "Factor",
-      "symbol": "FCTR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29018/large/FactorLogo.png?1696527989"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbbea044f9e7c0520195e49ad1e561572e7e1b948",
-      "name": "Mizar",
-      "symbol": "MZR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23272/large/V1DTptkT_400x400.jpg?1696522492"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x577fd586c9e6ba7f2e85e025d5824dbe19896656",
-      "name": "SYNO Finance",
-      "symbol": "SYNO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35065/large/Synonym_Finance_Twitter_PFP.png?1733990595"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8bf591eae535f93a242d5a954d3cde648b48a5a8",
-      "name": "Sumer Money suUSD",
-      "symbol": "SUUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33266/large/Sumer_Money_Logo.jpg?1701321416"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x66e535e8d2ebf13f49f3d49e5c50395a97c137b1",
-      "name": "Molten",
-      "symbol": "MOLTEN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36726/large/moltenmesh.png?1712147407"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5",
-      "name": "Smolcoin",
-      "symbol": "SMOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33951/large/Smol_Coin_Icon.png?1703558329"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xafe8107123eefd62469474dec9680860b890e5b6",
-      "name": "Oil Token",
-      "symbol": "OIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39504/large/logo_oil_200%D1%85200.png?1722581566"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xddd6ebd74684318fa912084a41a01f11b6c277f7",
-      "name": "WorkoutApp",
-      "symbol": "WRT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37270/large/wrt.jpg?1713888102"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x32eb7902d4134bf98a28b963d26de779af92a212",
-      "name": "Dopex Rebate",
-      "symbol": "RDPX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/16659/large/rDPX_200x200_Coingecko.png?1696516221"
+      "address": "0x93ca0d85837ff83158cd14d65b169cdb223b1921",
+      "name": "Eclipse Fi",
+      "symbol": "ECLIP",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31815/large/ECLIP_token_logo.png?1696530629"
     },
     {
       "chainId": 42161,
@@ -2940,11 +2772,51 @@
     },
     {
       "chainId": 42161,
-      "address": "0x299142a6370e1912156e53fbd4f25d7ba49ddcc5",
-      "name": "AI Meta Club",
-      "symbol": "AMC",
+      "address": "0x8038f3c971414fd1fc220ba727f2d4a0fc98cb65",
+      "name": "dHEDGE DAO",
+      "symbol": "DHT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31919/large/aimeta.jpg?1696530728"
+      "logoURI": "https://assets.coingecko.com/coins/images/12508/large/dht.png?1696512323"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd3188e0df68559c0b63361f6160c57ad88b239d8",
+      "name": "Astra DAO",
+      "symbol": "ASTRADAO",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/32870/large/ASTRADAO.jpg?1699673097"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdce765f021410b3266aa0053c93cb4535f1e12e0",
+      "name": "peg eUSD",
+      "symbol": "PEUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31521/large/peUSD_200x200.png?1696530331"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfbcfe8873fe28dfa25f1099282b088d52bbad9c",
+      "name": "Equilibria Finance",
+      "symbol": "EQB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30645/large/QLLK8pmR_400x400.jpg?1696529516"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6fd58f5a2f3468e35feb098b5f59f04157002407",
+      "name": "POGAI",
+      "symbol": "POGAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30116/large/pogai.jpeg?1696529039"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb52bd62ee0cf462fa9ccbda4bf27fe84d9ab6cf7",
+      "name": "Clipper SAIL",
+      "symbol": "SAIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31380/large/SAIL-Logo.png?1696530197"
     },
     {
       "chainId": 42161,
@@ -2956,11 +2828,163 @@
     },
     {
       "chainId": 42161,
+      "address": "0x07e49d5de43dda6162fa28d24d5935c151875283",
+      "name": "CVI",
+      "symbol": "GOVI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13875/large/GOVI.png?1696513619"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x88266f9eb705f5282a2507a9c418821a2ac9f8bd",
+      "name": "Nutcash",
+      "symbol": "NCASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52578/large/nutcash_200x200_beige_circle.png?1733692905"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xddd6ebd74684318fa912084a41a01f11b6c277f7",
+      "name": "WorkoutApp",
+      "symbol": "WRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37270/large/wrt.jpg?1713888102"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbbea044f9e7c0520195e49ad1e561572e7e1b948",
+      "name": "Mizar",
+      "symbol": "MZR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23272/large/V1DTptkT_400x400.jpg?1696522492"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x79ead7a012d97ed8deece279f9bc39e264d7eef9",
+      "name": "Bonsai",
+      "symbol": "BONSAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37883/large/bonsai.jpeg?1715840730"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xafe8107123eefd62469474dec9680860b890e5b6",
+      "name": "Oil Token",
+      "symbol": "OIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39504/large/logo_oil_200%D1%85200.png?1722581566"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11bbf12363dc8375b78d2719395d505f52a02f68",
+      "name": "Router Protocol  OLD ",
+      "symbol": "ROUTE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13709/large/router.jpg?1722424977"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x66e535e8d2ebf13f49f3d49e5c50395a97c137b1",
+      "name": "Molten",
+      "symbol": "MOLTEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36726/large/moltenmesh.png?1712147407"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x32eb7902d4134bf98a28b963d26de779af92a212",
+      "name": "Dopex Rebate",
+      "symbol": "RDPX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16659/large/rDPX_200x200_Coingecko.png?1696516221"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x577fd586c9e6ba7f2e85e025d5824dbe19896656",
+      "name": "SYNO Finance",
+      "symbol": "SYNO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35065/large/Synonym_Finance_Twitter_PFP.png?1733990595"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x155f0dd04424939368972f4e1838687d6a831151",
+      "name": "ArbiDoge",
+      "symbol": "ADOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18333/large/Screen-Shot-2021-09-04-at-11-59-16-AM.png?1696517824"
+    },
+    {
+      "chainId": 42161,
       "address": "0x6dbf2155b0636cb3fd5359fccefb8a2c02b6cb51",
       "name": "Plutus RDNT",
       "symbol": "PLSRDNT",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/30635/large/plsRDNT.png?1696529508"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x299142a6370e1912156e53fbd4f25d7ba49ddcc5",
+      "name": "AI Meta Club",
+      "symbol": "AMC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31919/large/aimeta.jpg?1696530728"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x641441c631e2f909700d2f41fd87f0aa6a6b4edb",
+      "name": "dForce USD",
+      "symbol": "USX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17422/large/usx_32.png?1696516969"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6dd963c510c2d2f09d5eddb48ede45fed063eb36",
+      "name": "Factor",
+      "symbol": "FCTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29018/large/FactorLogo.png?1696527989"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0002bcdaf53f4889bf2f43a3252d7c03fe1b80bc",
+      "name": "GorplesCoin",
+      "symbol": "GORPLES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38681/large/Round_Avatar.png?1720520435"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x323665443cef804a3b5206103304bd4872ea4253",
+      "name": "Verified USD",
+      "symbol": "USDV",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/32948/large/usdv_%281%29.png?1699933314"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5",
+      "name": "Smolcoin",
+      "symbol": "SMOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33951/large/Smol_Coin_Icon.png?1703558329"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb6212b633c941e9be168c4b9c2d9e785f1cd42fb",
+      "name": "Bitoro",
+      "symbol": "BTORO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50334/large/bitoro-logo-highres.jpg?1727306095"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8d7c2588c365b9e98ea464b63dbccdf13ecd9809",
+      "name": "Flourishing AI",
+      "symbol": "AI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17127/large/Flourishing_Icon_FullColor_200.png?1703377529"
     },
     {
       "chainId": 42161,
@@ -2980,75 +3004,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x8d7c2588c365b9e98ea464b63dbccdf13ecd9809",
-      "name": "Flourishing AI",
-      "symbol": "AI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17127/large/Flourishing_Icon_FullColor_200.png?1703377529"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x27f485b62c4a7e635f561a87560adf5090239e93",
-      "name": "DFX Finance",
-      "symbol": "DFX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14091/large/DFX.png?1696513813"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x323665443cef804a3b5206103304bd4872ea4253",
-      "name": "Verified USD",
-      "symbol": "USDV",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/32948/large/usdv_%281%29.png?1699933314"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x11bbf12363dc8375b78d2719395d505f52a02f68",
-      "name": "Router Protocol  OLD ",
-      "symbol": "ROUTE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13709/large/router.jpg?1722424977"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x0002bcdaf53f4889bf2f43a3252d7c03fe1b80bc",
-      "name": "GorplesCoin",
-      "symbol": "GORPLES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38681/large/Round_Avatar.png?1720520435"
-    },
-    {
-      "chainId": 42161,
       "address": "0x0caadd427a6feb5b5fc1137eb05aa7ddd9c08ce9",
       "name": "VEE",
       "symbol": "VEE",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/52199/large/1000002075.png?1732732974"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x326c33fd1113c1f29b35b4407f3d6312a8518431",
-      "name": "Strips Finance",
-      "symbol": "STRP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18327/large/Logo-Strips-200-x-200px---without-words.png?1696517818"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x86f65121804d2cdbef79f9f072d4e0c2eebabc08",
-      "name": "Garden",
-      "symbol": "SEED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34671/large/icon.png?1705656915"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x641441c631e2f909700d2f41fd87f0aa6a6b4edb",
-      "name": "dForce USD",
-      "symbol": "USX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17422/large/usx_32.png?1696516969"
     },
     {
       "chainId": 42161,
@@ -3068,11 +3028,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xb6212b633c941e9be168c4b9c2d9e785f1cd42fb",
-      "name": "Bitoro",
-      "symbol": "BTORO",
+      "address": "0x7f90122bf0700f9e7e1f688fe926940e8839f353",
+      "name": "Curve fi USDC USDT",
+      "symbol": "2CRV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50334/large/bitoro-logo-highres.jpg?1727306095"
+      "logoURI": "https://assets.coingecko.com/coins/images/28365/large/curve2.png?1696527368"
     },
     {
       "chainId": 42161,
@@ -3084,35 +3044,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x75ec618a817eb0a4a7e44ac3dfc64c963daf921a",
-      "name": "Token7007",
-      "symbol": "7007",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50293/large/token7007.png?1726931640"
-    },
-    {
-      "chainId": 42161,
       "address": "0xa9011ee5796be43123651181dc75c0e72bb1191c",
       "name": "NeuroPulse AI",
       "symbol": "NPAI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/31848/large/NPAI.png?1700257725"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe3b3fe7bca19ca77ad877a5bebab186becfad906",
-      "name": "Staked FRAX",
-      "symbol": "SFRAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35383/large/sfrax.png?1708445569"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3f56e0c36d275367b8c502090edf38289b3dea0d",
-      "name": "MAI  Arbitrum ",
-      "symbol": "MIMATIC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35517/large/mimatic-red.png?1709005586"
     },
     {
       "chainId": 42161,
@@ -3124,11 +3060,43 @@
     },
     {
       "chainId": 42161,
-      "address": "0x249c48e22e95514ca975de31f473f30c2f3c0916",
-      "name": "USDFI",
-      "symbol": "USDFI",
+      "address": "0x326c33fd1113c1f29b35b4407f3d6312a8518431",
+      "name": "Strips Finance",
+      "symbol": "STRP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31149/large/USDFI_200.png?1696529977"
+      "logoURI": "https://assets.coingecko.com/coins/images/18327/large/Logo-Strips-200-x-200px---without-words.png?1696517818"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcf934e2402a5e072928a39a956964eb8f2b5b79c",
+      "name": "PoolTogether",
+      "symbol": "POOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14003/large/PoolTogether.png?1696513732"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3f56e0c36d275367b8c502090edf38289b3dea0d",
+      "name": "MAI  Arbitrum ",
+      "symbol": "MIMATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35517/large/mimatic-red.png?1709005586"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe3b3fe7bca19ca77ad877a5bebab186becfad906",
+      "name": "Staked FRAX",
+      "symbol": "SFRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35383/large/sfrax.png?1708445569"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9f41b34f42058a7b74672055a5fae22c4b113fd1",
+      "name": "Yum",
+      "symbol": "YUM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39116/large/yum.png?1720590184"
     },
     {
       "chainId": 42161,
@@ -3140,27 +3108,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x45940000009600102a1c002f0097c4a500fa00ab",
-      "name": "Hermes Protocol",
-      "symbol": "HERMES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24251/large/Transparent-13_%281%29_%281%29.png?1725188033"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xef04804e1e474d3f9b73184d7ef5d786f3fce930",
-      "name": "Wall Street Games",
-      "symbol": "WSG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36483/large/wsg.jpeg?1711539007"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x9f41b34f42058a7b74672055a5fae22c4b113fd1",
-      "name": "Yum",
-      "symbol": "YUM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39116/large/yum.png?1720590184"
+      "address": "0x1bd013bd089c2b6b2d30a0e0b545810a5844e761",
+      "name": "OtterHome",
+      "symbol": "HOME",
+      "decimals": 16,
+      "logoURI": "https://assets.coingecko.com/coins/images/30740/large/LOGO.png?1696529610"
     },
     {
       "chainId": 42161,
@@ -3180,43 +3132,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x221a0f68770658c15b525d0f89f5da2baab5f321",
-      "name": "Open Dollar",
-      "symbol": "OD",
+      "address": "0x27f485b62c4a7e635f561a87560adf5090239e93",
+      "name": "DFX Finance",
+      "symbol": "DFX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38630/large/OD_Token_200_x_200.png?1718170821"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x7f90122bf0700f9e7e1f688fe926940e8839f353",
-      "name": "Curve fi USDC USDT",
-      "symbol": "2CRV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28365/large/curve2.png?1696527368"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xe4421566a501045ae4285996577a36f6cf074190",
-      "name": "Ice",
-      "symbol": "ICE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35093/large/ICE_LOGO.jpg?1707363813"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x8b5e4c9a188b1a187f2d1e80b1c2fb17fa2922e1",
-      "name": "GoldenBoys",
-      "symbol": "GOLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31353/large/goldenboys.png?1696530170"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb9af4762c039d63e30039f1712dfab77026408c7",
-      "name": "BullBear AI",
-      "symbol": "AIBB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30096/large/ICON_200.png?1696529020"
+      "logoURI": "https://assets.coingecko.com/coins/images/14091/large/DFX.png?1696513813"
     },
     {
       "chainId": 42161,
@@ -3228,19 +3148,91 @@
     },
     {
       "chainId": 42161,
-      "address": "0xecc68d0451e20292406967fe7c04280e5238ac7d",
-      "name": "Axelar Bridged Frax Ether",
-      "symbol": "AXLFRXETH",
+      "address": "0xe4421566a501045ae4285996577a36f6cf074190",
+      "name": "Ice",
+      "symbol": "ICE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38976/large/Screen_Shot_2024-06-18_at_12.55.54_PM_2.png?1719714886"
+      "logoURI": "https://assets.coingecko.com/coins/images/35093/large/ICE_LOGO.jpg?1707363813"
     },
     {
       "chainId": 42161,
-      "address": "0x2297aebd383787a160dd0d9f71508148769342e3",
-      "name": "Avalanche Bridged BTC  Arbitrum One ",
-      "symbol": "BTCB",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/51135/large/avalanche-core.png?1730195092"
+      "address": "0x45940000009600102a1c002f0097c4a500fa00ab",
+      "name": "Hermes Protocol",
+      "symbol": "HERMES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24251/large/Transparent-13_%281%29_%281%29.png?1725188033"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x498c620c7c91c6eba2e3cd5485383f41613b7eb6",
+      "name": "Alongside Crypto Market Index",
+      "symbol": "AMKT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28496/large/22999.png?1696527488"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1d1498166ddceee616a6d99868e1e0677300056f",
+      "name": "Space Token",
+      "symbol": "SPACE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20676/large/jYw3kgsY_400x400.png?1696520076"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x86f65121804d2cdbef79f9f072d4e0c2eebabc08",
+      "name": "Garden",
+      "symbol": "SEED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34671/large/icon.png?1705656915"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x75ec618a817eb0a4a7e44ac3dfc64c963daf921a",
+      "name": "Token7007",
+      "symbol": "7007",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50293/large/token7007.png?1726931640"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb9af4762c039d63e30039f1712dfab77026408c7",
+      "name": "BullBear AI",
+      "symbol": "AIBB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30096/large/ICON_200.png?1696529020"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xed5740209fcf6974d6f3a5f11e295b5e468ac27c",
+      "name": "KEWL EXCHANGE",
+      "symbol": "KWL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36883/large/yamuk.png?1712649510"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8b5e4c9a188b1a187f2d1e80b1c2fb17fa2922e1",
+      "name": "GoldenBoys",
+      "symbol": "GOLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31353/large/goldenboys.png?1696530170"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xef04804e1e474d3f9b73184d7ef5d786f3fce930",
+      "name": "Wall Street Games",
+      "symbol": "WSG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36483/large/wsg.jpeg?1711539007"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x249c48e22e95514ca975de31f473f30c2f3c0916",
+      "name": "USDFI",
+      "symbol": "USDFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31149/large/USDFI_200.png?1696529977"
     },
     {
       "chainId": 42161,
@@ -3252,11 +3244,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x31c91d8fb96bff40955dd2dbc909b36e8b104dde",
-      "name": "Poison Finance",
-      "symbol": "POION",
+      "address": "0x9500ba777560daf9d3ab148ea1cf1ed39df9ebdb",
+      "name": "STYLE Token",
+      "symbol": "STYLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28630/large/poisonlogo160x160.png?1696527614"
+      "logoURI": "https://assets.coingecko.com/coins/images/37507/large/Token_Logo__STYLE.png?1729579902"
     },
     {
       "chainId": 42161,
@@ -3268,19 +3260,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x1bd013bd089c2b6b2d30a0e0b545810a5844e761",
-      "name": "OtterHome",
-      "symbol": "HOME",
-      "decimals": 16,
-      "logoURI": "https://assets.coingecko.com/coins/images/30740/large/LOGO.png?1696529610"
+      "address": "0x31c91d8fb96bff40955dd2dbc909b36e8b104dde",
+      "name": "Poison Finance",
+      "symbol": "POION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28630/large/poisonlogo160x160.png?1696527614"
     },
     {
       "chainId": 42161,
-      "address": "0xed5740209fcf6974d6f3a5f11e295b5e468ac27c",
-      "name": "KEWL EXCHANGE",
-      "symbol": "KWL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36883/large/yamuk.png?1712649510"
+      "address": "0x2297aebd383787a160dd0d9f71508148769342e3",
+      "name": "Avalanche Bridged BTC  Arbitrum One ",
+      "symbol": "BTCB",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/51135/large/avalanche-core.png?1730195092"
     },
     {
       "chainId": 42161,
@@ -3300,14 +3292,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0x9dca587dc65ac0a043828b0acd946d71eb8d46c1",
-      "name": "iFARM",
-      "symbol": "IFARM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14472/large/ifarm.png?1696514159"
-    },
-    {
-      "chainId": 42161,
       "address": "0x255f1b39172f65dc6406b8bee8b08155c45fe1b6",
       "name": "HarambeCoin",
       "symbol": "HARAMBE",
@@ -3316,19 +3300,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xfd2fb8de10ec41ddd898a8c7fa70d8fc100834c4",
-      "name": "Bitci DOGE",
-      "symbol": "BOGE",
+      "address": "0x9dca587dc65ac0a043828b0acd946d71eb8d46c1",
+      "name": "iFARM",
+      "symbol": "IFARM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38048/large/DOGE_TOKEN_200.png?1716401036"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf18c263ec50cc211ef3f172228549b6618f10613",
-      "name": "Collab Land",
-      "symbol": "COLLAB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29098/large/collab.png?1696528061"
+      "logoURI": "https://assets.coingecko.com/coins/images/14472/large/ifarm.png?1696514159"
     },
     {
       "chainId": 42161,
@@ -3340,19 +3316,35 @@
     },
     {
       "chainId": 42161,
-      "address": "0x1d1498166ddceee616a6d99868e1e0677300056f",
-      "name": "Space Token",
-      "symbol": "SPACE",
+      "address": "0x221a0f68770658c15b525d0f89f5da2baab5f321",
+      "name": "Open Dollar",
+      "symbol": "OD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20676/large/jYw3kgsY_400x400.png?1696520076"
+      "logoURI": "https://assets.coingecko.com/coins/images/38630/large/OD_Token_200_x_200.png?1718170821"
     },
     {
       "chainId": 42161,
-      "address": "0x9500ba777560daf9d3ab148ea1cf1ed39df9ebdb",
-      "name": "STYLE Token",
-      "symbol": "STYLE",
+      "address": "0xfd2fb8de10ec41ddd898a8c7fa70d8fc100834c4",
+      "name": "Bitci DOGE",
+      "symbol": "BOGE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37507/large/Token_Logo__STYLE.png?1729579902"
+      "logoURI": "https://assets.coingecko.com/coins/images/38048/large/DOGE_TOKEN_200.png?1716401036"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbea0005b8599265d41256905a9b3073d397812e4",
+      "name": "Bean",
+      "symbol": "BEAN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18447/large/bean-logo-coingecko.png?1696517934"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf18c263ec50cc211ef3f172228549b6618f10613",
+      "name": "Collab Land",
+      "symbol": "COLLAB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29098/large/collab.png?1696528061"
     },
     {
       "chainId": 42161,
@@ -3364,107 +3356,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xd1e094cabc5acb9d3b0599c3f76f2d01ff8d3563",
-      "name": "VirtuSwap",
-      "symbol": "VRSW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30629/large/VirtuSwap_Logo_Red_200x200.png?1696529502"
-    },
-    {
-      "chainId": 42161,
       "address": "0xd8724322f44e5c58d7a815f542036fb17dbbf839",
       "name": "Wrapped OETH",
       "symbol": "WOETH",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/29734/large/woeth-200x200.png?1714796686"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x93c15cd7de26f07265f0272e0b831c5d7fab174f",
-      "name": "Liquid Finance",
-      "symbol": "LIQD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27056/large/liqd.png?1696526107"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xa3210cd727fe6daf8386af5623ba51a367e46263",
-      "name": "Basket",
-      "symbol": "BSKT",
-      "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/34661/large/BSKT_Logo.png?1705636891"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xdf4ef6ee483953fe3b84abd08c6a060445c01170",
-      "name": "Wrapped Accumulate",
-      "symbol": "WACME",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/27207/large/accumulate-logo-200x200.png?1696526255"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xbcd4d5ac29e06e4973a1ddcd782cd035d04bc0b7",
-      "name": "Quick Intel",
-      "symbol": "QKNTL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29605/large/IMG_6589D0616DF1-1.jpeg?1696528542"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x949185d3be66775ea648f4a306740ea9eff9c567",
-      "name": "Yel Finance",
-      "symbol": "YEL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17429/large/Logo200.png?1696516976"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3ed03e95dd894235090b3d4a49e0c3239edce59e",
-      "name": "Blox MYRC",
-      "symbol": "MYRC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38632/large/myrc-token-trans-200x200.png?1718172187"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x80dd74145b8bb10cef01bf914f796bd8b54d7809",
-      "name": "Hepton",
-      "symbol": "HTE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30274/large/HTECoingecko.png?1696529180"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd4fe6e1e37dfcf35e9eeb54d4cca149d1c10239f",
-      "name": "TREN Debt Token",
-      "symbol": "XY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52811/large/XY_Logo_200x200.png?1734365137"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x284592a004d945f98de5b040808578c61a4bb39a",
-      "name": "AIR",
-      "symbol": "AIR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36113/large/Air_%28AIR%29_1.png?1710487829"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xb01cf1be9568f09449382a47cd5bf58e2a9d5922",
-      "name": "Lightspeed",
-      "symbol": "SPEED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51401/large/lightspeed-round-200.png?1731085512"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x939727d85d99d0ac339bf1b76dfe30ca27c19067",
-      "name": "SIZE",
-      "symbol": "SIZE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34084/large/adadad.jpg?1703910572"
     },
     {
       "chainId": 42161,
@@ -3476,11 +3372,75 @@
     },
     {
       "chainId": 42161,
-      "address": "0x83e60b9f7f4db5cdb0877659b1740e73c662c55b",
-      "name": "Pingu Exchange",
-      "symbol": "PINGU",
+      "address": "0x80dd74145b8bb10cef01bf914f796bd8b54d7809",
+      "name": "Hepton",
+      "symbol": "HTE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34790/large/icon_primary.png?1706030846"
+      "logoURI": "https://assets.coingecko.com/coins/images/30274/large/HTECoingecko.png?1696529180"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb01cf1be9568f09449382a47cd5bf58e2a9d5922",
+      "name": "Lightspeed",
+      "symbol": "SPEED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51401/large/lightspeed-round-200.png?1731085512"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xecc68d0451e20292406967fe7c04280e5238ac7d",
+      "name": "Axelar Bridged Frax Ether",
+      "symbol": "AXLFRXETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38976/large/Screen_Shot_2024-06-18_at_12.55.54_PM_2.png?1719714886"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd1e094cabc5acb9d3b0599c3f76f2d01ff8d3563",
+      "name": "VirtuSwap",
+      "symbol": "VRSW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30629/large/VirtuSwap_Logo_Red_200x200.png?1696529502"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdf4ef6ee483953fe3b84abd08c6a060445c01170",
+      "name": "Wrapped Accumulate",
+      "symbol": "WACME",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/27207/large/accumulate-logo-200x200.png?1696526255"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8bf591eae535f93a242d5a954d3cde648b48a5a8",
+      "name": "Sumer Money suUSD",
+      "symbol": "SUUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33266/large/Sumer_Money_Logo.jpg?1701321416"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3ed03e95dd894235090b3d4a49e0c3239edce59e",
+      "name": "Blox MYRC",
+      "symbol": "MYRC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38632/large/myrc-token-trans-200x200.png?1718172187"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x949185d3be66775ea648f4a306740ea9eff9c567",
+      "name": "Yel Finance",
+      "symbol": "YEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17429/large/Logo200.png?1696516976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x284592a004d945f98de5b040808578c61a4bb39a",
+      "name": "AIR",
+      "symbol": "AIR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36113/large/Air_%28AIR%29_1.png?1710487829"
     },
     {
       "chainId": 42161,
@@ -3489,6 +3449,22 @@
       "symbol": "ARBI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/30275/large/ARBI_Logo.png?1696529181"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x939727d85d99d0ac339bf1b76dfe30ca27c19067",
+      "name": "SIZE",
+      "symbol": "SIZE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34084/large/adadad.jpg?1703910572"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa3210cd727fe6daf8386af5623ba51a367e46263",
+      "name": "Basket",
+      "symbol": "BSKT",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/34661/large/BSKT_Logo.png?1705636891"
     },
     {
       "chainId": 42161,
@@ -3516,11 +3492,19 @@
     },
     {
       "chainId": 42161,
-      "address": "0x8888888888f004100c0353d657be6300587a6ccd",
-      "name": "ACryptoS",
-      "symbol": "ACS",
+      "address": "0x3405e88af759992937b84e58f2fe691ef0eea320",
+      "name": "Frax Price Index Share",
+      "symbol": "FPIS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32721/large/ACS.jpg?1699009686"
+      "logoURI": "https://assets.coingecko.com/coins/images/24944/large/FPIS_icon.png?1696524099"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x83e60b9f7f4db5cdb0877659b1740e73c662c55b",
+      "name": "Pingu Exchange",
+      "symbol": "PINGU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34790/large/icon_primary.png?1706030846"
     },
     {
       "chainId": 42161,
@@ -3556,35 +3540,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xe20b9e246db5a0d21bf9209e4858bc9a3ff7a034",
-      "name": "Wrapped Banano",
-      "symbol": "WBAN",
+      "address": "0x8888888888f004100c0353d657be6300587a6ccd",
+      "name": "ACryptoS",
+      "symbol": "ACS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32617/large/WBAN.jpg?1698749253"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee",
-      "name": "Aave v3 DAI",
-      "symbol": "ADAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32886/large/dai.png?1699769446"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xecf2adaff1de8a512f6e8bfe67a2c836edb25da3",
-      "name": "Wonderful Memories",
-      "symbol": "WMEMO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/22392/large/wMEMO.png?1696521735"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x848e0ba28b637e8490d88bae51fa99c87116409b",
-      "name": "Agave",
-      "symbol": "AGVE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14146/large/agve.png?1696513865"
+      "logoURI": "https://assets.coingecko.com/coins/images/32721/large/ACS.jpg?1699009686"
     },
     {
       "chainId": 42161,
@@ -3596,27 +3556,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0xd26b0c6ef8581e921ae41c66e508c62a581b709d",
-      "name": "Sexone",
-      "symbol": "SEX",
+      "address": "0xbcd4d5ac29e06e4973a1ddcd782cd035d04bc0b7",
+      "name": "Quick Intel",
+      "symbol": "QKNTL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32135/large/IMG_20231004_163306_491.jpg?1696589011"
+      "logoURI": "https://assets.coingecko.com/coins/images/29605/large/IMG_6589D0616DF1-1.jpeg?1696528542"
     },
     {
       "chainId": 42161,
-      "address": "0xccd05a0fcfc1380e9da27862adb2198e58e0d66f",
-      "name": "ANIMA",
-      "symbol": "ANIMA",
+      "address": "0xecf2adaff1de8a512f6e8bfe67a2c836edb25da3",
+      "name": "Wonderful Memories",
+      "symbol": "WMEMO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30377/large/anima_logo_yellow.png?1696529271"
+      "logoURI": "https://assets.coingecko.com/coins/images/22392/large/wMEMO.png?1696521735"
     },
     {
       "chainId": 42161,
-      "address": "0x123389c2f0e9194d9ba98c21e63c375b67614108",
-      "name": "EthereumMax",
-      "symbol": "EMAX",
+      "address": "0xd4fe6e1e37dfcf35e9eeb54d4cca149d1c10239f",
+      "name": "TREN Debt Token",
+      "symbol": "XY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15540/large/EMAX-Coin-Final2000x.png?1696515181"
+      "logoURI": "https://assets.coingecko.com/coins/images/52811/large/XY_Logo_200x200.png?1734365137"
     },
     {
       "chainId": 42161,
@@ -3628,11 +3588,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x4727a7d2022e99ee5c298513b730307f458f9b40",
-      "name": "Guberto",
-      "symbol": "GUBERTO",
+      "address": "0x848e0ba28b637e8490d88bae51fa99c87116409b",
+      "name": "Agave",
+      "symbol": "AGVE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50787/large/guberto_%281%29.jpg?1729210166"
+      "logoURI": "https://assets.coingecko.com/coins/images/14146/large/agve.png?1696513865"
     },
     {
       "chainId": 42161,
@@ -3644,27 +3604,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0x9b06f3c5de42d4623d7a2bd940ec735103c68a76",
-      "name": "Volta Club",
-      "symbol": "VOLTA",
+      "address": "0xe20b9e246db5a0d21bf9209e4858bc9a3ff7a034",
+      "name": "Wrapped Banano",
+      "symbol": "WBAN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31602/large/volta-200x200.png?1696530418"
+      "logoURI": "https://assets.coingecko.com/coins/images/32617/large/WBAN.jpg?1698749253"
     },
     {
       "chainId": 42161,
-      "address": "0x8347dff20de05b11c0781aaea90d5bee46c30252",
-      "name": "Playahh App",
-      "symbol": "PLAH",
+      "address": "0x59debed8d46a0cb823d8be8b957add987ead39aa",
+      "name": "Quack Token",
+      "symbol": "QUACK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40098/large/logoPlayahh10.png?1725632328"
+      "logoURI": "https://assets.coingecko.com/coins/images/31436/large/0x639C0D019C257966C4907bD4E68E3F349bB58109.png?1696530251"
     },
     {
       "chainId": 42161,
-      "address": "0xed7f000ee335b8199b004cca1c6f36d188cf6cb8",
-      "name": "D2 Finance",
-      "symbol": "D2",
+      "address": "0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee",
+      "name": "Aave v3 DAI",
+      "symbol": "ADAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34914/large/D2_Token_Logo.png?1706610408"
+      "logoURI": "https://assets.coingecko.com/coins/images/32886/large/dai.png?1699769446"
     },
     {
       "chainId": 42161,
@@ -3676,22 +3636,6 @@
     },
     {
       "chainId": 42161,
-      "address": "0x3419875b4d3bca7f3fdda2db7a476a79fd31b4fe",
-      "name": "DizzyHavoc",
-      "symbol": "DZHV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35575/large/dizzyhavoc_circle_3_200_200_transparentBg.png?1709194317"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xd44257dde89ca53f1471582f718632e690e46dc2",
-      "name": "S",
-      "symbol": "S",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50350/large/s.jpg?1727249471"
-    },
-    {
-      "chainId": 42161,
       "address": "0x8b5d1d8b3466ec21f8ee33ce63f319642c026142",
       "name": "High Yield ETH Index",
       "symbol": "HYETH",
@@ -3700,11 +3644,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0x67c31056358b8977ea95a3a899dd380d4bced706",
-      "name": "ETHforestAI",
-      "symbol": "ETHFAI",
+      "address": "0x51707dc661630f8fd624b985fa6ef4f1d4d919db",
+      "name": "Unvest",
+      "symbol": "UNV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29515/large/ethfai_logo.png?1696528459"
+      "logoURI": "https://assets.coingecko.com/coins/images/18119/large/UNV.jpg?1696517622"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x76bc2e765414e6c8b596c0f52c4240f80268f41d",
+      "name": "Unibit",
+      "symbol": "UIBT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36911/large/Unibit.png?1712764033"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xed7f000ee335b8199b004cca1c6f36d188cf6cb8",
+      "name": "D2 Finance",
+      "symbol": "D2",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34914/large/D2_Token_Logo.png?1706610408"
     },
     {
       "chainId": 42161,
@@ -3715,19 +3675,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x352f4bf396a7353a0877f99e99757e5d294df374",
-      "name": "Sundae the Dog",
-      "symbol": "SUNDAE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32010/large/sundae.jpg?1696530808"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x6daf586b7370b14163171544fca24abcc0862ac5",
-      "name": "xPet tech BPET",
-      "symbol": "BPET",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33848/large/BPET_logo.png?1703122571"
+      "address": "0xf29fdf6b7bdffb025d7e6dfdf344992d2d16e249",
+      "name": "Genius X",
+      "symbol": "GENSX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/30904/large/GX_short_logo.png?1696529749"
     },
     {
       "chainId": 42161,
@@ -3739,11 +3691,35 @@
     },
     {
       "chainId": 42161,
+      "address": "0x6daf586b7370b14163171544fca24abcc0862ac5",
+      "name": "xPet tech BPET",
+      "symbol": "BPET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33848/large/BPET_logo.png?1703122571"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2c7941a0fe9c52223b229747322af16160161c98",
+      "name": "Jarvis",
+      "symbol": "JARVIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35812/large/jarvis.png?1709873633"
+    },
+    {
+      "chainId": 42161,
       "address": "0x16a500aec6c37f84447ef04e66c57cfc6254cf92",
       "name": "Umoja",
       "symbol": "UMJA",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/38328/large/Umoja_Logo.png?1717639928"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xccd05a0fcfc1380e9da27862adb2198e58e0d66f",
+      "name": "ANIMA",
+      "symbol": "ANIMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30377/large/anima_logo_yellow.png?1696529271"
     },
     {
       "chainId": 42161,
@@ -3755,11 +3731,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x643b34980e635719c15a2d4ce69571a258f940e9",
-      "name": "The Standard EURO",
-      "symbol": "EUROS",
+      "address": "0x67c31056358b8977ea95a3a899dd380d4bced706",
+      "name": "ETHforestAI",
+      "symbol": "ETHFAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32231/large/EUROs-coingecko.png?1696936278"
+      "logoURI": "https://assets.coingecko.com/coins/images/29515/large/ethfai_logo.png?1696528459"
     },
     {
       "chainId": 42161,
@@ -3779,35 +3755,27 @@
     },
     {
       "chainId": 42161,
-      "address": "0xd3ac016b1b8c80eeadde4d186a9138c9324e4189",
-      "name": "Okcash",
-      "symbol": "OK",
+      "address": "0x8347dff20de05b11c0781aaea90d5bee46c30252",
+      "name": "Playahh App",
+      "symbol": "PLAH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/274/large/ok-logo-200px.png?1696501624"
+      "logoURI": "https://assets.coingecko.com/coins/images/40098/large/logoPlayahh10.png?1725632328"
     },
     {
       "chainId": 42161,
-      "address": "0x51707dc661630f8fd624b985fa6ef4f1d4d919db",
-      "name": "Unvest",
-      "symbol": "UNV",
+      "address": "0xd44257dde89ca53f1471582f718632e690e46dc2",
+      "name": "S",
+      "symbol": "S",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18119/large/UNV.jpg?1696517622"
+      "logoURI": "https://assets.coingecko.com/coins/images/50350/large/s.jpg?1727249471"
     },
     {
       "chainId": 42161,
-      "address": "0x666966ef3925b1c92fa355fda9722899f3e73451",
-      "name": "Stable",
-      "symbol": "STABLE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31148/large/stable_200.png?1696529976"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x3405e88af759992937b84e58f2fe691ef0eea320",
-      "name": "Frax Price Index Share",
-      "symbol": "FPIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24944/large/FPIS_icon.png?1696524099"
+      "address": "0x9ed7e4b1bff939ad473da5e7a218c771d1569456",
+      "name": "Reunit Wallet",
+      "symbol": "REUNI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/29492/large/reunit_200.png?1696528436"
     },
     {
       "chainId": 42161,
@@ -3827,27 +3795,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0xdb298285fe4c5410b05390ca80e8fbe9de1f259b",
-      "name": "handle fi",
-      "symbol": "FOREX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18533/large/handle.fiFOREXLogoDark200x200.png?1696518013"
-    },
-    {
-      "chainId": 42161,
       "address": "0x033f193b3fceb22a440e89a2867e8fee181594d9",
       "name": "Rodeo Finance",
       "symbol": "RDO",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/30905/large/RDO_ticker_logo_-_color-01-01.png?1696529750"
-    },
-    {
-      "chainId": 42161,
-      "address": "0xf29fdf6b7bdffb025d7e6dfdf344992d2d16e249",
-      "name": "Genius X",
-      "symbol": "GENSX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/30904/large/GX_short_logo.png?1696529749"
     },
     {
       "chainId": 42161,
@@ -3859,11 +3811,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
-      "name": "BetSwirl",
-      "symbol": "BETS",
+      "address": "0x352f4bf396a7353a0877f99e99757e5d294df374",
+      "name": "Sundae the Dog",
+      "symbol": "SUNDAE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26618/large/icon_200.png?1696525691"
+      "logoURI": "https://assets.coingecko.com/coins/images/32010/large/sundae.jpg?1696530808"
     },
     {
       "chainId": 42161,
@@ -3875,6 +3827,22 @@
     },
     {
       "chainId": 42161,
+      "address": "0x3419875b4d3bca7f3fdda2db7a476a79fd31b4fe",
+      "name": "DizzyHavoc",
+      "symbol": "DZHV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35575/large/dizzyhavoc_circle_3_200_200_transparentBg.png?1709194317"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd3ac016b1b8c80eeadde4d186a9138c9324e4189",
+      "name": "Okcash",
+      "symbol": "OK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/274/large/ok-logo-200px.png?1696501624"
+    },
+    {
+      "chainId": 42161,
       "address": "0x0a3bb08b3a15a19b4de82f8acfc862606fb69a2d",
       "name": "iZUMi Bond USD",
       "symbol": "IUSD",
@@ -3883,27 +3851,35 @@
     },
     {
       "chainId": 42161,
-      "address": "0x2b1d36f5b61addaf7da7ebbd11b35fd8cfb0de31",
-      "name": "Interport Token",
-      "symbol": "ITP",
+      "address": "0x666966ef3925b1c92fa355fda9722899f3e73451",
+      "name": "Stable",
+      "symbol": "STABLE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28338/large/ITP_Logo_200.png?1696527344"
+      "logoURI": "https://assets.coingecko.com/coins/images/31148/large/stable_200.png?1696529976"
     },
     {
       "chainId": 42161,
-      "address": "0x9ed7e4b1bff939ad473da5e7a218c771d1569456",
-      "name": "Reunit Wallet",
-      "symbol": "REUNI",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/29492/large/reunit_200.png?1696528436"
+      "address": "0x643b34980e635719c15a2d4ce69571a258f940e9",
+      "name": "The Standard EURO",
+      "symbol": "EUROS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32231/large/EUROs-coingecko.png?1696936278"
     },
     {
       "chainId": 42161,
-      "address": "0x59debed8d46a0cb823d8be8b957add987ead39aa",
-      "name": "Quack Token",
-      "symbol": "QUACK",
+      "address": "0x2e516ba5bf3b7ee47fb99b09eadb60bde80a82e0",
+      "name": "aEGGS",
+      "symbol": "AEGGS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31436/large/0x639C0D019C257966C4907bD4E68E3F349bB58109.png?1696530251"
+      "logoURI": "https://assets.coingecko.com/coins/images/29520/large/aeggs.png?1696528463"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9b06f3c5de42d4623d7a2bd940ec735103c68a76",
+      "name": "Volta Club",
+      "symbol": "VOLTA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31602/large/volta-200x200.png?1696530418"
     },
     {
       "chainId": 42161,
@@ -3915,11 +3891,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x76bc2e765414e6c8b596c0f52c4240f80268f41d",
-      "name": "Unibit",
-      "symbol": "UIBT",
+      "address": "0x2b1d36f5b61addaf7da7ebbd11b35fd8cfb0de31",
+      "name": "Interport Token",
+      "symbol": "ITP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36911/large/Unibit.png?1712764033"
+      "logoURI": "https://assets.coingecko.com/coins/images/28338/large/ITP_Logo_200.png?1696527344"
     },
     {
       "chainId": 42161,
@@ -3931,11 +3907,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x180f7cf38805d1be95c7632f653e26b0838e2969",
-      "name": "XDEFI",
-      "symbol": "XDEFI",
+      "address": "0xd26b0c6ef8581e921ae41c66e508c62a581b709d",
+      "name": "Sexone",
+      "symbol": "SEX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19524/large/xdefi.jpg?1723436519"
+      "logoURI": "https://assets.coingecko.com/coins/images/32135/large/IMG_20231004_163306_491.jpg?1696589011"
     },
     {
       "chainId": 42161,
@@ -3947,11 +3923,35 @@
     },
     {
       "chainId": 42161,
+      "address": "0x180f7cf38805d1be95c7632f653e26b0838e2969",
+      "name": "XDEFI",
+      "symbol": "XDEFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19524/large/xdefi.jpg?1723436519"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
+      "name": "BetSwirl",
+      "symbol": "BETS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26618/large/icon_200.png?1696525691"
+    },
+    {
+      "chainId": 42161,
       "address": "0x1426cf37caa89628c4da2864e40cf75e6d66ac6b",
       "name": "Relay Chain",
       "symbol": "RELAY",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/17816/large/relay-logo-200.png?1696517336"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdb298285fe4c5410b05390ca80e8fbe9de1f259b",
+      "name": "handle fi",
+      "symbol": "FOREX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18533/large/handle.fiFOREXLogoDark200x200.png?1696518013"
     },
     {
       "chainId": 42161,
@@ -3971,27 +3971,11 @@
     },
     {
       "chainId": 42161,
-      "address": "0x1310952bc5594852459ee45bfd0df70b34ac5509",
-      "name": "Parifi",
-      "symbol": "PRF",
+      "address": "0x6b5b5eac259e883b484ed879d43dd4d616a90e65",
+      "name": "The Knowers",
+      "symbol": "KNOW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34710/large/parifi200x200.png?1705894380"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x4d22e37eb4d71d1acc5f4889a65936d2a44a2f15",
-      "name": "Hat",
-      "symbol": "HAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39394/large/Black_circle_%281%29.png?1721976884"
-    },
-    {
-      "chainId": 42161,
-      "address": "0x319e222de462ac959baf2aec848697aec2bbd770",
-      "name": "OreoSwap",
-      "symbol": "OREO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28582/large/oreoswapx.png?1696527570"
+      "logoURI": "https://assets.coingecko.com/coins/images/36964/large/63_%281%29.png?1712907583"
     },
     {
       "chainId": 42161,
@@ -4003,12 +3987,28 @@
     },
     {
       "chainId": 42161,
-      "address": "0x57f5e098cad7a3d1eed53991d4d66c45c9af7812",
-      "name": "Wrapped USDM",
-      "symbol": "WUSDM",
+      "address": "0x4d22e37eb4d71d1acc5f4889a65936d2a44a2f15",
+      "name": "Hat",
+      "symbol": "HAT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33785/large/wUSDM_PNG_240px.png?1702981552"
+      "logoURI": "https://assets.coingecko.com/coins/images/39394/large/Black_circle_%281%29.png?1721976884"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf329e36c7bf6e5e86ce2150875a84ce77f477375",
+      "name": "Aave v3 AAVE",
+      "symbol": "AAAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32887/large/aave.png?1699773604"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1310952bc5594852459ee45bfd0df70b34ac5509",
+      "name": "Parifi",
+      "symbol": "PRF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34710/large/parifi200x200.png?1705894380"
     }
   ],
-  "timestamp": "2024-12-17T18:12:40.576Z"
+  "timestamp": "2024-12-17T20:31:05.733Z"
 }

--- a/src/public/CoinGecko.8453.json
+++ b/src/public/CoinGecko.8453.json
@@ -5,9 +5,9 @@
     "defi"
   ],
   "version": {
-    "major": 0,
+    "major": 1,
     "minor": 0,
-    "patch": 1
+    "patch": 0
   },
   "tokens": [
     {
@@ -84,6 +84,14 @@
     },
     {
       "chainId": 8453,
+      "address": "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",
+      "name": "Wrapped stETH",
+      "symbol": "WSTETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
+    },
+    {
+      "chainId": 8453,
       "address": "0x9e1028f5f1d5ede59748ffcee5532509976840e0",
       "name": "Compound",
       "symbol": "COMP",
@@ -97,6 +105,22 @@
       "symbol": "BRETT",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/35529/large/1000050750.png?1709031995"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3992b27da26848c2b19cea6fd25ad5568b68ab98",
+      "name": "MANTRA",
+      "symbol": "OM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12151/large/OM_Token.png?1696511991"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+      "name": "CARV",
+      "symbol": "CARV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
     },
     {
       "chainId": 8453,
@@ -116,30 +140,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
-      "name": "CARV",
-      "symbol": "CARV",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3992b27da26848c2b19cea6fd25ad5568b68ab98",
-      "name": "MANTRA",
-      "symbol": "OM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12151/large/OM_Token.png?1696511991"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xaac78d1219c08aecc8e37e03858fe885f5ef1799",
-      "name": "Yield Guild Games",
-      "symbol": "YGG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17358/large/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
-    },
-    {
-      "chainId": 8453,
       "address": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
       "name": "Degen  Base ",
       "symbol": "DEGEN",
@@ -148,11 +148,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",
-      "name": "Wrapped stETH",
-      "symbol": "WSTETH",
+      "address": "0xaac78d1219c08aecc8e37e03858fe885f5ef1799",
+      "name": "Yield Guild Games",
+      "symbol": "YGG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
+      "logoURI": "https://assets.coingecko.com/coins/images/17358/large/Shield_Mark_-_Colored_-_Iridescent.png?1696516909"
     },
     {
       "chainId": 8453,
@@ -188,6 +188,14 @@
     },
     {
       "chainId": 8453,
+      "address": "0x99ac4484e8a1dbd6a185380b3a811913ac884d87",
+      "name": "Savings Dai",
+      "symbol": "SDAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32254/large/sdai.png?1697015278"
+    },
+    {
+      "chainId": 8453,
       "address": "0x50da645f148798f68ef2d7db7c1cb22a6819bb2c",
       "name": "SPX6900",
       "symbol": "SPX",
@@ -209,22 +217,6 @@
       "symbol": "USDBC",
       "decimals": 6,
       "logoURI": "https://assets.coingecko.com/coins/images/31164/large/baseusdc.jpg?1696529993"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x99ac4484e8a1dbd6a185380b3a811913ac884d87",
-      "name": "Savings Dai",
-      "symbol": "SDAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32254/large/sdai.png?1697015278"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfb42da273158b0f642f59f2ba7cc1d5457481677",
-      "name": "Lingo",
-      "symbol": "LINGO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52647/large/Lingo_200x200.png?1733914947"
     },
     {
       "chainId": 8453,
@@ -252,22 +244,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0xe3b53af74a4bf62ae5511055290838050bf764df",
-      "name": "Stargate Finance",
-      "symbol": "STG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfa980ced6895ac314e7de34ef1bfae90a5add21b",
-      "name": "Echelon Prime",
-      "symbol": "PRIME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/prime-logo-small-border_%282%29.png?1696528020"
-    },
-    {
-      "chainId": 8453,
       "address": "0x2c24497d4086490e7ead87cc12597fb50c2e6ed6",
       "name": "SynFutures",
       "symbol": "F",
@@ -276,11 +252,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0xd722e55c1d9d9fa0021a5215cbb904b92b3dc5d4",
-      "name": "Radiant Capital",
-      "symbol": "RDNT",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
+      "address": "0xfb42da273158b0f642f59f2ba7cc1d5457481677",
+      "name": "Lingo",
+      "symbol": "LINGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52647/large/Lingo_200x200.png?1733914947"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe3b53af74a4bf62ae5511055290838050bf764df",
+      "name": "Stargate Finance",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
     },
     {
       "chainId": 8453,
@@ -300,27 +284,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",
-      "name": "L2 Standard Bridged USDT  Base ",
-      "symbol": "USDT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39963/large/usdt.png?1724952731"
+      "address": "0xd722e55c1d9d9fa0021a5215cbb904b92b3dc5d4",
+      "name": "Radiant Capital",
+      "symbol": "RDNT",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1696525610"
     },
     {
       "chainId": 8453,
-      "address": "0x4f9fd6be4a90f2620860d680c0d4d5fb53d1a825",
-      "name": "aixbt by Virtuals",
-      "symbol": "AIXBT",
+      "address": "0xfa980ced6895ac314e7de34ef1bfae90a5add21b",
+      "name": "Echelon Prime",
+      "symbol": "PRIME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51784/large/3.png?1731981138"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376",
-      "name": "Overnight fi USD   Base ",
-      "symbol": "USD+",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39624/large/USD_.png?1723179227"
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/prime-logo-small-border_%282%29.png?1696528020"
     },
     {
       "chainId": 8453,
@@ -332,11 +308,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xac1bd2486aaf3b5c0fc3fd868558b082a531b2b4",
-      "name": "Toshi",
-      "symbol": "TOSHI",
+      "address": "0x4f9fd6be4a90f2620860d680c0d4d5fb53d1a825",
+      "name": "aixbt by Virtuals",
+      "symbol": "AIXBT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31126/large/Toshi_Logo_-_Circular.png?1721677476"
+      "logoURI": "https://assets.coingecko.com/coins/images/51784/large/3.png?1731981138"
     },
     {
       "chainId": 8453,
@@ -348,19 +324,27 @@
     },
     {
       "chainId": 8453,
+      "address": "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376",
+      "name": "Overnight fi USD   Base ",
+      "symbol": "USD+",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39624/large/USD_.png?1723179227"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac1bd2486aaf3b5c0fc3fd868558b082a531b2b4",
+      "name": "Toshi",
+      "symbol": "TOSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31126/large/Toshi_Logo_-_Circular.png?1721677476"
+    },
+    {
+      "chainId": 8453,
       "address": "0xca4569949699d56e1834efe9f58747ca0f151b01",
       "name": "Token Metrics AI",
       "symbol": "TMAI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/37707/large/Mascot_200x200.png?1733173189"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x96419929d7949d6a801a6909c145c8eef6a40431",
-      "name": "Spectral",
-      "symbol": "SPEC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36138/large/ls7wS7vf_400x400.jpg?1724975224"
     },
     {
       "chainId": 8453,
@@ -385,6 +369,22 @@
       "symbol": "BAL",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1696511572"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2c8c89c442436cc6c0a77943e09c8daf49da3161",
+      "name": "Zeebu",
+      "symbol": "ZBU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31145/large/200x200_Front_token.png?1696529974"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x96419929d7949d6a801a6909c145c8eef6a40431",
+      "name": "Spectral",
+      "symbol": "SPEC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36138/large/ls7wS7vf_400x400.jpg?1724975224"
     },
     {
       "chainId": 8453,
@@ -452,35 +452,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xa88594d404727625a9437c3f886c7643872296ae",
-      "name": "Moonwell",
-      "symbol": "WELL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/26133/large/WELL.png?1696525221"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb1a03eda10342529bbf8eb700a06c60441fef25d",
-      "name": "Mister Miggles",
-      "symbol": "MIGGLES",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39251/large/New_LOGO.png?1734294728"
-    },
-    {
-      "chainId": 8453,
       "address": "0xc43f3ae305a92043bd9b62ebd2fe14f7547ee485",
       "name": "CHEX Token",
       "symbol": "CHEX",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/10349/large/logo-white-bg-dark.png?1733475849"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x768be13e1680b5ebe0024c42c896e3db59ec0149",
-      "name": "Ski Mask Dog",
-      "symbol": "SKI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37195/large/32992128-F52F-4346-84CA-8E0C48F43606.jpeg?1713676521"
     },
     {
       "chainId": 8453,
@@ -492,19 +468,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0xcd2f22236dd9dfe2356d7c543161d4d260fd9bcb",
-      "name": "Aavegotchi",
-      "symbol": "GHST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/12467/large/GHST.png?1696512286"
-    },
-    {
-      "chainId": 8453,
       "address": "0xb166e8b140d35d9d8226e40c09f757bac5a4d87d",
       "name": "Non Playable Coin",
       "symbol": "NPC",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/31193/large/NPC_200x200.png?1696530021"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb1a03eda10342529bbf8eb700a06c60441fef25d",
+      "name": "Mister Miggles",
+      "symbol": "MIGGLES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39251/large/New_LOGO.png?1734294728"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x768be13e1680b5ebe0024c42c896e3db59ec0149",
+      "name": "Ski Mask Dog",
+      "symbol": "SKI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37195/large/32992128-F52F-4346-84CA-8E0C48F43606.jpeg?1713676521"
     },
     {
       "chainId": 8453,
@@ -516,6 +500,22 @@
     },
     {
       "chainId": 8453,
+      "address": "0xcd2f22236dd9dfe2356d7c543161d4d260fd9bcb",
+      "name": "Aavegotchi",
+      "symbol": "GHST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12467/large/GHST.png?1696512286"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",
+      "name": "L2 Standard Bridged USDT  Base ",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/39963/large/usdt.png?1724952731"
+    },
+    {
+      "chainId": 8453,
       "address": "0x67f0870bb897f5e1c369976b4a2962d527b9562c",
       "name": "Department Of Government Efficiency",
       "symbol": "DOGE",
@@ -524,19 +524,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x2c8c89c442436cc6c0a77943e09c8daf49da3161",
-      "name": "Zeebu",
-      "symbol": "ZBU",
+      "address": "0xa88594d404727625a9437c3f886c7643872296ae",
+      "name": "Moonwell",
+      "symbol": "WELL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31145/large/200x200_Front_token.png?1696529974"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe2b1dc2d4a3b4e59fdf0c47b71a7a86391a8b35a",
-      "name": "RWA Inc ",
-      "symbol": "RWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50975/large/logo_%281%29.png?1732594737"
+      "logoURI": "https://assets.coingecko.com/coins/images/26133/large/WELL.png?1696525221"
     },
     {
       "chainId": 8453,
@@ -548,11 +540,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x3e31966d4f81c72d2a55310a6365a56a4393e98d",
-      "name": "World Mobile Token",
-      "symbol": "WMTX",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
+      "address": "0xe2b1dc2d4a3b4e59fdf0c47b71a7a86391a8b35a",
+      "name": "RWA Inc ",
+      "symbol": "RWA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50975/large/logo_%281%29.png?1732594737"
     },
     {
       "chainId": 8453,
@@ -564,27 +556,19 @@
     },
     {
       "chainId": 8453,
+      "address": "0x3e31966d4f81c72d2a55310a6365a56a4393e98d",
+      "name": "World Mobile Token",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17333/large/1000097112.png?1727698144"
+    },
+    {
+      "chainId": 8453,
       "address": "0x2a06a17cbc6d0032cac2c6696da90f29d39a1a29",
       "name": "HarryPotterObamaSonic10Inu  ETH ",
       "symbol": "BITCOIN",
       "decimals": 8,
       "logoURI": "https://assets.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd89d90d26b48940fa8f58385fe84625d468e057a",
-      "name": "Avail",
-      "symbol": "AVAIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37372/large/avail-logo.png?1714145201"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x623cd3a3edf080057892aaf8d773bbb7a5c9b6e9",
-      "name": "Sekuya Multiverse",
-      "symbol": "SKYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38096/large/SKYA_Logo_200x200.png?1731909478"
     },
     {
       "chainId": 8453,
@@ -596,19 +580,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0x619c4bbbd65f836b78b36cbe781513861d57f39d",
-      "name": "Bitget Wallet Token",
-      "symbol": "BWB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37767/large/bwb.png?1715480561"
-    },
-    {
-      "chainId": 8453,
       "address": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
       "name": "Cookie DAO",
       "symbol": "COOKIE",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/38450/large/cookie_token_logo_200x200.png?1733194528"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x619c4bbbd65f836b78b36cbe781513861d57f39d",
+      "name": "Bitget Wallet Token",
+      "symbol": "BWB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37767/large/bwb.png?1715480561"
     },
     {
       "chainId": 8453,
@@ -620,6 +604,14 @@
     },
     {
       "chainId": 8453,
+      "address": "0xd89d90d26b48940fa8f58385fe84625d468e057a",
+      "name": "Avail",
+      "symbol": "AVAIL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37372/large/avail-logo.png?1714145201"
+    },
+    {
+      "chainId": 8453,
       "address": "0xfb1aaba03c31ea98a3eec7591808acb1947ee7ac",
       "name": "Gains Network",
       "symbol": "GNS",
@@ -628,19 +620,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
-      "name": "Renzo Restaked ETH",
-      "symbol": "EZETH",
+      "address": "0xc48823ec67720a04a9dfd8c7d109b2c3d6622094",
+      "name": "Metacade",
+      "symbol": "MCADE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
+      "logoURI": "https://assets.coingecko.com/coins/images/29764/large/Square_Profile_Photo_1080_x_1080px.png?1699396445"
     },
     {
       "chainId": 8453,
-      "address": "0x4621b7a9c75199271f773ebd9a499dbd165c3191",
-      "name": "DOLA",
-      "symbol": "DOLA",
+      "address": "0x623cd3a3edf080057892aaf8d773bbb7a5c9b6e9",
+      "name": "Sekuya Multiverse",
+      "symbol": "SKYA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
+      "logoURI": "https://assets.coingecko.com/coins/images/38096/large/SKYA_Logo_200x200.png?1731909478"
     },
     {
       "chainId": 8453,
@@ -652,19 +644,35 @@
     },
     {
       "chainId": 8453,
+      "address": "0x1c4cca7c5db003824208adda61bd749e55f463a3",
+      "name": "GAME by Virtuals",
+      "symbol": "GAME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51063/large/Gaming_Agent_1fe70d54ba.jpg?1729925539"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
+      "name": "Renzo Restaked ETH",
+      "symbol": "EZETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34753/large/Ezeth_logo_circle.png?1713496404"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1dd2d631c92b1acdfcdd51a0f7145a50130050c4",
+      "name": "Alien Base",
+      "symbol": "ALB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31301/large/ALB.png?1720133373"
+    },
+    {
+      "chainId": 8453,
       "address": "0x029a3b0532871735809a51e8653d6017ef04b6fa",
       "name": "TYBENG",
       "symbol": "TYBENG",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/31022/large/NVoa_mZ6_400x400.jpg?1721805735"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc48823ec67720a04a9dfd8c7d109b2c3d6622094",
-      "name": "Metacade",
-      "symbol": "MCADE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29764/large/Square_Profile_Photo_1080_x_1080px.png?1699396445"
     },
     {
       "chainId": 8453,
@@ -684,75 +692,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x1dd2d631c92b1acdfcdd51a0f7145a50130050c4",
-      "name": "Alien Base",
-      "symbol": "ALB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31301/large/ALB.png?1720133373"
-    },
-    {
-      "chainId": 8453,
       "address": "0xb33ff54b9f7242ef1593d2c9bcd8f9df46c77935",
       "name": "Freysa AI",
       "symbol": "FAI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/52315/large/FAI.png?1733076295"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6b2504a03ca4d43d0d73776f6ad46dab2f2a4cfd",
-      "name": "Unit 00   Rei",
-      "symbol": "REI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52005/large/Unit_00_-_Rei.jpg?1732592775"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x52b492a33e447cdb854c7fc19f1e57e8bfa1777d",
-      "name": "Based Pepe",
-      "symbol": "PEPE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39763/large/based_pepe_transparent.png?1724010222"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x800822d361335b4d5f352dac293ca4128b5b605f",
-      "name": "SYMMIO",
-      "symbol": "SYMM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52828/large/256.jpg?1734435636"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
-      "name": "OX Coin",
-      "symbol": "OX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe3086852a4b125803c815a158249ae468a3254ca",
-      "name": "mfercoin",
-      "symbol": "MFER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36550/large/mfercoin-logo.png?1711876821"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x57f5fbd3de65dfc0bd3630f732969e5fb97e6d37",
-      "name": "MAGA",
-      "symbol": "TRUMP",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/31498/large/Maga-Trump-Logo-200px.png?1696530309"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe997017e0cb0ceb503565f181e9ea922cd979c35",
-      "name": "LimeWire",
-      "symbol": "LMWR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30356/large/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
     },
     {
       "chainId": 8453,
@@ -764,11 +708,75 @@
     },
     {
       "chainId": 8453,
+      "address": "0x4621b7a9c75199271f773ebd9a499dbd165c3191",
+      "name": "DOLA",
+      "symbol": "DOLA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1696513984"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6b2504a03ca4d43d0d73776f6ad46dab2f2a4cfd",
+      "name": "Unit 00   Rei",
+      "symbol": "REI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52005/large/Unit_00_-_Rei.jpg?1732592775"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xba0dda8762c24da9487f5fa026a9b64b695a07ea",
+      "name": "OX Coin",
+      "symbol": "OX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35365/large/9.png?1727331352"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9a26f5433671751c3276a065f57e5a02d2817973",
+      "name": "Keyboard Cat  Base ",
+      "symbol": "KEYCAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36608/large/keyboard_cat.jpeg?1711965348"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x57f5fbd3de65dfc0bd3630f732969e5fb97e6d37",
+      "name": "MAGA",
+      "symbol": "TRUMP",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/31498/large/Maga-Trump-Logo-200px.png?1696530309"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe3086852a4b125803c815a158249ae468a3254ca",
+      "name": "mfercoin",
+      "symbol": "MFER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36550/large/mfercoin-logo.png?1711876821"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe997017e0cb0ceb503565f181e9ea922cd979c35",
+      "name": "LimeWire",
+      "symbol": "LMWR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30356/large/LimeWire_Logo_Icon_200x200_%281%29.png?1696529256"
+    },
+    {
+      "chainId": 8453,
       "address": "0x9b8df6e244526ab5f6e6400d331db28c8fdddb55",
       "name": "Wrapped Solana  Universal ",
       "symbol": "USOL",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/39987/large/UA-SOL_1.png?1725027946"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x52b492a33e447cdb854c7fc19f1e57e8bfa1777d",
+      "name": "Based Pepe",
+      "symbol": "PEPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39763/large/based_pepe_transparent.png?1724010222"
     },
     {
       "chainId": 8453,
@@ -791,16 +799,8 @@
       "address": "0x18dd5b087bca9920562aff7a0199b96b9230438b",
       "name": "Propy",
       "symbol": "PRO",
-      "decimals": 18,
+      "decimals": 8,
       "logoURI": "https://assets.coingecko.com/coins/images/869/large/propy.png?1696502002"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa6f774051dfb6b54869227fda2df9cb46f296c09",
-      "name": "SKI MASK CAT",
-      "symbol": "SKICAT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52355/large/logo200x.png?1733168346"
     },
     {
       "chainId": 8453,
@@ -812,14 +812,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0xb0505e5a99abd03d94a1169e638b78edfed26ea4",
-      "name": "Wrapped SUI  Universal ",
-      "symbol": "USUI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50482/large/UA-SUI-PAD.png?1727888681"
-    },
-    {
-      "chainId": 8453,
       "address": "0x455234ab787665a219125235fb01b22b512dfcaa",
       "name": "DOSE",
       "symbol": "DOSE",
@@ -828,19 +820,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0x9a26f5433671751c3276a065f57e5a02d2817973",
-      "name": "Keyboard Cat  Base ",
-      "symbol": "KEYCAT",
+      "address": "0xa6f774051dfb6b54869227fda2df9cb46f296c09",
+      "name": "SKI MASK CAT",
+      "symbol": "SKICAT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36608/large/keyboard_cat.jpeg?1711965348"
+      "logoURI": "https://assets.coingecko.com/coins/images/52355/large/logo200x.png?1733168346"
     },
     {
       "chainId": 8453,
-      "address": "0x368181499736d0c0cc614dbb145e2ec1ac86b8c6",
-      "name": "Liquity USD",
-      "symbol": "LUSD",
+      "address": "0xb0505e5a99abd03d94a1169e638b78edfed26ea4",
+      "name": "Wrapped SUI  Universal ",
+      "symbol": "USUI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1696514341"
+      "logoURI": "https://assets.coingecko.com/coins/images/50482/large/UA-SUI-PAD.png?1727888681"
     },
     {
       "chainId": 8453,
@@ -852,14 +844,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0xef22cb48b8483df6152e1423b19df5553bbd818b",
-      "name": "Heurist",
-      "symbol": "HEU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51361/large/200X200.png?1733764636"
-    },
-    {
-      "chainId": 8453,
       "address": "0x15ac90165f8b45a80534228bdcb124a011f62fee",
       "name": "MOEW",
       "symbol": "MOEW",
@@ -868,27 +852,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0x1035ae3f87a91084c6c5084d0615cc6121c5e228",
-      "name": "Based Fwog",
-      "symbol": "FWOG",
+      "address": "0x368181499736d0c0cc614dbb145e2ec1ac86b8c6",
+      "name": "Liquity USD",
+      "symbol": "LUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52691/large/IMG_8652.PNG?1734033750"
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1696514341"
     },
     {
       "chainId": 8453,
-      "address": "0xafb89a09d82fbde58f18ac6437b3fc81724e4df6",
-      "name": "Own The Doge",
-      "symbol": "DOG",
+      "address": "0xea651c035f52b644856cab1f59775369c36ecadd",
+      "name": "La ka",
+      "symbol": "LAIKA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18111/large/Doge.png?1696517615"
+      "logoURI": "https://assets.coingecko.com/coins/images/39364/large/logo_laika.jpg?1721895773"
     },
     {
       "chainId": 8453,
-      "address": "0x161e113b8e9bbaefb846f73f31624f6f9607bd44",
-      "name": "Simmi Token",
-      "symbol": "SIMMI",
+      "address": "0x37e0b50ddbd719a46b9660396114c7f3fc9aa076",
+      "name": "Patriot on Base",
+      "symbol": "PATRIOT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52349/large/simmi.png?1733160996"
+      "logoURI": "https://assets.coingecko.com/coins/images/52764/large/200x200_%281%29.png?1734267707"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xef22cb48b8483df6152e1423b19df5553bbd818b",
+      "name": "Heurist",
+      "symbol": "HEU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51361/large/200X200.png?1733764636"
     },
     {
       "chainId": 8453,
@@ -900,6 +892,22 @@
     },
     {
       "chainId": 8453,
+      "address": "0x161e113b8e9bbaefb846f73f31624f6f9607bd44",
+      "name": "Simmi Token",
+      "symbol": "SIMMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52349/large/simmi.png?1733160996"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1035ae3f87a91084c6c5084d0615cc6121c5e228",
+      "name": "Based Fwog",
+      "symbol": "FWOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52691/large/IMG_8652.PNG?1734033750"
+    },
+    {
+      "chainId": 8453,
       "address": "0x18e692c03de43972fe81058f322fa542ae1a5e2c",
       "name": "imgnAI",
       "symbol": "IMGNAI",
@@ -908,11 +916,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xfbb75a59193a3525a8825bebe7d4b56899e2f7e1",
-      "name": "ResearchCoin",
-      "symbol": "RSC",
+      "address": "0xd3c68968137317a57a9babeacc7707ec433548b4",
+      "name": "Phavercoin",
+      "symbol": "SOCIAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28146/large/RH_BOTTLE_CLEAN_Aug_2024_1.png?1732742001"
+      "logoURI": "https://assets.coingecko.com/coins/images/50304/large/Phavercoin-_Social-MAIN-purple-logo-square.png?1727024458"
     },
     {
       "chainId": 8453,
@@ -932,22 +940,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0xd6aaf4d477999fa50c5a1aa35f708862113a73cc",
-      "name": "Propbase",
-      "symbol": "PROPS",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/32932/large/PROP_BASE_%286%29.png?1699870054"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xeec468333ccc16d4bf1cef497a56cf8c0aae4ca3",
-      "name": "Anzen Finance",
-      "symbol": "ANZ",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52456/large/ANZ_symbol200w.png?1733391218"
-    },
-    {
-      "chainId": 8453,
       "address": "0xeb6d78148f001f3aa2f588997c5e102e489ad341",
       "name": "Super Champs",
       "symbol": "CHAMP",
@@ -956,19 +948,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x23a96680ccde03bd4bdd9a3e9a0cb56a5d27f7c9",
-      "name": "Henlo",
-      "symbol": "HENLO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52083/large/henlo.webp?1732532244"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd3c68968137317a57a9babeacc7707ec433548b4",
-      "name": "Phavercoin",
-      "symbol": "SOCIAL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50304/large/Phavercoin-_Social-MAIN-purple-logo-square.png?1727024458"
+      "address": "0xd6aaf4d477999fa50c5a1aa35f708862113a73cc",
+      "name": "Propbase",
+      "symbol": "PROPS",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/32932/large/PROP_BASE_%286%29.png?1699870054"
     },
     {
       "chainId": 8453,
@@ -980,11 +964,43 @@
     },
     {
       "chainId": 8453,
-      "address": "0x0fd7a301b51d0a83fcaf6718628174d527b373b6",
-      "name": "Luminous",
-      "symbol": "LUM",
+      "address": "0xeec468333ccc16d4bf1cef497a56cf8c0aae4ca3",
+      "name": "Anzen Finance",
+      "symbol": "ANZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51439/large/LUM.jpg?1731232511"
+      "logoURI": "https://assets.coingecko.com/coins/images/52456/large/ANZ_symbol200w.png?1733391218"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x23a96680ccde03bd4bdd9a3e9a0cb56a5d27f7c9",
+      "name": "Henlo",
+      "symbol": "HENLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52083/large/henlo.webp?1732532244"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xafb89a09d82fbde58f18ac6437b3fc81724e4df6",
+      "name": "Own The Doge",
+      "symbol": "DOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18111/large/Doge.png?1696517615"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe2dca969624795985f2f083bcd0b674337ba130a",
+      "name": "Saakuru",
+      "symbol": "SKR",
+      "decimals": 17,
+      "logoURI": "https://assets.coingecko.com/coins/images/37058/large/saakuru.jpeg?1713172376"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdfbea88c4842d30c26669602888d746d30f9d60d",
+      "name": "crow with knife",
+      "symbol": "CAW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36067/large/200px.png?1710405601"
     },
     {
       "chainId": 8453,
@@ -996,11 +1012,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0x37e0b50ddbd719a46b9660396114c7f3fc9aa076",
-      "name": "Patriot on Base",
-      "symbol": "PATRIOT",
+      "address": "0x0fd7a301b51d0a83fcaf6718628174d527b373b6",
+      "name": "Luminous",
+      "symbol": "LUM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52764/large/200x200_%281%29.png?1734267707"
+      "logoURI": "https://assets.coingecko.com/coins/images/51439/large/LUM.jpg?1731232511"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x322eeb45f496fa11b0134d14bf5758d4d6f7ba3c",
+      "name": "Fwog Takes",
+      "symbol": "FWOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52796/large/logo200.png?1734330713"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0bbbead62f7647ae8323d2cb243a0db74b7c2b80",
+      "name": "Ambire Wallet",
+      "symbol": "WALLET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23154/large/wallet.PNG?1696522445"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x08d7ea3c148672c4b03999eb0d0467733da2db6a",
+      "name": "Nostra",
+      "symbol": "NSTR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28282/large/Nostra_200x200b.png?1719434526"
     },
     {
       "chainId": 8453,
@@ -1009,22 +1049,6 @@
       "symbol": "POKT",
       "decimals": 6,
       "logoURI": "https://assets.coingecko.com/coins/images/22506/large/POKT.jpg?1703257310"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4",
-      "name": "Electronic USD",
-      "symbol": "EUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28445/large/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1c4cca7c5db003824208adda61bd749e55f463a3",
-      "name": "GAME by Virtuals",
-      "symbol": "GAME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51063/large/Gaming_Agent_1fe70d54ba.jpg?1729925539"
     },
     {
       "chainId": 8453,
@@ -1044,11 +1068,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x625bb9bb04bdca51871ed6d07e2dd9034e914631",
-      "name": "H4CK Terminal by Virtuals",
-      "symbol": "H4CK",
+      "address": "0x04c0599ae5a44757c0af6f9ec3b93da8976c150a",
+      "name": "ether fi Bridged weETH  Base ",
+      "symbol": "WEETHBASE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52822/large/h4ck.jpg?1734409358"
+      "logoURI": "https://assets.coingecko.com/coins/images/39950/large/WETH.PNG?1724902237"
     },
     {
       "chainId": 8453,
@@ -1060,11 +1084,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
-      "name": "Gyroscope GYD",
-      "symbol": "GYD",
+      "address": "0x890a40bfae3bf25a5e7c50a31505774ee7a5d33b",
+      "name": "Worldwide USD",
+      "symbol": "WUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x38815a4455921667d673b4cb3d48f0383ee93400",
+      "name": "pSTAKE Finance",
+      "symbol": "PSTAKE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
+      "logoURI": "https://assets.coingecko.com/coins/images/23931/large/512_x_512_Dark.png?1721243699"
     },
     {
       "chainId": 8453,
@@ -1076,19 +1108,43 @@
     },
     {
       "chainId": 8453,
-      "address": "0x04c0599ae5a44757c0af6f9ec3b93da8976c150a",
-      "name": "ether fi Bridged weETH  Base ",
-      "symbol": "WEETHBASE",
+      "address": "0x01facc69ec7360640aa5898e852326752801674a",
+      "name": "Fuse",
+      "symbol": "FUSE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39950/large/WETH.PNG?1724902237"
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
     },
     {
       "chainId": 8453,
-      "address": "0x08d7ea3c148672c4b03999eb0d0467733da2db6a",
-      "name": "Nostra",
-      "symbol": "NSTR",
+      "address": "0x703d57164ca270b0b330a87fd159cfef1490c0a5",
+      "name": "RAI Finance",
+      "symbol": "SOFI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28282/large/Nostra_200x200b.png?1719434526"
+      "logoURI": "https://assets.coingecko.com/coins/images/14686/large/sofi.png?1696514359"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x32e0f9d26d1e33625742a52620cc76c1130efde6",
+      "name": "BASED",
+      "symbol": "BASED",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39669/large/BASED.jpg?1723603780"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x625bb9bb04bdca51871ed6d07e2dd9034e914631",
+      "name": "H4CK Terminal by Virtuals",
+      "symbol": "H4CK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52822/large/h4ck.jpg?1734409358"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xca5d8f8a8d49439357d3cf46ca2e720702f132b8",
+      "name": "Gyroscope GYD",
+      "symbol": "GYD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33428/large/GYD-gradient_resized_transparent.png?1702316822"
     },
     {
       "chainId": 8453,
@@ -1108,83 +1164,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x38815a4455921667d673b4cb3d48f0383ee93400",
-      "name": "pSTAKE Finance",
-      "symbol": "PSTAKE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23931/large/512_x_512_Dark.png?1721243699"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x703d57164ca270b0b330a87fd159cfef1490c0a5",
-      "name": "RAI Finance",
-      "symbol": "SOFI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14686/large/sofi.png?1696514359"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x890a40bfae3bf25a5e7c50a31505774ee7a5d33b",
-      "name": "Worldwide USD",
-      "symbol": "WUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/35358/large/WUSD%282%29.png?1715042139"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe2dca969624795985f2f083bcd0b674337ba130a",
-      "name": "Saakuru",
-      "symbol": "SKR",
-      "decimals": 17,
-      "logoURI": "https://assets.coingecko.com/coins/images/37058/large/saakuru.jpeg?1713172376"
-    },
-    {
-      "chainId": 8453,
       "address": "0x750cf88d9e0c2bcedeec31d5faad6ed6e3f1abc6",
       "name": "XCAD Network",
       "symbol": "XCAD",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/15857/large/xcad_logo.jpg?1707832192"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x32e0f9d26d1e33625742a52620cc76c1130efde6",
-      "name": "BASED",
-      "symbol": "BASED",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39669/large/BASED.jpg?1723603780"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x01facc69ec7360640aa5898e852326752801674a",
-      "name": "Fuse",
-      "symbol": "FUSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/10347/large/fuse.png?1696510348"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x858c50c3af1913b0e849afdb74617388a1a5340d",
-      "name": "SubQuery Network",
-      "symbol": "SQT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23359/large/LinkedIn_Avatar_Op1.png?1724379155"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfad8cb754230dbfd249db0e8eccb5142dd675a0d",
-      "name": "AEROBUD",
-      "symbol": "AEROBUD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38210/large/Logo_Coingecko.png?1716798924"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x64baa63f3eedf9661f736d8e4d42c6f8aa0cda71",
-      "name": "Geko Base",
-      "symbol": "GEKO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52703/large/1000018965.png?1734056168"
     },
     {
       "chainId": 8453,
@@ -1196,11 +1180,35 @@
     },
     {
       "chainId": 8453,
+      "address": "0x9a33406165f562e16c3abd82fd1185482e01b49a",
+      "name": "Talent Protocol",
+      "symbol": "TALENT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51120/large/Ticker-logo-200.png?1730128751"
+    },
+    {
+      "chainId": 8453,
       "address": "0x2d189eabb667aa1ecfc01963a6a3a5d83960f558",
       "name": "GALAXIS Token",
       "symbol": "GALAXIS",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/36221/large/500x500.png?1714755244"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfbb75a59193a3525a8825bebe7d4b56899e2f7e1",
+      "name": "ResearchCoin",
+      "symbol": "RSC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28146/large/RH_BOTTLE_CLEAN_Aug_2024_1.png?1732742001"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x50ce4129ca261ccde4eb100c170843c2936bc11b",
+      "name": "KOLZ",
+      "symbol": "KOLZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51235/large/KOLZ.png?1730447667"
     },
     {
       "chainId": 8453,
@@ -1212,11 +1220,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0x322eeb45f496fa11b0134d14bf5758d4d6f7ba3c",
-      "name": "Fwog Takes",
-      "symbol": "FWOG",
+      "address": "0x77184100237e46b06cd7649abf37435f5d5e678b",
+      "name": "SuperMeme",
+      "symbol": "SPR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52796/large/logo200.png?1734330713"
+      "logoURI": "https://assets.coingecko.com/coins/images/52813/large/SPRticker_200x200.png?1734370008"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x64baa63f3eedf9661f736d8e4d42c6f8aa0cda71",
+      "name": "Geko Base",
+      "symbol": "GEKO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52703/large/1000018965.png?1734056168"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x858c50c3af1913b0e849afdb74617388a1a5340d",
+      "name": "SubQuery Network",
+      "symbol": "SQT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23359/large/LinkedIn_Avatar_Op1.png?1724379155"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf2d3d488626a117984fda70f8106abc0049018d3",
+      "name": "Miracle Play",
+      "symbol": "MPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32653/large/MPT.png?1698895300"
     },
     {
       "chainId": 8453,
@@ -1236,19 +1268,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0xea651c035f52b644856cab1f59775369c36ecadd",
-      "name": "La ka",
-      "symbol": "LAIKA",
+      "address": "0xcde172dc5ffc46d228838446c57c1227e0b82049",
+      "name": "Boomer",
+      "symbol": "BOOMER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39364/large/logo_laika.jpg?1721895773"
+      "logoURI": "https://assets.coingecko.com/coins/images/36477/large/Token_Image_200x200.png?1714757172"
     },
     {
       "chainId": 8453,
-      "address": "0x50ce4129ca261ccde4eb100c170843c2936bc11b",
-      "name": "KOLZ",
-      "symbol": "KOLZ",
+      "address": "0x489fe42c267fe0366b16b0c39e7aeef977e841ef",
+      "name": "Wrapped Ampleforth",
+      "symbol": "WAMPL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51235/large/KOLZ.png?1730447667"
+      "logoURI": "https://assets.coingecko.com/coins/images/20825/large/photo_2021-11-25_02-05-11.jpg?1696520218"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd2012fc1b913ce50732ebcaa7e601fe37ac728c6",
+      "name": "StakeStone ETH",
+      "symbol": "STONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33103/large/200_200.png?1702602672"
     },
     {
       "chainId": 8453,
@@ -1260,43 +1300,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xf2d3d488626a117984fda70f8106abc0049018d3",
-      "name": "Miracle Play",
-      "symbol": "MPT",
+      "address": "0x731814e491571a2e9ee3c5b1f7f3b962ee8f4870",
+      "name": "VaderAI by Virtuals",
+      "symbol": "VADER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32653/large/MPT.png?1698895300"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdfbea88c4842d30c26669602888d746d30f9d60d",
-      "name": "crow with knife",
-      "symbol": "CAW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36067/large/200px.png?1710405601"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcde172dc5ffc46d228838446c57c1227e0b82049",
-      "name": "Boomer",
-      "symbol": "BOOMER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36477/large/Token_Image_200x200.png?1714757172"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6797b6244fa75f2e78cdffc3a4eb169332b730cc",
-      "name": "Eagle AI",
-      "symbol": "EAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38650/large/Eagle_AI.png?1718215736"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x27e3bc3a66e24cad043ac3d93a12a8070e3897ba",
-      "name": "Ovr",
-      "symbol": "OVR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13429/large/LOGO-OVER-ICON-200X200PX.png?1699396496"
+      "logoURI": "https://assets.coingecko.com/coins/images/51910/large/kare_pepe.png?1733345833"
     },
     {
       "chainId": 8453,
@@ -1316,6 +1324,14 @@
     },
     {
       "chainId": 8453,
+      "address": "0x27e3bc3a66e24cad043ac3d93a12a8070e3897ba",
+      "name": "Ovr",
+      "symbol": "OVR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13429/large/LOGO-OVER-ICON-200X200PX.png?1699396496"
+    },
+    {
+      "chainId": 8453,
       "address": "0x3792dbdd07e87413247df995e692806aa13d3299",
       "name": "ECOMI",
       "symbol": "OMI",
@@ -1324,19 +1340,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xd2012fc1b913ce50732ebcaa7e601fe37ac728c6",
-      "name": "StakeStone ETH",
-      "symbol": "STONE",
+      "address": "0x6797b6244fa75f2e78cdffc3a4eb169332b730cc",
+      "name": "Eagle AI",
+      "symbol": "EAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33103/large/200_200.png?1702602672"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x731814e491571a2e9ee3c5b1f7f3b962ee8f4870",
-      "name": "VaderAI by Virtuals",
-      "symbol": "VADER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51910/large/kare_pepe.png?1733345833"
+      "logoURI": "https://assets.coingecko.com/coins/images/38650/large/Eagle_AI.png?1718215736"
     },
     {
       "chainId": 8453,
@@ -1348,43 +1356,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x0578d8a44db98b23bf096a382e016e29a5ce0ffe",
-      "name": "higher",
-      "symbol": "HIGHER",
+      "address": "0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4",
+      "name": "Electronic USD",
+      "symbol": "EUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36084/large/200x200logo.png?1710427814"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0bbbead62f7647ae8323d2cb243a0db74b7c2b80",
-      "name": "Ambire Wallet",
-      "symbol": "WALLET",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23154/large/wallet.PNG?1696522445"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9a33406165f562e16c3abd82fd1185482e01b49a",
-      "name": "Talent Protocol",
-      "symbol": "TALENT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51120/large/Ticker-logo-200.png?1730128751"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3d2eba645c44bbd32a34b7c017667711eb5b173c",
-      "name": "Wrapped MistCoin",
-      "symbol": "WMC",
-      "decimals": 2,
-      "logoURI": "https://assets.coingecko.com/coins/images/32490/large/355966EE-F4AD-4023-A38E-59B9DEF1C6C3.jpeg?1732678326"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6d3b8c76c5396642960243febf736c6be8b60562",
-      "name": "Skull of Pepe Token",
-      "symbol": "SKOP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38342/large/skop.jpeg?1717141011"
+      "logoURI": "https://assets.coingecko.com/coins/images/28445/large/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f.png?1696527441"
     },
     {
       "chainId": 8453,
@@ -1396,11 +1372,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0xd27c288fd69f228e0c02f79e5ecadff962e05a2b",
-      "name": "Fire",
-      "symbol": "FIRE",
+      "address": "0x25e0a7767d03461eaf88b47cd9853722fe05dfd3",
+      "name": "PoSciDonDAO Token",
+      "symbol": "SCI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50835/large/fire-coin-200.png?1729242121"
+      "logoURI": "https://assets.coingecko.com/coins/images/52651/large/LogoMark200x200.png?1733953414"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6d3b8c76c5396642960243febf736c6be8b60562",
+      "name": "Skull of Pepe Token",
+      "symbol": "SKOP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38342/large/skop.jpeg?1717141011"
     },
     {
       "chainId": 8453,
@@ -1412,11 +1396,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x9beec80e62aa257ced8b0edd8692f79ee8783777",
-      "name": "This Is My Iguana",
-      "symbol": "TIMI",
+      "address": "0xed2d13a70acbd61074fc56bd0d0845e35f793e5e",
+      "name": "Planet Mojo",
+      "symbol": "MOJO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39361/large/200x200.png?1722464115"
+      "logoURI": "https://assets.coingecko.com/coins/images/36670/large/MOJOIcon.jpg?1712061269"
     },
     {
       "chainId": 8453,
@@ -1428,43 +1412,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0x2974dc646e375e83bd1c0342625b49f288987fa4",
-      "name": "Swarm Markets",
-      "symbol": "SMT",
+      "address": "0xcf67815cce72e682eb4429eca46843bed81ca739",
+      "name": "GAM3S GG",
+      "symbol": "G3",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/17488/large/swarm-SMT-token-symbol_200x200.png?1696517029"
+      "logoURI": "https://assets.coingecko.com/coins/images/35662/large/G3_logo.jpg?1709454143"
     },
     {
       "chainId": 8453,
-      "address": "0xc438b0c0e80a8fa1b36898d1b36a3fc2ec371c54",
-      "name": "Blep Super Meme",
-      "symbol": "BLEP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52788/large/ezgif.com-jpg-to-png-converter.png?1734291658"
+      "address": "0x3d2eba645c44bbd32a34b7c017667711eb5b173c",
+      "name": "Wrapped MistCoin",
+      "symbol": "WMC",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/32490/large/355966EE-F4AD-4023-A38E-59B9DEF1C6C3.jpeg?1732678326"
     },
     {
       "chainId": 8453,
-      "address": "0xed2d13a70acbd61074fc56bd0d0845e35f793e5e",
-      "name": "Planet Mojo",
-      "symbol": "MOJO",
+      "address": "0x800822d361335b4d5f352dac293ca4128b5b605f",
+      "name": "SYMMIO",
+      "symbol": "SYMM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36670/large/MOJOIcon.jpg?1712061269"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0d97f261b1e88845184f678e2d1e7a98d9fd38de",
-      "name": "Base God",
-      "symbol": "TYBG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34563/large/tybg.png?1705400778"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x60d01ec2d5e98ac51c8b4cf84dfcce98d527c747",
-      "name": "iZUMi Finance",
-      "symbol": "IZI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21791/large/izumi-logo-symbol.png?1696521144"
+      "logoURI": "https://assets.coingecko.com/coins/images/52828/large/256.jpg?1734435636"
     },
     {
       "chainId": 8453,
@@ -1476,19 +1444,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0x20d704099b62ada091028bcfc44445041ed16f09",
-      "name": "Chaos",
-      "symbol": "CHAOS",
+      "address": "0xc438b0c0e80a8fa1b36898d1b36a3fc2ec371c54",
+      "name": "Blep Super Meme",
+      "symbol": "BLEP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52444/large/chaos-2.jpg?1733365634"
+      "logoURI": "https://assets.coingecko.com/coins/images/52788/large/ezgif.com-jpg-to-png-converter.png?1734291658"
     },
     {
       "chainId": 8453,
-      "address": "0x9c0e042d65a2e1ff31ac83f404e5cb79f452c337",
-      "name": "Wrapped Aptos  Universal ",
-      "symbol": "UAPT",
+      "address": "0x0d97f261b1e88845184f678e2d1e7a98d9fd38de",
+      "name": "Base God",
+      "symbol": "TYBG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50646/large/UA-APTOS-PAD_1.png?1728579627"
+      "logoURI": "https://assets.coingecko.com/coins/images/34563/large/tybg.png?1705400778"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9beec80e62aa257ced8b0edd8692f79ee8783777",
+      "name": "This Is My Iguana",
+      "symbol": "TIMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39361/large/200x200.png?1722464115"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0578d8a44db98b23bf096a382e016e29a5ce0ffe",
+      "name": "higher",
+      "symbol": "HIGHER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36084/large/200x200logo.png?1710427814"
     },
     {
       "chainId": 8453,
@@ -1500,11 +1484,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0x5875eee11cf8398102fdad704c9e96607675467a",
-      "name": "sUSDS",
-      "symbol": "SUSDS",
+      "address": "0x5ed25e305e08f58afd7995eac72563e6be65a617",
+      "name": "Wrapped NEAR  Universal ",
+      "symbol": "UNEAR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52721/large/sUSDS_Coin.png?1734086971"
+      "logoURI": "https://assets.coingecko.com/coins/images/50645/large/UA-NEAR_1.png?1728579564"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x20d704099b62ada091028bcfc44445041ed16f09",
+      "name": "Chaos",
+      "symbol": "CHAOS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52444/large/chaos-2.jpg?1733365634"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0808bf94d57c905f1236212654268ef82e1e594e",
+      "name": "ritestream",
+      "symbol": "RITE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24130/large/rite.png?1696523321"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2974dc646e375e83bd1c0342625b49f288987fa4",
+      "name": "Swarm Markets",
+      "symbol": "SMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17488/large/swarm-SMT-token-symbol_200x200.png?1696517029"
     },
     {
       "chainId": 8453,
@@ -1516,11 +1524,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xc0fbc4967259786c743361a5885ef49380473dcf",
-      "name": "Aleph im",
-      "symbol": "ALEPH",
+      "address": "0x0c03ce270b4826ec62e7dd007f0b716068639f7b",
+      "name": "The Innovation Game",
+      "symbol": "TIG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/11676/large/Aleph-Logo-BW.png?1696511566"
+      "logoURI": "https://assets.coingecko.com/coins/images/50669/large/TIG_Logo_200x200.png?1729604604"
     },
     {
       "chainId": 8453,
@@ -1532,11 +1540,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x489fe42c267fe0366b16b0c39e7aeef977e841ef",
-      "name": "Wrapped Ampleforth",
-      "symbol": "WAMPL",
+      "address": "0x9c0e042d65a2e1ff31ac83f404e5cb79f452c337",
+      "name": "Wrapped Aptos  Universal ",
+      "symbol": "UAPT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20825/large/photo_2021-11-25_02-05-11.jpg?1696520218"
+      "logoURI": "https://assets.coingecko.com/coins/images/50646/large/UA-APTOS-PAD_1.png?1728579627"
     },
     {
       "chainId": 8453,
@@ -1548,19 +1556,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x25e0a7767d03461eaf88b47cd9853722fe05dfd3",
-      "name": "PoSciDonDAO Token",
-      "symbol": "SCI",
+      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
+      "name": "PAW",
+      "symbol": "PAW",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52651/large/LogoMark200x200.png?1733953414"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcf67815cce72e682eb4429eca46843bed81ca739",
-      "name": "GAM3S GG",
-      "symbol": "G3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35662/large/G3_logo.jpg?1709454143"
+      "logoURI": "https://assets.coingecko.com/coins/images/28946/large/PawLogo.png?1699394612"
     },
     {
       "chainId": 8453,
@@ -1572,131 +1572,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0x5ed25e305e08f58afd7995eac72563e6be65a617",
-      "name": "Wrapped NEAR  Universal ",
-      "symbol": "UNEAR",
+      "address": "0x74aa9bb52b36a378a6e641b86d7acb76dc9b3940",
+      "name": "Dtravel",
+      "symbol": "TRVL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50645/large/UA-NEAR_1.png?1728579564"
+      "logoURI": "https://assets.coingecko.com/coins/images/20911/large/trvl.jpeg?1696520301"
     },
     {
       "chainId": 8453,
-      "address": "0x1d008f50fb828ef9debbbeae1b71fffe929bf317",
-      "name": "clank fun",
-      "symbol": "CLANKFUN",
+      "address": "0xc0fbc4967259786c743361a5885ef49380473dcf",
+      "name": "Aleph im",
+      "symbol": "ALEPH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52595/large/photo_2024-12-13_00-23-11.jpg?1734095623"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c03ce270b4826ec62e7dd007f0b716068639f7b",
-      "name": "The Innovation Game",
-      "symbol": "TIG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50669/large/TIG_Logo_200x200.png?1729604604"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0a953dd9fc813fefaf6015b804c9dfa0624690c0",
-      "name": "Cornucopias",
-      "symbol": "COPI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21452/large/g56WwJDA_400x400.jpg?1696520814"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2c002ffec41568d138acc36f5894d6156398d539",
-      "name": "Lucky Dog",
-      "symbol": "LUCKY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51334/large/LUCKYTokenSymbol.png?1730797716"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc11158c5da9db1d553ed28f0c2ba1cbedd42cfcb",
-      "name": "PAW",
-      "symbol": "PAW",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28946/large/PawLogo.png?1699394612"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf9569cfb8fd265e91aa478d86ae8c78b8af55df4",
-      "name": "AUKI",
-      "symbol": "AUKI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39811/large/COINGECKO-200-x-200_%281%29.png?1724166209"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3ecced5b416e58664f04a39dd18935eb71d33b15",
-      "name": "Brian",
-      "symbol": "BRIAN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51099/large/Brian_Arm_Strong.png?1730083824"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3639e6f4c224ebd1bf6373c3d97917d33e0492bb",
-      "name": "Paca AI",
-      "symbol": "PACA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52625/large/PACA_LOGO_WEBSITE.jpg?1733986871"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x20dd04c17afd5c9a8b3f2cdacaa8ee7907385bef",
-      "name": "Native",
-      "symbol": "NATIVE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52565/large/native_logo_fill.png?1733672418"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
-      "name": "Seedworld",
-      "symbol": "SWORLD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51000/large/IMG_2798.PNG?1729685531"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf0268c5f9aa95baf5c25d646aabb900ac12f0800",
-      "name": "RealGoat",
-      "symbol": "RGOAT",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/38923/large/IMG_20240625_033037_003.jpg?1719521003"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8fe815417913a93ea99049fc0718ee1647a2a07c",
-      "name": "XSwap",
-      "symbol": "XSWAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36000/large/XSwap_Icon_%282%29.png?1710320467"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x62ff28a01abd2484adb18c61f78f30fb2e4a6fdb",
-      "name": "Otto",
-      "symbol": "OTTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52644/large/Otto_logo_200x200.png?1733873416"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x02454a97a8372f3a760a033dbb39e67d73bd6d87",
-      "name": "Katana Inu",
-      "symbol": "KATA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21872/large/Katana_Inu512.png?1696521226"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x74ccbe53f77b08632ce0cb91d3a545bf6b8e0979",
-      "name": "Fantom Bomb",
-      "symbol": "BOMB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24109/large/logo-blue.png?1696523301"
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/large/Aleph-Logo-BW.png?1696511566"
     },
     {
       "chainId": 8453,
@@ -1708,67 +1596,99 @@
     },
     {
       "chainId": 8453,
-      "address": "0x12e96c2bfea6e835cf8dd38a5834fa61cf723736",
-      "name": "Wrapped DOGE  Universal ",
-      "symbol": "UDOGE",
+      "address": "0xd27c288fd69f228e0c02f79e5ecadff962e05a2b",
+      "name": "Fire",
+      "symbol": "FIRE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40099/large/UA-DOGE_1.png?1725632510"
+      "logoURI": "https://assets.coingecko.com/coins/images/50835/large/fire-coin-200.png?1729242121"
     },
     {
       "chainId": 8453,
-      "address": "0xac12f930318be4f9d37f602cbf89cd33e99aa9d4",
-      "name": "Wexo",
-      "symbol": "WEXO",
+      "address": "0x3ecced5b416e58664f04a39dd18935eb71d33b15",
+      "name": "Brian",
+      "symbol": "BRIAN",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33801/large/wexo_token_200x200.png?1702991908"
+      "logoURI": "https://assets.coingecko.com/coins/images/51099/large/Brian_Arm_Strong.png?1730083824"
     },
     {
       "chainId": 8453,
-      "address": "0x74aa9bb52b36a378a6e641b86d7acb76dc9b3940",
-      "name": "Dtravel",
-      "symbol": "TRVL",
+      "address": "0x74ccbe53f77b08632ce0cb91d3a545bf6b8e0979",
+      "name": "Fantom Bomb",
+      "symbol": "BOMB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20911/large/trvl.jpeg?1696520301"
+      "logoURI": "https://assets.coingecko.com/coins/images/24109/large/logo-blue.png?1696523301"
     },
     {
       "chainId": 8453,
-      "address": "0x919e43a2cce006710090e64bde9e01b38fd7f32f",
-      "name": "Agent YP by Virtuals",
-      "symbol": "AIYP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52716/large/PFP.png?1734060541"
+      "address": "0xf0268c5f9aa95baf5c25d646aabb900ac12f0800",
+      "name": "RealGoat",
+      "symbol": "RGOAT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/38923/large/IMG_20240625_033037_003.jpg?1719521003"
     },
     {
       "chainId": 8453,
-      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
-      "name": "Wagmi",
-      "symbol": "WAGMI",
+      "address": "0x60d01ec2d5e98ac51c8b4cf84dfcce98d527c747",
+      "name": "iZUMi Finance",
+      "symbol": "IZI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31887/large/wagmi_token_logo.png?1696530698"
+      "logoURI": "https://assets.coingecko.com/coins/images/21791/large/izumi-logo-symbol.png?1696521144"
     },
     {
       "chainId": 8453,
-      "address": "0x20fd4c5396f7d9686f9997e0f10991957f7112fc",
-      "name": "redacted gdupi",
-      "symbol": "GDUPI",
+      "address": "0x2c002ffec41568d138acc36f5894d6156398d539",
+      "name": "Lucky Dog",
+      "symbol": "LUCKY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52704/large/200x200.png?1734056667"
+      "logoURI": "https://assets.coingecko.com/coins/images/51334/large/LUCKYTokenSymbol.png?1730797716"
     },
     {
       "chainId": 8453,
-      "address": "0xf83759099dc88f75fc83de854c41e0d9e83ada9b",
-      "name": "Obortech",
-      "symbol": "OBOT",
+      "address": "0x02454a97a8372f3a760a033dbb39e67d73bd6d87",
+      "name": "Katana Inu",
+      "symbol": "KATA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14929/large/OBORTECH_200.png?1696514590"
+      "logoURI": "https://assets.coingecko.com/coins/images/21872/large/Katana_Inu512.png?1696521226"
     },
     {
       "chainId": 8453,
-      "address": "0xf6e932ca12afa26665dc4dde7e27be02a7c02e50",
-      "name": "Mochi",
-      "symbol": "MOCHI",
+      "address": "0x20dd04c17afd5c9a8b3f2cdacaa8ee7907385bef",
+      "name": "Native",
+      "symbol": "NATIVE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33083/large/CIRCLE-200x200.png?1713297273"
+      "logoURI": "https://assets.coingecko.com/coins/images/52565/large/native_logo_fill.png?1733672418"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1d008f50fb828ef9debbbeae1b71fffe929bf317",
+      "name": "clank fun",
+      "symbol": "CLANKFUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52595/large/photo_2024-12-13_00-23-11.jpg?1734095623"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3639e6f4c224ebd1bf6373c3d97917d33e0492bb",
+      "name": "Paca AI",
+      "symbol": "PACA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52625/large/PACA_LOGO_WEBSITE.jpg?1733986871"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x62ff28a01abd2484adb18c61f78f30fb2e4a6fdb",
+      "name": "Otto",
+      "symbol": "OTTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52644/large/Otto_logo_200x200.png?1733873416"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8fe815417913a93ea99049fc0718ee1647a2a07c",
+      "name": "XSwap",
+      "symbol": "XSWAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36000/large/XSwap_Icon_%282%29.png?1710320467"
     },
     {
       "chainId": 8453,
@@ -1780,11 +1700,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0xcc0adb6c436eb1f65b2f27733bf926691b94c5f1",
-      "name": "Guanciale by Virtuals",
-      "symbol": "GUAN",
+      "address": "0xac12f930318be4f9d37f602cbf89cd33e99aa9d4",
+      "name": "Wexo",
+      "symbol": "WEXO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51865/large/guanciale.jpeg?1732173396"
+      "logoURI": "https://assets.coingecko.com/coins/images/33801/large/wexo_token_200x200.png?1702991908"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x12e96c2bfea6e835cf8dd38a5834fa61cf723736",
+      "name": "Wrapped DOGE  Universal ",
+      "symbol": "UDOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40099/large/UA-DOGE_1.png?1725632510"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf9569cfb8fd265e91aa478d86ae8c78b8af55df4",
+      "name": "AUKI",
+      "symbol": "AUKI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39811/large/COINGECKO-200-x-200_%281%29.png?1724166209"
     },
     {
       "chainId": 8453,
@@ -1793,6 +1729,30 @@
       "symbol": "GM",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/52139/large/sRavZnte_.png?1732642259"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf3c7cecf8cbc3066f9a87b310cebe198d00479ac",
+      "name": "FEED EVERY GORILLA",
+      "symbol": "FEG",
+      "decimals": 11,
+      "logoURI": "https://assets.coingecko.com/coins/images/29643/large/IMG_3919.jpeg?1721352213"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xaf20f5f19698f1d19351028cd7103b63d30de7d7",
+      "name": "Wagmi",
+      "symbol": "WAGMI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31887/large/wagmi_token_logo.png?1696530698"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x968be3f7bfef0f8edc3c1ad90232ebb0da0867aa",
+      "name": "Seedworld",
+      "symbol": "SWORLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51000/large/IMG_2798.PNG?1729685531"
     },
     {
       "chainId": 8453,
@@ -1812,59 +1772,51 @@
     },
     {
       "chainId": 8453,
+      "address": "0xf83759099dc88f75fc83de854c41e0d9e83ada9b",
+      "name": "Obortech",
+      "symbol": "OBOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14929/large/OBORTECH_200.png?1696514590"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf6e932ca12afa26665dc4dde7e27be02a7c02e50",
+      "name": "Mochi",
+      "symbol": "MOCHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33083/large/CIRCLE-200x200.png?1713297273"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcc0adb6c436eb1f65b2f27733bf926691b94c5f1",
+      "name": "Guanciale by Virtuals",
+      "symbol": "GUAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51865/large/guanciale.jpeg?1732173396"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0a953dd9fc813fefaf6015b804c9dfa0624690c0",
+      "name": "Cornucopias",
+      "symbol": "COPI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21452/large/g56WwJDA_400x400.jpg?1696520814"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcb327b99ff831bf8223cced12b1338ff3aa322ff",
+      "name": "Based ETH",
+      "symbol": "BSDETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35774/large/Icon_White_on_Blue.png?1709793654"
+    },
+    {
+      "chainId": 8453,
       "address": "0xa7d68d155d17cb30e311367c2ef1e82ab6022b67",
       "name": "Braintrust",
       "symbol": "BTRST",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/18100/large/braintrust.PNG?1696517605"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2dad3a13ef0c6366220f989157009e501e7938f8",
-      "name": "Extra Finance",
-      "symbol": "EXTRA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30973/large/Ex_logo-white-blue_ring_288x.png?1696529812"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf3c7cecf8cbc3066f9a87b310cebe198d00479ac",
-      "name": "FEED EVERY GORILLA",
-      "symbol": "FEG",
-      "decimals": 11,
-      "logoURI": "https://assets.coingecko.com/coins/images/29643/large/IMG_3919.jpeg?1721352213"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa3a34a0d9a08ccddb6ed422ac0a28a06731335aa",
-      "name": "Wrapped ADA  Universal ",
-      "symbol": "UADA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51868/large/UA-ADA.png?1732095196"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfd1013c72cbb0ffb920d347c5836bf88965d0d5e",
-      "name": "STIX",
-      "symbol": "STIX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52015/large/STIX_Logo_Transparent_200x200.png?1732346967"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x749e5334752466cda899b302ed4176b8573dc877",
-      "name": "Assimilate",
-      "symbol": "SIM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52377/large/SIM_LOGO.jpeg?1733253732"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdcefd8c8fcc492630b943abcab3429f12ea9fea2",
-      "name": "KlimaDAO",
-      "symbol": "KLIMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/19169/large/Klima-Token.png?1696518618"
     },
     {
       "chainId": 8453,
@@ -1876,6 +1828,30 @@
     },
     {
       "chainId": 8453,
+      "address": "0xa3a34a0d9a08ccddb6ed422ac0a28a06731335aa",
+      "name": "Wrapped ADA  Universal ",
+      "symbol": "UADA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51868/large/UA-ADA.png?1732095196"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x20fd4c5396f7d9686f9997e0f10991957f7112fc",
+      "name": "redacted gdupi",
+      "symbol": "GDUPI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52704/large/200x200.png?1734056667"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2dad3a13ef0c6366220f989157009e501e7938f8",
+      "name": "Extra Finance",
+      "symbol": "EXTRA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30973/large/Ex_logo-white-blue_ring_288x.png?1696529812"
+    },
+    {
+      "chainId": 8453,
       "address": "0x5babfc2f240bc5de90eb7e19d789412db1dec402",
       "name": "Burning Circle",
       "symbol": "CIRCLE",
@@ -1884,131 +1860,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x315b8c9a1123c10228d469551033440441b41f0b",
-      "name": "BEATS on BASE",
-      "symbol": "BEATS",
+      "address": "0x919e43a2cce006710090e64bde9e01b38fd7f32f",
+      "name": "Agent YP by Virtuals",
+      "symbol": "AIYP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52396/large/200x200_transparent.png?1733293803"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0f1cfd0bb452db90a3bfc0848349463010419ab2",
-      "name": "Guru Network",
-      "symbol": "GURU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38583/large/tGURU_token_circle.png?1718087986"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5a76a56ad937335168b30df3aa1327277421c6ae",
-      "name": "Vela Token",
-      "symbol": "VELA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28739/large/VELA_logo_-_no_background.png?1696527719"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
-      "name": "Any Inu",
-      "symbol": "AI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34126/large/anyinulogo200.png?1704174269"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
-      "name": "Truflation",
-      "symbol": "TRUF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36642/large/truflation.jpg?1733315818"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1c7a460413dd4e964f96d8dfc56e7223ce88cd85",
-      "name": "Seamless Protocol",
-      "symbol": "SEAM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33480/large/Seamless_Logo_Black_Transparent.png?1702019657"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0808bf94d57c905f1236212654268ef82e1e594e",
-      "name": "ritestream",
-      "symbol": "RITE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24130/large/rite.png?1696523321"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xebff2db643cf955247339c8c6bcd8406308ca437",
-      "name": "ChompCoin",
-      "symbol": "CHOMP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36942/large/chomplogo200.png?1712864472"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c5142bc58f9a61ab8c3d2085dd2f4e550c5ce0b",
-      "name": "RUSSELL",
-      "symbol": "RUSSELL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50690/large/russelllogo.png?1730010143"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb34457736aa191ff423f84f5d669f68b231e6c4e",
-      "name": "AGENT DOGE by Virtuals",
-      "symbol": "AIDOGE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52187/large/Screenshot_2024-11-23_at_4.09.40%E2%80%AFPM.png?1732723139"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4e74d4db6c0726ccded4656d0bce448876bb4c7a",
-      "name": "Wrapped BMX Liquidity Token",
-      "symbol": "WBLT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31532/large/wBLT_200x200.png?1696530341"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5b2124d427fac9c80c902cbdd74b03dd85d7d3fe",
-      "name": "Dypius",
-      "symbol": "DYP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33016/large/RS-zDhFE_400x400.jpg?1700157370"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf31e6d62bfc485857af2186eb3d8ee94b4379fed",
-      "name": "Chinese Doge Wow",
-      "symbol": "CHIDO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52054/large/1.png?1732449299"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
-      "name": "Dexalot",
-      "symbol": "ALOT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24188/large/logo_200x200.png?1696523376"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1196c6704789620514fd25632abe15f69a50bc4f",
-      "name": "Pepe Clanker",
-      "symbol": "PEPEC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52568/large/pepepepepe.jpeg?1733674517"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x71a67215a2025f501f386a49858a9ced2fc0249d",
-      "name": "Wrapped SEI  Universal ",
-      "symbol": "USEI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51023/large/UA-SEI_1.png?1729770680"
+      "logoURI": "https://assets.coingecko.com/coins/images/52716/large/PFP.png?1734060541"
     },
     {
       "chainId": 8453,
@@ -2020,67 +1876,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0x2676e4e0e2eb58d9bdb5078358ff8a3a964cedf5",
-      "name": "Polytrader by Virtuals",
-      "symbol": "POLY",
+      "address": "0x749e5334752466cda899b302ed4176b8573dc877",
+      "name": "Assimilate",
+      "symbol": "SIM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52168/large/poly.jpg?1732682921"
+      "logoURI": "https://assets.coingecko.com/coins/images/52377/large/SIM_LOGO.jpeg?1733253732"
     },
     {
       "chainId": 8453,
-      "address": "0xa9f5031b54c44c3603b4300fde9b8f5cd18ad06f",
-      "name": "Mars Battle",
-      "symbol": "SHOOT",
+      "address": "0x5a76a56ad937335168b30df3aa1327277421c6ae",
+      "name": "Vela Token",
+      "symbol": "VELA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36553/large/icon.png?1711896644"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x051fb509e4a775fabd257611eea1efaed8f91359",
-      "name": "CateCoin",
-      "symbol": "CATE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/15364/large/logo.png?1696515013"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x47b464edb8dc9bc67b5cd4c9310bb87b773845bd",
-      "name": "NORMIE",
-      "symbol": "NORMIE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/35880/large/NORMIEsite.png?1709983341"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe2c86869216ac578bd62a4b8313770d9ee359a05",
-      "name": "EMAIL Token",
-      "symbol": "EMT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38631/large/EMT_square_LG%282%29.png?1718171885"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc7edf7b7b3667a06992508e7b156eff794a9e1c8",
-      "name": "Persistence One",
-      "symbol": "XPRT",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/14582/large/Download%28black_Dark%29.png?1723470571"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf544251d25f3d243a36b07e7e7962a678f952691",
-      "name": "Tarot",
-      "symbol": "TAROT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31800/large/TAROT.jpg?1696530615"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x54b659832f59c24cec0e4a2cd193377f1bcefc3c",
-      "name": "Akashalife",
-      "symbol": "AK1111",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50533/large/Akasha-CoinIcon_%283%29.png?1728206155"
+      "logoURI": "https://assets.coingecko.com/coins/images/28739/large/VELA_logo_-_no_background.png?1696527719"
     },
     {
       "chainId": 8453,
@@ -2092,51 +1900,155 @@
     },
     {
       "chainId": 8453,
-      "address": "0xbc1852f8940991d91bd2b09a5abb5e7b8092a16c",
-      "name": "BasePrinter",
-      "symbol": "BASEPRINTER",
+      "address": "0x1c7a460413dd4e964f96d8dfc56e7223ce88cd85",
+      "name": "Seamless Protocol",
+      "symbol": "SEAM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52667/large/BasePrinter.png?1734013829"
+      "logoURI": "https://assets.coingecko.com/coins/images/33480/large/Seamless_Logo_Black_Transparent.png?1702019657"
     },
     {
       "chainId": 8453,
-      "address": "0x4498cd8ba045e00673402353f5a4347562707e7d",
-      "name": "r DataDAO",
-      "symbol": "RDAT",
+      "address": "0x2598c30330d5771ae9f983979209486ae26de875",
+      "name": "Any Inu",
+      "symbol": "AI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39174/large/Q7oVa2cC_400x400.png?1720799391"
+      "logoURI": "https://assets.coingecko.com/coins/images/34126/large/anyinulogo200.png?1704174269"
     },
     {
       "chainId": 8453,
-      "address": "0x554bba833518793056cf105e66abea330672c0de",
-      "name": "Maha",
-      "symbol": "MAHA",
+      "address": "0xb34457736aa191ff423f84f5d669f68b231e6c4e",
+      "name": "AGENT DOGE by Virtuals",
+      "symbol": "AIDOGE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13404/large/black.png?1724679606"
+      "logoURI": "https://assets.coingecko.com/coins/images/52187/large/Screenshot_2024-11-23_at_4.09.40%E2%80%AFPM.png?1732723139"
     },
     {
       "chainId": 8453,
-      "address": "0xda761a290e01c69325d12d82ac402e5a73d62e81",
-      "name": "Base Pro Shops",
-      "symbol": "BPS",
+      "address": "0xfad8cb754230dbfd249db0e8eccb5142dd675a0d",
+      "name": "AEROBUD",
+      "symbol": "AEROBUD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36855/large/BPS_2.png?1712634757"
+      "logoURI": "https://assets.coingecko.com/coins/images/38210/large/Logo_Coingecko.png?1716798924"
     },
     {
       "chainId": 8453,
-      "address": "0x8f2e6758c4d6570344bd5007dec6301cd57590a0",
-      "name": "Spot",
-      "symbol": "SPOT",
+      "address": "0x5b2124d427fac9c80c902cbdd74b03dd85d7d3fe",
+      "name": "Dypius",
+      "symbol": "DYP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33016/large/RS-zDhFE_400x400.jpg?1700157370"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xebff2db643cf955247339c8c6bcd8406308ca437",
+      "name": "ChompCoin",
+      "symbol": "CHOMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36942/large/chomplogo200.png?1712864472"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfd1013c72cbb0ffb920d347c5836bf88965d0d5e",
+      "name": "STIX",
+      "symbol": "STIX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52015/large/STIX_Logo_Transparent_200x200.png?1732346967"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x315b8c9a1123c10228d469551033440441b41f0b",
+      "name": "BEATS on BASE",
+      "symbol": "BEATS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52396/large/200x200_transparent.png?1733293803"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x051fb509e4a775fabd257611eea1efaed8f91359",
+      "name": "CateCoin",
+      "symbol": "CATE",
       "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/28426/large/SPOT_Logo_200x200_sq_small_centered.png?1696527423"
+      "logoURI": "https://assets.coingecko.com/coins/images/15364/large/logo.png?1696515013"
     },
     {
       "chainId": 8453,
-      "address": "0x36912b5cf63e509f18e53ac98b3012fa79e77bf5",
-      "name": "FUEGO",
-      "symbol": "FUEGO",
+      "address": "0x0f1cfd0bb452db90a3bfc0848349463010419ab2",
+      "name": "Guru Network",
+      "symbol": "GURU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51345/large/FUEGO_200x200.jpg?1730825086"
+      "logoURI": "https://assets.coingecko.com/coins/images/38583/large/tGURU_token_circle.png?1718087986"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0c5142bc58f9a61ab8c3d2085dd2f4e550c5ce0b",
+      "name": "RUSSELL",
+      "symbol": "RUSSELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50690/large/russelllogo.png?1730010143"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2676e4e0e2eb58d9bdb5078358ff8a3a964cedf5",
+      "name": "Polytrader by Virtuals",
+      "symbol": "POLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52168/large/poly.jpg?1732682921"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb59c8912c83157a955f9d715e556257f432c35d7",
+      "name": "Truflation",
+      "symbol": "TRUF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36642/large/truflation.jpg?1733315818"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa9f5031b54c44c3603b4300fde9b8f5cd18ad06f",
+      "name": "Mars Battle",
+      "symbol": "SHOOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36553/large/icon.png?1711896644"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdcefd8c8fcc492630b943abcab3429f12ea9fea2",
+      "name": "KlimaDAO",
+      "symbol": "KLIMA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19169/large/Klima-Token.png?1696518618"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc7edf7b7b3667a06992508e7b156eff794a9e1c8",
+      "name": "Persistence One",
+      "symbol": "XPRT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14582/large/Download%28black_Dark%29.png?1723470571"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x54b659832f59c24cec0e4a2cd193377f1bcefc3c",
+      "name": "Akashalife",
+      "symbol": "AK1111",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50533/large/Akasha-CoinIcon_%283%29.png?1728206155"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf31e6d62bfc485857af2186eb3d8ee94b4379fed",
+      "name": "Chinese Doge Wow",
+      "symbol": "CHIDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52054/large/1.png?1732449299"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x47b464edb8dc9bc67b5cd4c9310bb87b773845bd",
+      "name": "NORMIE",
+      "symbol": "NORMIE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/35880/large/NORMIEsite.png?1709983341"
     },
     {
       "chainId": 8453,
@@ -2148,11 +2060,75 @@
     },
     {
       "chainId": 8453,
-      "address": "0x4366c1568fd6167eee67d25ef6980da38e3421bc",
-      "name": "Based Hoppy",
-      "symbol": "HOPPY",
+      "address": "0xbb22ff867f8ca3d5f2251b4084f6ec86d4666e14",
+      "name": "Cryptex Finance",
+      "symbol": "CTX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52765/large/New_Project_-_2024-12-13T125213.686.png?1734268017"
+      "logoURI": "https://assets.coingecko.com/coins/images/14932/large/CTX_Logo_200px.png?1723514786"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3ee5e23eee121094f1cfc0ccc79d6c809ebd22e5",
+      "name": "Ionic Protocol",
+      "symbol": "ION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36713/large/Ionic-icon-green.png?1712127547"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9d5a383581882750ce27f84c72f017b378edb736",
+      "name": "Dexalot",
+      "symbol": "ALOT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24188/large/logo_200x200.png?1696523376"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe2c86869216ac578bd62a4b8313770d9ee359a05",
+      "name": "EMAIL Token",
+      "symbol": "EMT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38631/large/EMT_square_LG%282%29.png?1718171885"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4498cd8ba045e00673402353f5a4347562707e7d",
+      "name": "r DataDAO",
+      "symbol": "RDAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39174/large/Q7oVa2cC_400x400.png?1720799391"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbc1852f8940991d91bd2b09a5abb5e7b8092a16c",
+      "name": "BasePrinter",
+      "symbol": "BASEPRINTER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52667/large/BasePrinter.png?1734013829"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f2e6758c4d6570344bd5007dec6301cd57590a0",
+      "name": "Spot",
+      "symbol": "SPOT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28426/large/SPOT_Logo_200x200_sq_small_centered.png?1696527423"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x554bba833518793056cf105e66abea330672c0de",
+      "name": "Maha",
+      "symbol": "MAHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13404/large/black.png?1724679606"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf544251d25f3d243a36b07e7e7962a678f952691",
+      "name": "Tarot",
+      "symbol": "TAROT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31800/large/TAROT.jpg?1696530615"
     },
     {
       "chainId": 8453,
@@ -2164,11 +2140,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x4f81837c2f4a189a0b69370027cc2627d93785b4",
-      "name": "Seraph by Virtuals",
-      "symbol": "SERAPH",
+      "address": "0xda761a290e01c69325d12d82ac402e5a73d62e81",
+      "name": "Base Pro Shops",
+      "symbol": "BPS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52442/large/fire_guy.png?1733351187"
+      "logoURI": "https://assets.coingecko.com/coins/images/36855/large/BPS_2.png?1712634757"
     },
     {
       "chainId": 8453,
@@ -2180,11 +2156,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x6009e7cd237087e6d7570990e8bdac09c3e182b0",
-      "name": "TaskBunny",
-      "symbol": "BNY",
+      "address": "0x71a67215a2025f501f386a49858a9ced2fc0249d",
+      "name": "Wrapped SEI  Universal ",
+      "symbol": "USEI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51478/large/Bunny_coin_200x200.png?1731404290"
+      "logoURI": "https://assets.coingecko.com/coins/images/51023/large/UA-SEI_1.png?1729770680"
     },
     {
       "chainId": 8453,
@@ -2204,102 +2180,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0xc796e499cc8f599a2a8280825d8bda92f7a895e0",
-      "name": "Neurobro",
-      "symbol": "BRO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52649/large/coingeckooo.png?1733917525"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c41f1fc9022feb69af6dc666abfe73c9ffda7ce",
-      "name": "Bitcoin on Base",
-      "symbol": "BTCB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38868/large/BTCB_Official_Logo_July_2024.png?1721753012"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7480527815ccae421400da01e052b120cc4255e9",
-      "name": "Workie",
-      "symbol": "WORKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38774/large/Pfp2_%281%29.png?1724903016"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
-      "name": "Nya",
-      "symbol": "NYA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40082/large/nya.jpg?1725523655"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7431ada8a591c955a994a21710752ef9b882b8e3",
-      "name": "MorpheusAI",
-      "symbol": "MOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37969/large/MOR200X200.png?1716327119"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb757977bc882a14db86b048f2abb2f2a14d33184",
-      "name": "DogLibre",
-      "symbol": "DOGL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37011/large/doglibre.jpeg?1713141966"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x56a38e7216304108e841579041249feb236c887b",
-      "name": "Libertum",
-      "symbol": "LBM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37147/large/wmGmpgSW_400x400.jpg?1713469301"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x62bba099edd65740c0d192ffe84973b1aae682d2",
-      "name": "SpunkySDX",
-      "symbol": "SSDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52469/large/spunkysdx.png?1733412208"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x22af33fe49fd1fa80c7149773dde5890d3c76f3b",
-      "name": "BankrCoin",
-      "symbol": "BNKR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52626/large/banker.png?1733818573"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x614577036f0a024dbc1c88ba616b394dd65d105a",
-      "name": "GENIUS AI",
-      "symbol": "GNUS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36914/large/IMG_5346.png?1712769235"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcb327b99ff831bf8223cced12b1338ff3aa322ff",
-      "name": "Based ETH",
-      "symbol": "BSDETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35774/large/Icon_White_on_Blue.png?1709793654"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xbb22ff867f8ca3d5f2251b4084f6ec86d4666e14",
-      "name": "Cryptex Finance",
-      "symbol": "CTX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14932/large/CTX_Logo_200px.png?1723514786"
-    },
-    {
-      "chainId": 8453,
       "address": "0xe095780ba2a64a4efa7a74830f0b71656f0b0ad4",
       "name": "Byte",
       "symbol": "BYTE",
@@ -2308,35 +2188,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x9f95e17b2668afe01f8fbd157068b0a4405cc08d",
-      "name": "Bullieverse",
-      "symbol": "BULL",
+      "address": "0x6009e7cd237087e6d7570990e8bdac09c3e182b0",
+      "name": "TaskBunny",
+      "symbol": "BNY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/24174/large/KR3qVAQe_400x400.jpg?1696523362"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd98832e8a59156acbee4744b9a94a9989a728f36",
-      "name": "AgentAIgo",
-      "symbol": "AGENT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52294/large/agent_logo.jpg?1732966712"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xdcf5130274753c8050ab061b1a1dcbf583f5bfd0",
-      "name": "ViciCoin",
-      "symbol": "VCNT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31305/large/ViciCoin_-_small.png?1696530124"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb38266e0e9d9681b77aeb0a280e98131b953f865",
-      "name": "DOVU",
-      "symbol": "DOVU",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/31930/large/Dovu_Icon_Black_%281%29.png?1696530738"
+      "logoURI": "https://assets.coingecko.com/coins/images/51478/large/Bunny_coin_200x200.png?1731404290"
     },
     {
       "chainId": 8453,
@@ -2348,11 +2204,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xbeb0fd48c2ba0f1aacad2814605f09e08a96b94e",
-      "name": "GME  Base ",
-      "symbol": "GME",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37229/large/gamestop.jpeg?1713780481"
+      "address": "0x7480527815ccae421400da01e052b120cc4255e9",
+      "name": "Workie",
+      "symbol": "WORKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38774/large/Pfp2_%281%29.png?1724903016"
     },
     {
       "chainId": 8453,
@@ -2364,19 +2220,67 @@
     },
     {
       "chainId": 8453,
-      "address": "0xf09930625447d6a5f8e1217edb5649c7314e4e96",
-      "name": "Skibidi Dop Dop",
-      "symbol": "SKIBIDI",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/52594/large/skibidi-logo-coingecko.png?1733727963"
+      "address": "0x62bba099edd65740c0d192ffe84973b1aae682d2",
+      "name": "SpunkySDX",
+      "symbol": "SSDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52469/large/spunkysdx.png?1733412208"
     },
     {
       "chainId": 8453,
-      "address": "0xdb6e0e5094a25a052ab6845a9f1e486b9a9b3dde",
-      "name": "Okayeg",
-      "symbol": "OKAYEG",
+      "address": "0x0c41f1fc9022feb69af6dc666abfe73c9ffda7ce",
+      "name": "Bitcoin on Base",
+      "symbol": "BTCB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37748/large/Okayeg_200.png?1715442444"
+      "logoURI": "https://assets.coingecko.com/coins/images/38868/large/BTCB_Official_Logo_July_2024.png?1721753012"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb757977bc882a14db86b048f2abb2f2a14d33184",
+      "name": "DogLibre",
+      "symbol": "DOGL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37011/large/doglibre.jpeg?1713141966"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x614577036f0a024dbc1c88ba616b394dd65d105a",
+      "name": "GENIUS AI",
+      "symbol": "GNUS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36914/large/IMG_5346.png?1712769235"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x56a38e7216304108e841579041249feb236c887b",
+      "name": "Libertum",
+      "symbol": "LBM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37147/large/wmGmpgSW_400x400.jpg?1713469301"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc796e499cc8f599a2a8280825d8bda92f7a895e0",
+      "name": "Neurobro",
+      "symbol": "BRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52649/large/coingeckooo.png?1733917525"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9f95e17b2668afe01f8fbd157068b0a4405cc08d",
+      "name": "Bullieverse",
+      "symbol": "BULL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24174/large/KR3qVAQe_400x400.jpg?1696523362"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4f81837c2f4a189a0b69370027cc2627d93785b4",
+      "name": "Seraph by Virtuals",
+      "symbol": "SERAPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52442/large/fire_guy.png?1733351187"
     },
     {
       "chainId": 8453,
@@ -2385,6 +2289,54 @@
       "symbol": "ANDY",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/36552/large/ANDY.jpg?1711896298"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x01aac2b594f7bdbec740f0f1aa22910ebb4b74ab",
+      "name": "Unio Coin",
+      "symbol": "UNIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50191/large/uniocoin-200x200.png?1726206790"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1196c6704789620514fd25632abe15f69a50bc4f",
+      "name": "Pepe Clanker",
+      "symbol": "PEPEC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52568/large/pepepepepe.jpeg?1733674517"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf09930625447d6a5f8e1217edb5649c7314e4e96",
+      "name": "Skibidi Dop Dop",
+      "symbol": "SKIBIDI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/52594/large/skibidi-logo-coingecko.png?1733727963"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7431ada8a591c955a994a21710752ef9b882b8e3",
+      "name": "MorpheusAI",
+      "symbol": "MOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37969/large/MOR200X200.png?1716327119"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xdcf5130274753c8050ab061b1a1dcbf583f5bfd0",
+      "name": "ViciCoin",
+      "symbol": "VCNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31305/large/ViciCoin_-_small.png?1696530124"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7a8a5012022bccbf3ea4b03cd2bb5583d915fb1a",
+      "name": "Chuck",
+      "symbol": "CHUCK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37468/large/1000030138.jpg?1714457112"
     },
     {
       "chainId": 8453,
@@ -2404,14 +2356,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0x7a8a5012022bccbf3ea4b03cd2bb5583d915fb1a",
-      "name": "Chuck",
-      "symbol": "CHUCK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37468/large/1000030138.jpg?1714457112"
-    },
-    {
-      "chainId": 8453,
       "address": "0x70737489dfdf1a29b7584d40500d3561bd4fe196",
       "name": "BORED",
       "symbol": "BORED",
@@ -2420,43 +2364,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0x354d6890caa31a5e28b6059d46781f40880786a6",
-      "name": "ghffb47yii2rteeyy10op",
-      "symbol": "GHFFB47YII2RTEEYY10",
+      "address": "0x38f9bf9dce51833ec7f03c9dc218197999999999",
+      "name": "Nya",
+      "symbol": "NYA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52104/large/0x354d6890caa31a5e28b6059d46781f40880786a6.png?1732591949"
+      "logoURI": "https://assets.coingecko.com/coins/images/40082/large/nya.jpg?1725523655"
     },
     {
       "chainId": 8453,
-      "address": "0xb4e1b230dd0476238fc64c99ff9d6ccdfdb2258d",
-      "name": "Florence Finance Medici",
-      "symbol": "FFM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34382/large/M_PNG_200x200_copy.png?1704779326"
+      "address": "0xbeb0fd48c2ba0f1aacad2814605f09e08a96b94e",
+      "name": "GME  Base ",
+      "symbol": "GME",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37229/large/gamestop.jpeg?1713780481"
     },
     {
       "chainId": 8453,
-      "address": "0x8d3419b9a18651f3926a205ee0b1acea1e7192de",
-      "name": "Law of Attraction",
-      "symbol": "LOA",
+      "address": "0xdb6e0e5094a25a052ab6845a9f1e486b9a9b3dde",
+      "name": "Okayeg",
+      "symbol": "OKAYEG",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38008/large/1.png?1716270777"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xff0c532fdb8cd566ae169c1cb157ff2bdc83e105",
-      "name": "Fren Pet",
-      "symbol": "FP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33022/large/token.png?1700274697"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfaa4f3bcfc87d791e9305951275e0f62a98bcb10",
-      "name": "Super Best Friends",
-      "symbol": "SUBF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36368/large/1000017215.jpg?1711338058"
+      "logoURI": "https://assets.coingecko.com/coins/images/37748/large/Okayeg_200.png?1715442444"
     },
     {
       "chainId": 8453,
@@ -2468,11 +2396,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0xbf1aea8670d2528e08334083616dd9c5f3b087ae",
-      "name": "MAI  Base ",
-      "symbol": "MIMATIC",
+      "address": "0x22af33fe49fd1fa80c7149773dde5890d3c76f3b",
+      "name": "BankrCoin",
+      "symbol": "BNKR",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35466/large/mimatic-red.png?1708687857"
+      "logoURI": "https://assets.coingecko.com/coins/images/52626/large/banker.png?1733818573"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x314d7f9e2f55b430ef656fbb98a7635d43a2261e",
+      "name": "Naym",
+      "symbol": "NAYM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50981/large/naym.jpg?1729651162"
     },
     {
       "chainId": 8453,
@@ -2484,6 +2420,22 @@
     },
     {
       "chainId": 8453,
+      "address": "0x4366c1568fd6167eee67d25ef6980da38e3421bc",
+      "name": "Based Hoppy",
+      "symbol": "HOPPY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52765/large/New_Project_-_2024-12-13T125213.686.png?1734268017"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfaa4f3bcfc87d791e9305951275e0f62a98bcb10",
+      "name": "Super Best Friends",
+      "symbol": "SUBF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36368/large/1000017215.jpg?1711338058"
+    },
+    {
+      "chainId": 8453,
       "address": "0x7f05a7a9af2f5a07d1e64877c8dc37a64a22508e",
       "name": "Ajna Protocol",
       "symbol": "AJNA",
@@ -2492,19 +2444,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x64cb1bafc59bf93aeb90676885c63540cf4f4106",
-      "name": "Coin6900",
-      "symbol": "COIN",
+      "address": "0xb4e1b230dd0476238fc64c99ff9d6ccdfdb2258d",
+      "name": "Florence Finance Medici",
+      "symbol": "FFM",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51425/large/logo.jpg?1731186114"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x99b2b1a2adb02b38222adcd057783d7e5d1fcc7d",
-      "name": "Common Wealth",
-      "symbol": "WLTH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37858/large/WLTH_TICKER_200x200.png?1730241264"
+      "logoURI": "https://assets.coingecko.com/coins/images/34382/large/M_PNG_200x200_copy.png?1704779326"
     },
     {
       "chainId": 8453,
@@ -2532,115 +2476,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xb4e017223fd3d639d0264de4da1b9e080325cb5e",
-      "name": "SyncVault",
-      "symbol": "SVTS",
+      "address": "0x36912b5cf63e509f18e53ac98b3012fa79e77bf5",
+      "name": "FUEGO",
+      "symbol": "FUEGO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50447/large/White_SV_logo_200x200.png?1727771615"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x76734b57dfe834f102fb61e1ebf844adf8dd931e",
-      "name": "Weirdo",
-      "symbol": "WEIRDO",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/37847/large/New_Project_%2823%29.png?1726539603"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc48e605c7b722a57277e087a6170b9e227e5ac0a",
-      "name": "OmniCat",
-      "symbol": "OMNI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33917/large/omnicatlogo.png?1717544778"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1db0c569ebb4a8b57ac01833b9792f526305e062",
-      "name": "GenomesDAO GENOME",
-      "symbol": "GENOME",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36763/large/images.jpg?1712282056"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x689644b86075ed61c647596862c7403e1c474dbf",
-      "name": "Bamboo on Base",
-      "symbol": "BAMBOO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39126/large/Bamboo_Logo_800x800.png?1720656497"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x85645b86243886b7c7c1da6288571f8bea6fc035",
-      "name": "Tyler",
-      "symbol": "TYLER",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/52587/large/IMG_7775.JPG?1733713659"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x41e0fe1317bd6e8944b037cd59b22d428c1434c2",
-      "name": "Virtu by Virtuals",
-      "symbol": "VIRTU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51827/large/_removal.ai__24fd4161-77b5-412f-b553-a99e9012f575_photo_2024-11-07_08-05-59.png?1732042711"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5a7a2bf9ffae199f088b25837dcd7e115cf8e1bb",
-      "name": "IMO",
-      "symbol": "IMO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14831/large/IMO_logo_rond_200.png?1729798616"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
-      "name": "Glo Dollar",
-      "symbol": "USDGLO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29319/large/GLO_logo_pine_on_cyan_1_3.png?1716971065"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8fbd0648971d56f1f2c35fa075ff5bc75fb0e39d",
-      "name": "UNKJD",
-      "symbol": "MBS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20841/large/monkeyball.png?1696520233"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4da78059d97f155e18b37765e2e042270f4e0fc4",
-      "name": "WUFFI",
-      "symbol": "WUF",
-      "decimals": 4,
-      "logoURI": "https://assets.coingecko.com/coins/images/36933/large/WUFFI.jpg?1720613603"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x655a51e6803faf50d4ace80fa501af2f29c856cf",
-      "name": "PAID",
-      "symbol": "PAID",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/13761/large/PAID_Logo_new.png?1730798431"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe0023e73aab4fe9a22f059a9d27e857e027ee3dc",
-      "name": "RWAX",
-      "symbol": "RWAX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38266/large/Rwax_Token_Symbol_logo-200.png?1716949733"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd7574820e04eb724855ec781c16be78b31ff9134",
-      "name": "SOX",
-      "symbol": "SOX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52773/large/0xd7574820e04eb724855ec781c16be78b31ff9134__MConverter.eu__%281%29.jpg?1734279428"
+      "logoURI": "https://assets.coingecko.com/coins/images/51345/large/FUEGO_200x200.jpg?1730825086"
     },
     {
       "chainId": 8453,
@@ -2652,27 +2492,91 @@
     },
     {
       "chainId": 8453,
-      "address": "0xf7c1cefcf7e1dd8161e00099facd3e1db9e528ee",
-      "name": "Tower",
-      "symbol": "TOWER",
+      "address": "0xc48e605c7b722a57277e087a6170b9e227e5ac0a",
+      "name": "OmniCat",
+      "symbol": "OMNI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14134/large/tower-circular-1000.png?1696513854"
+      "logoURI": "https://assets.coingecko.com/coins/images/33917/large/omnicatlogo.png?1717544778"
     },
     {
       "chainId": 8453,
-      "address": "0x98f4779fccb177a6d856dd1dfd78cd15b7cd2af5",
-      "name": "MISATO",
-      "symbol": "MISATO",
+      "address": "0x8d3419b9a18651f3926a205ee0b1acea1e7192de",
+      "name": "Law of Attraction",
+      "symbol": "LOA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52231/large/misatocleanboost.png?1732802425"
+      "logoURI": "https://assets.coingecko.com/coins/images/38008/large/1.png?1716270777"
     },
     {
       "chainId": 8453,
-      "address": "0xedc68c4c54228d273ed50fc450e253f685a2c6b9",
-      "name": "Javsphere",
-      "symbol": "JAV",
+      "address": "0x4e74d4db6c0726ccded4656d0bce448876bb4c7a",
+      "name": "Wrapped BMX Liquidity Token",
+      "symbol": "WBLT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36740/large/jav-token-v2.png?1712210923"
+      "logoURI": "https://assets.coingecko.com/coins/images/31532/large/wBLT_200x200.png?1696530341"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x76734b57dfe834f102fb61e1ebf844adf8dd931e",
+      "name": "Weirdo",
+      "symbol": "WEIRDO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/37847/large/New_Project_%2823%29.png?1726539603"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbf1aea8670d2528e08334083616dd9c5f3b087ae",
+      "name": "MAI  Base ",
+      "symbol": "MIMATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35466/large/mimatic-red.png?1708687857"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x99b2b1a2adb02b38222adcd057783d7e5d1fcc7d",
+      "name": "Common Wealth",
+      "symbol": "WLTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37858/large/WLTH_TICKER_200x200.png?1730241264"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb4e017223fd3d639d0264de4da1b9e080325cb5e",
+      "name": "SyncVault",
+      "symbol": "SVTS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50447/large/White_SV_logo_200x200.png?1727771615"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x64cb1bafc59bf93aeb90676885c63540cf4f4106",
+      "name": "Coin6900",
+      "symbol": "COIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51425/large/logo.jpg?1731186114"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x354d6890caa31a5e28b6059d46781f40880786a6",
+      "name": "ghffb47yii2rteeyy10op",
+      "symbol": "GHFFB47YII2RTEEYY10",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52104/large/0x354d6890caa31a5e28b6059d46781f40880786a6.png?1732591949"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xff0c532fdb8cd566ae169c1cb157ff2bdc83e105",
+      "name": "Fren Pet",
+      "symbol": "FP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33022/large/token.png?1700274697"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x85645b86243886b7c7c1da6288571f8bea6fc035",
+      "name": "Tyler",
+      "symbol": "TYLER",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/52587/large/IMG_7775.JPG?1733713659"
     },
     {
       "chainId": 8453,
@@ -2684,35 +2588,91 @@
     },
     {
       "chainId": 8453,
-      "address": "0x01aac2b594f7bdbec740f0f1aa22910ebb4b74ab",
-      "name": "Unio Coin",
-      "symbol": "UNIO",
+      "address": "0x655a51e6803faf50d4ace80fa501af2f29c856cf",
+      "name": "PAID",
+      "symbol": "PAID",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50191/large/uniocoin-200x200.png?1726206790"
+      "logoURI": "https://assets.coingecko.com/coins/images/13761/large/PAID_Logo_new.png?1730798431"
     },
     {
       "chainId": 8453,
-      "address": "0xf04d220b8136e2d3d4be08081dbb565c3c302ffd",
-      "name": "Freya by Virtuals",
-      "symbol": "FREYA",
+      "address": "0x689644b86075ed61c647596862c7403e1c474dbf",
+      "name": "Bamboo on Base",
+      "symbol": "BAMBOO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52325/large/FREYA_%281%29.png?1733079799"
+      "logoURI": "https://assets.coingecko.com/coins/images/39126/large/Bamboo_Logo_800x800.png?1720656497"
     },
     {
       "chainId": 8453,
-      "address": "0x4dd9077269dd08899f2a9e73507125962b5bc87f",
-      "name": "Crash On Base",
-      "symbol": "CRASH",
+      "address": "0xfc48314ad4ad5bd36a84e8307b86a68a01d95d9c",
+      "name": "AION 5100",
+      "symbol": "AION",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38817/large/_iNshlUA.png?1722185418"
+      "logoURI": "https://assets.coingecko.com/coins/images/52808/large/l8DUQ6ns_400x400.jpg?1734361482"
     },
     {
       "chainId": 8453,
-      "address": "0x3c3860d89b81c91974fc1f8a41aeeef604c17058",
-      "name": "Kinetix Finance Token",
-      "symbol": "KAI",
+      "address": "0xedc68c4c54228d273ed50fc450e253f685a2c6b9",
+      "name": "Javsphere",
+      "symbol": "JAV",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/34031/large/KFI_Token_1.png?1703675672"
+      "logoURI": "https://assets.coingecko.com/coins/images/36740/large/jav-token-v2.png?1712210923"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8fbd0648971d56f1f2c35fa075ff5bc75fb0e39d",
+      "name": "UNKJD",
+      "symbol": "MBS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20841/large/monkeyball.png?1696520233"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5a7a2bf9ffae199f088b25837dcd7e115cf8e1bb",
+      "name": "IMO",
+      "symbol": "IMO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14831/large/IMO_logo_rond_200.png?1729798616"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe0023e73aab4fe9a22f059a9d27e857e027ee3dc",
+      "name": "RWAX",
+      "symbol": "RWAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38266/large/Rwax_Token_Symbol_logo-200.png?1716949733"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
+      "name": "Glo Dollar",
+      "symbol": "USDGLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29319/large/GLO_logo_pine_on_cyan_1_3.png?1716971065"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd7574820e04eb724855ec781c16be78b31ff9134",
+      "name": "SOX",
+      "symbol": "SOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52773/large/0xd7574820e04eb724855ec781c16be78b31ff9134__MConverter.eu__%281%29.jpg?1734279428"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb38266e0e9d9681b77aeb0a280e98131b953f865",
+      "name": "DOVU",
+      "symbol": "DOVU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/31930/large/Dovu_Icon_Black_%281%29.png?1696530738"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4da78059d97f155e18b37765e2e042270f4e0fc4",
+      "name": "WUFFI",
+      "symbol": "WUF",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/36933/large/WUFFI.jpg?1720613603"
     },
     {
       "chainId": 8453,
@@ -2724,51 +2684,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0x681a09a902d9c7445b3b1ab282c38d60c72f1f09",
-      "name": "AlphaKEK AI",
-      "symbol": "AIKEK",
+      "address": "0xf7c1cefcf7e1dd8161e00099facd3e1db9e528ee",
+      "name": "Tower",
+      "symbol": "TOWER",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35445/large/alphakek_-_Copy.png?1708620097"
+      "logoURI": "https://assets.coingecko.com/coins/images/14134/large/tower-circular-1000.png?1696513854"
     },
     {
       "chainId": 8453,
-      "address": "0x728f0a7fec1859cb0d71a432271d4e80310d235f",
-      "name": "Pog Coin",
-      "symbol": "POGS",
+      "address": "0x4dd9077269dd08899f2a9e73507125962b5bc87f",
+      "name": "Crash On Base",
+      "symbol": "CRASH",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37524/large/Untitled_design_%2860%29.png?1731815368"
+      "logoURI": "https://assets.coingecko.com/coins/images/38817/large/_iNshlUA.png?1722185418"
     },
     {
       "chainId": 8453,
-      "address": "0xe161be4a74ab8fa8706a2d03e67c02318d0a0ad6",
-      "name": "Apetardio",
-      "symbol": "APETARDIO",
+      "address": "0x41e0fe1317bd6e8944b037cd59b22d428c1434c2",
+      "name": "Virtu by Virtuals",
+      "symbol": "VIRTU",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38155/large/apetardio200x200.png?1716669062"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf56b3b3972f2f154555a0b62ff5a22b7b2a3c90b",
-      "name": "ZAP",
-      "symbol": "ZAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50515/large/zap.jpg?1728033535"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3ee5e23eee121094f1cfc0ccc79d6c809ebd22e5",
-      "name": "Ionic Protocol",
-      "symbol": "ION",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36713/large/Ionic-icon-green.png?1712127547"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x004aa1586011f3454f487eac8d0d5c647d646c69",
-      "name": "DogeVerse",
-      "symbol": "DOGEVERSE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38495/large/DogeVerse_200x200.png?1717692269"
+      "logoURI": "https://assets.coingecko.com/coins/images/51827/large/_removal.ai__24fd4161-77b5-412f-b553-a99e9012f575_photo_2024-11-07_08-05-59.png?1732042711"
     },
     {
       "chainId": 8453,
@@ -2780,19 +2716,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0x645c7aa841087e2e7f741c749ab27422ff5bba8e",
-      "name": "Iona by Virtuals",
-      "symbol": "IONA",
+      "address": "0x1db0c569ebb4a8b57ac01833b9792f526305e062",
+      "name": "GenomesDAO GENOME",
+      "symbol": "GENOME",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52166/large/iona.jpg?1732682259"
+      "logoURI": "https://assets.coingecko.com/coins/images/36763/large/images.jpg?1712282056"
     },
     {
       "chainId": 8453,
-      "address": "0x6e51b3a19f114013e5dc09d0477a536c7e4e0207",
-      "name": "Media Network",
-      "symbol": "MEDIA",
+      "address": "0x3c3860d89b81c91974fc1f8a41aeeef604c17058",
+      "name": "Kinetix Finance Token",
+      "symbol": "KAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/15142/large/media50x50.png?1696514798"
+      "logoURI": "https://assets.coingecko.com/coins/images/34031/large/KFI_Token_1.png?1703675672"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe161be4a74ab8fa8706a2d03e67c02318d0a0ad6",
+      "name": "Apetardio",
+      "symbol": "APETARDIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38155/large/apetardio200x200.png?1716669062"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x728f0a7fec1859cb0d71a432271d4e80310d235f",
+      "name": "Pog Coin",
+      "symbol": "POGS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37524/large/Untitled_design_%2860%29.png?1731815368"
     },
     {
       "chainId": 8453,
@@ -2804,6 +2756,46 @@
     },
     {
       "chainId": 8453,
+      "address": "0x97b959385dfdcaf252223838746beb232ac601aa",
+      "name": "AI Market Compass",
+      "symbol": "AIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39363/large/AIM_%282%29.jpg?1723415448"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd98832e8a59156acbee4744b9a94a9989a728f36",
+      "name": "AgentAIgo",
+      "symbol": "AGENT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52294/large/agent_logo.jpg?1732966712"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7404ac09adf614603d9c16a7ce85a1101f3514ba",
+      "name": "PLAY",
+      "symbol": "PLAY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52562/large/play_token.png?1733669740"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x004aa1586011f3454f487eac8d0d5c647d646c69",
+      "name": "DogeVerse",
+      "symbol": "DOGEVERSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38495/large/DogeVerse_200x200.png?1717692269"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6e51b3a19f114013e5dc09d0477a536c7e4e0207",
+      "name": "Media Network",
+      "symbol": "MEDIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15142/large/media50x50.png?1696514798"
+    },
+    {
+      "chainId": 8453,
       "address": "0x1287a235474e0331c0975e373bdd066444d1bd35",
       "name": "TAIKAI",
       "symbol": "TKAI",
@@ -2812,11 +2804,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0x844c03892863b0e3e00e805e41b34527044d5c72",
-      "name": "Panana",
-      "symbol": "PANANA",
+      "address": "0xf56b3b3972f2f154555a0b62ff5a22b7b2a3c90b",
+      "name": "ZAP",
+      "symbol": "ZAP",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52672/large/panana_eat.png?1734017755"
+      "logoURI": "https://assets.coingecko.com/coins/images/50515/large/zap.jpg?1728033535"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7d9ce55d54ff3feddb611fc63ff63ec01f26d15f",
+      "name": "Fungi",
+      "symbol": "FUNGI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/36690/large/image_2024-03-29_20-10-19_%282%29_%283%29.png?1712091884"
     },
     {
       "chainId": 8453,
@@ -2836,19 +2836,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xfa1f6e048e66ac240a4bb7eab7ee888e76081a6c",
-      "name": "Drone",
-      "symbol": "DRONE",
+      "address": "0xa0a2e84f6f19c09a095d4a83ac8de5a32d303a13",
+      "name": "Lil Brett",
+      "symbol": "LILB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38161/large/drone_no_background.png?1716674159"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7d9ce55d54ff3feddb611fc63ff63ec01f26d15f",
-      "name": "Fungi",
-      "symbol": "FUNGI",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/36690/large/image_2024-03-29_20-10-19_%282%29_%283%29.png?1712091884"
+      "logoURI": "https://assets.coingecko.com/coins/images/51813/large/%28100_x_100_px%29.png?1732029374"
     },
     {
       "chainId": 8453,
@@ -2860,91 +2852,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x7404ac09adf614603d9c16a7ce85a1101f3514ba",
-      "name": "PLAY",
-      "symbol": "PLAY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52562/large/play_token.png?1733669740"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd1917629b3e6a72e6772aab5dbe58eb7fa3c2f33",
-      "name": "Settled EthXY Token",
-      "symbol": "SEXY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33032/large/logo-circle.png?1700348518"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1c555eee8018fee4fbca4bb657c5f175601e3ed7",
-      "name": "HUMO",
-      "symbol": "HUMO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52829/large/HUMO_Token.png?1734449906"
-    },
-    {
-      "chainId": 8453,
       "address": "0xa067436db77ab18b1a315095e4b816791609897c",
       "name": "WASSIE",
       "symbol": "WASSIE",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/30144/large/logo-coingecko.png?1696529065"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfc48314ad4ad5bd36a84e8307b86a68a01d95d9c",
-      "name": "AION 5100",
-      "symbol": "AION",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52808/large/l8DUQ6ns_400x400.jpg?1734361482"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1b6a569dd61edce3c383f6d565e2f79ec3a12980",
-      "name": "Young Peezy AKA Pepe",
-      "symbol": "PEEZY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36649/large/PFP_CG_200x200.jpeg?1719953176"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x97b959385dfdcaf252223838746beb232ac601aa",
-      "name": "AI Market Compass",
-      "symbol": "AIM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39363/large/AIM_%282%29.jpg?1723415448"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x548f93779fbc992010c07467cbaf329dd5f059b7",
-      "name": "BMX",
-      "symbol": "BMX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31699/large/bmx_white.png?1696530517"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa0a2e84f6f19c09a095d4a83ac8de5a32d303a13",
-      "name": "Lil Brett",
-      "symbol": "LILB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51813/large/%28100_x_100_px%29.png?1732029374"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3c5fdf0ee37d62c774025599e3b692d027746e24",
-      "name": "Bonkey",
-      "symbol": "BONKEY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51629/large/nWKo5DZvrtkwwjtT7YXyYQeDstBhvwrqxdOmGmWvUNN6d_GSurf_TR1InJS8oLo2WYIJG2ZsX2Lffmr8z1bjqjygtVNcAKuMIX3TJPg65wPZepTpTQnXCXZrbA_oXuiIkzN2PU1vd1i6scKtGgJa4ffeecm1R7WzR7NX65j6JVu_ys42VMrpvNuNJ2ovRGM8sh9V-MovD8Mbs9NkaYQ_%281%29.jpg?1731664154"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3203856eac03d343f9d5245ba2f39861838a7b36",
-      "name": "Aviator",
-      "symbol": "AVI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31024/large/avi-200x200png.png?1711119363"
     },
     {
       "chainId": 8453,
@@ -2956,27 +2868,27 @@
     },
     {
       "chainId": 8453,
-      "address": "0x776aaef8d8760129a0398cf8674ee28cefc0eab9",
-      "name": "Floppa Cat",
-      "symbol": "FLOPPA",
+      "address": "0xd1917629b3e6a72e6772aab5dbe58eb7fa3c2f33",
+      "name": "Settled EthXY Token",
+      "symbol": "SEXY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36969/large/floppa.jpg?1722771377"
+      "logoURI": "https://assets.coingecko.com/coins/images/33032/large/logo-circle.png?1700348518"
     },
     {
       "chainId": 8453,
-      "address": "0x3fbde9864362ce4abb244ebef2ef0482aba8ea39",
-      "name": "Baklava",
-      "symbol": "BAVA",
+      "address": "0x681a09a902d9c7445b3b1ab282c38d60c72f1f09",
+      "name": "AlphaKEK AI",
+      "symbol": "AIKEK",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23780/large/200x200_BAVA_LOGO_%282%29.png?1696522980"
+      "logoURI": "https://assets.coingecko.com/coins/images/35445/large/alphakek_-_Copy.png?1708620097"
     },
     {
       "chainId": 8453,
-      "address": "0x4b556f3a476b58be7f35df77edd68fbe5076f706",
-      "name": "MintStakeShare",
-      "symbol": "MSS",
+      "address": "0x3203856eac03d343f9d5245ba2f39861838a7b36",
+      "name": "Aviator",
+      "symbol": "AVI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39424/large/logo200x200.png?1729946358"
+      "logoURI": "https://assets.coingecko.com/coins/images/31024/large/avi-200x200png.png?1711119363"
     },
     {
       "chainId": 8453,
@@ -2988,91 +2900,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xfafb7581a65a1f554616bf780fc8a8acd2ab8c9b",
-      "name": "Squid Game",
-      "symbol": "SQUID",
+      "address": "0x645c7aa841087e2e7f741c749ab27422ff5bba8e",
+      "name": "Iona by Virtuals",
+      "symbol": "IONA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/20506/large/squid.png?1696519912"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x63228048121877a9e0f52020834a135074e8207c",
-      "name": "Moonsama",
-      "symbol": "SAMA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28308/large/Small.png?1696527312"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8931ee05ec111325c1700b68e5ef7b887e00661d",
-      "name": "The Big Guy",
-      "symbol": "BGUY",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/38875/large/download.png?1719336441"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x5b5dee44552546ecea05edea01dcd7be7aa6144a",
-      "name": "TN100x",
-      "symbol": "TN100X",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35729/large/patch-transparent-blue.png?1729878068"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4194f4e29d652656b6dc84f10363482c5ac101b5",
-      "name": "MPAA",
-      "symbol": "MPAA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39521/large/photo_2024-08-03_12-01-50.jpg?1722790299"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc8e51fefd7d595c217c7ab641513faa4ad522b26",
-      "name": "Crappy Bird CTO",
-      "symbol": "CRAPPY",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52776/large/Gk2z6bC-_400x400_%281%29.jpg?1734282641"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x26f1bb40ea88b46ceb21557dc0ffac7b7c0ad40f",
-      "name": "ALF",
-      "symbol": "ALF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38867/large/alf200.png?1719283344"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xaa6cccdce193698d33deb9ffd4be74eaa74c4898",
-      "name": "ElonRWA",
-      "symbol": "ELONRWA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36970/large/elonrwa.png?1712910039"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x99298c6be0e8ec9e56b7a2be5850abe1fc109d94",
-      "name": "Degen Capital by Virtuals",
-      "symbol": "DEGENC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52246/large/Degenc_with_Pnut_Logo.png?1733992482"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x613ce28076289de255f1a6487437f03e37e4a71d",
-      "name": "Dackie USD",
-      "symbol": "DCKUSD",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/39966/large/Dackie_USD_Stablecoin.png?1724957262"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3054e8f8fba3055a42e5f5228a2a4e2ab1326933",
-      "name": "zuzalu",
-      "symbol": "ZUZALU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36909/large/ZUZALA.jpg?1712732086"
+      "logoURI": "https://assets.coingecko.com/coins/images/52166/large/iona.jpg?1732682259"
     },
     {
       "chainId": 8453,
@@ -3084,27 +2916,107 @@
     },
     {
       "chainId": 8453,
-      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
-      "name": "Lava Network",
-      "symbol": "LAVA",
+      "address": "0xf04d220b8136e2d3d4be08081dbb565c3c302ffd",
+      "name": "Freya by Virtuals",
+      "symbol": "FREYA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52325/large/FREYA_%281%29.png?1733079799"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfef2d7b013b88fec2bfe4d2fee0aeb719af73481",
+      "name": " onchain",
+      "symbol": "ONCHAIN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36948/large/IMG_2072.jpeg?1712896843"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x698b49063c14d2753d23064ff891a876cffa6fb5",
+      "name": "NIKITA by Virtuals",
+      "symbol": "NIKITA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52146/large/NikitaNewPP.png?1734294864"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c5fdf0ee37d62c774025599e3b692d027746e24",
+      "name": "Bonkey",
+      "symbol": "BONKEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51629/large/nWKo5DZvrtkwwjtT7YXyYQeDstBhvwrqxdOmGmWvUNN6d_GSurf_TR1InJS8oLo2WYIJG2ZsX2Lffmr8z1bjqjygtVNcAKuMIX3TJPg65wPZepTpTQnXCXZrbA_oXuiIkzN2PU1vd1i6scKtGgJa4ffeecm1R7WzR7NX65j6JVu_ys42VMrpvNuNJ2ovRGM8sh9V-MovD8Mbs9NkaYQ_%281%29.jpg?1731664154"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4b556f3a476b58be7f35df77edd68fbe5076f706",
+      "name": "MintStakeShare",
+      "symbol": "MSS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39424/large/logo200x200.png?1729946358"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4194f4e29d652656b6dc84f10363482c5ac101b5",
+      "name": "MPAA",
+      "symbol": "MPAA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39521/large/photo_2024-08-03_12-01-50.jpg?1722790299"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8931ee05ec111325c1700b68e5ef7b887e00661d",
+      "name": "The Big Guy",
+      "symbol": "BGUY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/38875/large/download.png?1719336441"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3fbde9864362ce4abb244ebef2ef0482aba8ea39",
+      "name": "Baklava",
+      "symbol": "BAVA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23780/large/200x200_BAVA_LOGO_%282%29.png?1696522980"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfa1f6e048e66ac240a4bb7eab7ee888e76081a6c",
+      "name": "Drone",
+      "symbol": "DRONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38161/large/drone_no_background.png?1716674159"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1b6a569dd61edce3c383f6d565e2f79ec3a12980",
+      "name": "Young Peezy AKA Pepe",
+      "symbol": "PEEZY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36649/large/PFP_CG_200x200.jpeg?1719953176"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x613ce28076289de255f1a6487437f03e37e4a71d",
+      "name": "Dackie USD",
+      "symbol": "DCKUSD",
       "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37354/large/lava_logo.png?1714098423"
+      "logoURI": "https://assets.coingecko.com/coins/images/39966/large/Dackie_USD_Stablecoin.png?1724957262"
     },
     {
       "chainId": 8453,
-      "address": "0x474f4cb764df9da079d94052fed39625c147c12c",
-      "name": "Bonsai Token",
-      "symbol": "BONSAI",
+      "address": "0xc8e51fefd7d595c217c7ab641513faa4ad522b26",
+      "name": "Crappy Bird CTO",
+      "symbol": "CRAPPY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/35884/large/Bonsai_BW_Coingecko-200x200.jpg?1710071621"
+      "logoURI": "https://assets.coingecko.com/coins/images/52776/large/Gk2z6bC-_400x400_%281%29.jpg?1734282641"
     },
     {
       "chainId": 8453,
-      "address": "0xf34e0cff046e154cafcae502c7541b9e5fd8c249",
-      "name": "Thales",
-      "symbol": "THALES",
+      "address": "0xaa6cccdce193698d33deb9ffd4be74eaa74c4898",
+      "name": "ElonRWA",
+      "symbol": "ELONRWA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18388/large/CLVZJN_C_400x400.png?1696517879"
+      "logoURI": "https://assets.coingecko.com/coins/images/36970/large/elonrwa.png?1712910039"
     },
     {
       "chainId": 8453,
@@ -3116,11 +3028,35 @@
     },
     {
       "chainId": 8453,
-      "address": "0x17931cfc3217261ce0fa21bb066633c463ed8634",
-      "name": "BASEDChad",
-      "symbol": "BASED",
+      "address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
+      "name": "Lava Network",
+      "symbol": "LAVA",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37354/large/lava_logo.png?1714098423"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5b5dee44552546ecea05edea01dcd7be7aa6144a",
+      "name": "TN100x",
+      "symbol": "TN100X",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36378/large/Main_Logo.png?1713748521"
+      "logoURI": "https://assets.coingecko.com/coins/images/35729/large/patch-transparent-blue.png?1729878068"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfafb7581a65a1f554616bf780fc8a8acd2ab8c9b",
+      "name": "Squid Game",
+      "symbol": "SQUID",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20506/large/squid.png?1696519912"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3054e8f8fba3055a42e5f5228a2a4e2ab1326933",
+      "name": "zuzalu",
+      "symbol": "ZUZALU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36909/large/ZUZALA.jpg?1712732086"
     },
     {
       "chainId": 8453,
@@ -3129,6 +3065,70 @@
       "symbol": "RWA",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/37119/large/0x928a6a9fc62b2c94baf2992a6fba4715f5bb0066.jpg?1713356569"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3816dd4bd44c8830c2fa020a5605bac72fa3de7a",
+      "name": "Presearch",
+      "symbol": "PRE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1299/large/presearch.png?1696502369"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x548f93779fbc992010c07467cbaf329dd5f059b7",
+      "name": "BMX",
+      "symbol": "BMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31699/large/bmx_white.png?1696530517"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x98f4779fccb177a6d856dd1dfd78cd15b7cd2af5",
+      "name": "MISATO",
+      "symbol": "MISATO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52231/large/misatocleanboost.png?1732802425"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4b6f82a4ed0b9e3767f53309b87819a78d041a7f",
+      "name": "Juicybet",
+      "symbol": "JSP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38262/large/JB_token.png?1717686707"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x776aaef8d8760129a0398cf8674ee28cefc0eab9",
+      "name": "Floppa Cat",
+      "symbol": "FLOPPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36969/large/floppa.jpg?1722771377"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x844c03892863b0e3e00e805e41b34527044d5c72",
+      "name": "Panana",
+      "symbol": "PANANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52672/large/panana_eat.png?1734017755"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1c555eee8018fee4fbca4bb657c5f175601e3ed7",
+      "name": "HUMO",
+      "symbol": "HUMO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52829/large/HUMO_Token.png?1734449906"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x13741c5df9ab03e7aa9fb3bf1f714551dd5a5f8a",
+      "name": "Noggles",
+      "symbol": "NOGS",
+      "decimals": 15,
+      "logoURI": "https://assets.coingecko.com/coins/images/37238/large/nogs.jpeg?1713851209"
     },
     {
       "chainId": 8453,
@@ -3148,19 +3148,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x314d7f9e2f55b430ef656fbb98a7635d43a2261e",
-      "name": "Naym",
-      "symbol": "NAYM",
+      "address": "0x26f1bb40ea88b46ceb21557dc0ffac7b7c0ad40f",
+      "name": "ALF",
+      "symbol": "ALF",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50981/large/naym.jpg?1729651162"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x4b6f82a4ed0b9e3767f53309b87819a78d041a7f",
-      "name": "Juicybet",
-      "symbol": "JSP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38262/large/JB_token.png?1717686707"
+      "logoURI": "https://assets.coingecko.com/coins/images/38867/large/alf200.png?1719283344"
     },
     {
       "chainId": 8453,
@@ -3172,43 +3164,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x13741c5df9ab03e7aa9fb3bf1f714551dd5a5f8a",
-      "name": "Noggles",
-      "symbol": "NOGS",
-      "decimals": 15,
-      "logoURI": "https://assets.coingecko.com/coins/images/37238/large/nogs.jpeg?1713851209"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcde90558fc317c69580deeaf3efc509428df9080",
-      "name": "Normilio",
-      "symbol": "NORMILIO",
+      "address": "0xfc60aa1ffca50ce08b3cdec9626c0bb9e9b09bec",
+      "name": "Envision Labs",
+      "symbol": "VIS",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36915/large/vm2byD93.jpg?1733436102"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x478e03d45716dda94f6dbc15a633b0d90c237e2f",
-      "name": "Shaka",
-      "symbol": "SHAKA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36850/large/sharetheshaka.png?1712585688"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6a27cd26a373530835b9fe7ac472b3e080070f64",
-      "name": "BlockAI",
-      "symbol": "BAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39638/large/logo-200x200-transparent-bg.png?1723278224"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xebb78043e29f4af24e6266a7d142f5a08443969e",
-      "name": "Derp",
-      "symbol": "DERP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33069/large/derpdex_%281%29.png?1700793428"
+      "logoURI": "https://assets.coingecko.com/coins/images/37142/large/Envision_Logo.png?1713421742"
     },
     {
       "chainId": 8453,
@@ -3220,11 +3180,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x2eac9b08a4d86f347b9e856fb3ec082e61c76545",
-      "name": "AIRENE by Virtuals",
-      "symbol": "AIRENE",
+      "address": "0x17931cfc3217261ce0fa21bb066633c463ed8634",
+      "name": "BASEDChad",
+      "symbol": "BASED",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51485/large/airene_icon_1to1.png?1731405207"
+      "logoURI": "https://assets.coingecko.com/coins/images/36378/large/Main_Logo.png?1713748521"
     },
     {
       "chainId": 8453,
@@ -3236,6 +3196,14 @@
     },
     {
       "chainId": 8453,
+      "address": "0xebb78043e29f4af24e6266a7d142f5a08443969e",
+      "name": "Derp",
+      "symbol": "DERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33069/large/derpdex_%281%29.png?1700793428"
+    },
+    {
+      "chainId": 8453,
       "address": "0xeb9e49fb4c33d9f6aefb1b03f9133435e24c0ec6",
       "name": "Newton On Base",
       "symbol": "NEWB",
@@ -3244,59 +3212,19 @@
     },
     {
       "chainId": 8453,
-      "address": "0x39fed555ff57cb1154bfa6b1a2492bb914ce2d9b",
-      "name": "EchoLeaks by Virtuals",
-      "symbol": "ECHO",
+      "address": "0xcde90558fc317c69580deeaf3efc509428df9080",
+      "name": "Normilio",
+      "symbol": "NORMILIO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52172/large/echoleaks.jpg?1732683705"
+      "logoURI": "https://assets.coingecko.com/coins/images/36915/large/vm2byD93.jpg?1733436102"
     },
     {
       "chainId": 8453,
-      "address": "0xba5ed8a0e261bf2a5ad629d4d5de884ccbfdf3f7",
-      "name": "Just a based guy",
-      "symbol": "BASEDGUY",
+      "address": "0x2eac9b08a4d86f347b9e856fb3ec082e61c76545",
+      "name": "AIRENE by Virtuals",
+      "symbol": "AIRENE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52705/large/IMG_0040.png?1734056757"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xed899bfdb28c8ad65307fa40f4acab113ae2e14c",
-      "name": "Roost",
-      "symbol": "ROOST",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36458/large/roost.jpeg?1711493580"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8853f0c059c27527d33d02378e5e4f6d5afb574a",
-      "name": "AI INU",
-      "symbol": "AIINU",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36902/large/aiinu.png?1712699681"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x24cb2b89844604c57350776d81e14765d03b91de",
-      "name": "Zunami ETH",
-      "symbol": "ZUNETH",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37835/large/zunETH_200x200.png?1715741123"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x91273b316240879fd902c0c3fcf7c0158777b42f",
-      "name": "Olyn by Virtuals",
-      "symbol": "OLYN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52167/large/olyn.jpg?1732682477"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x637ca2cfa168f97caf0730d6c6012c10f49839fa",
-      "name": "Game Money",
-      "symbol": "GM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52746/large/200.png?1734316320"
+      "logoURI": "https://assets.coingecko.com/coins/images/51485/large/airene_icon_1to1.png?1731405207"
     },
     {
       "chainId": 8453,
@@ -3308,35 +3236,43 @@
     },
     {
       "chainId": 8453,
+      "address": "0x6a27cd26a373530835b9fe7ac472b3e080070f64",
+      "name": "BlockAI",
+      "symbol": "BAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39638/large/logo-200x200-transparent-bg.png?1723278224"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xed899bfdb28c8ad65307fa40f4acab113ae2e14c",
+      "name": "Roost",
+      "symbol": "ROOST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36458/large/roost.jpeg?1711493580"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x24cb2b89844604c57350776d81e14765d03b91de",
+      "name": "Zunami ETH",
+      "symbol": "ZUNETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37835/large/zunETH_200x200.png?1715741123"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xba5ed8a0e261bf2a5ad629d4d5de884ccbfdf3f7",
+      "name": "Just a based guy",
+      "symbol": "BASEDGUY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52705/large/IMG_0040.png?1734056757"
+    },
+    {
+      "chainId": 8453,
       "address": "0x686b1209b2de12818aa69dd139530448d0c792b3",
       "name": "Poopcoin",
       "symbol": "POOP",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/36549/large/poopcoin.png?1711876394"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf2c862ba9edba3579dd8b37389deea0528c625c2",
-      "name": "Warpie",
-      "symbol": "WARPIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37005/large/Warpie_Logo_transparent__%28200_x_200_px%29.png?1713071864"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x78a087d713be963bf307b18f2ff8122ef9a63ae9",
-      "name": "BaseSwap",
-      "symbol": "BSWAP",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31245/large/Baseswap_LogoNew.jpg?1696530070"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xe8aae6251c6cf39927b0ff31399030c60bec798f",
-      "name": "SUMI",
-      "symbol": "SUMI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51253/large/SUMI.jpg?1730477794"
     },
     {
       "chainId": 8453,
@@ -3348,67 +3284,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0xe13e40e8fdb815fbc4a1e2133ab5588c33bac45d",
-      "name": "TRIBAL",
-      "symbol": "TRIBAL",
+      "address": "0xe8aae6251c6cf39927b0ff31399030c60bec798f",
+      "name": "SUMI",
+      "symbol": "SUMI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38531/large/7pc8ov67182ddpbqjnff20ik4oye.png?1733194448"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x698b49063c14d2753d23064ff891a876cffa6fb5",
-      "name": "NIKITA by Virtuals",
-      "symbol": "NIKITA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52146/large/NikitaNewPP.png?1734294864"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xefb97aaf77993922ac4be4da8fbc9a2425322677",
-      "name": "Web 3 Dollar",
-      "symbol": "USD3",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38073/large/usd3%28200_x_200_px%29.png?1716449060"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd5b9ddb04f20ea773c9b56607250149b26049b1f",
-      "name": "Zunami USD",
-      "symbol": "ZUNUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37809/large/zunUSD_200x200.png?1715591997"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf5f2a79eeccf6e7f4c570c803f529930e29cc96b",
-      "name": "CertaiK by Virtuals",
-      "symbol": "CERTAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52488/large/download.jpeg?1733432223"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
-      "name": "Equalizer  BASE ",
-      "symbol": "SCALE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32221/large/SCALE_icon_200x200.png?1696835640"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x63cb9a22cbc00bf9159429e9dede4b88c3dba8ce",
-      "name": "LaunchTokenBot",
-      "symbol": "CAPO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52234/large/f22a0bcbbfa4da6930bf8c1d37c2e0a0.jpeg?1732804814"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xc2bc7a73613b9bd5f373fe10b55c59a69f4d617b",
-      "name": "DackieSwap",
-      "symbol": "DACKIE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30752/large/dackieswap_large.png?1707290196"
+      "logoURI": "https://assets.coingecko.com/coins/images/51253/large/SUMI.jpg?1730477794"
     },
     {
       "chainId": 8453,
@@ -3420,11 +3300,131 @@
     },
     {
       "chainId": 8453,
-      "address": "0x3816dd4bd44c8830c2fa020a5605bac72fa3de7a",
-      "name": "Presearch",
-      "symbol": "PRE",
+      "address": "0x0028e1e60167b48a938b785aa5292917e7eaca8b",
+      "name": "Coinye West",
+      "symbol": "COINYE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/1299/large/presearch.png?1696502369"
+      "logoURI": "https://assets.coingecko.com/coins/images/36403/large/Coinye_West.png?1711369153"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x474f4cb764df9da079d94052fed39625c147c12c",
+      "name": "Bonsai Token",
+      "symbol": "BONSAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35884/large/Bonsai_BW_Coingecko-200x200.jpg?1710071621"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xefb97aaf77993922ac4be4da8fbc9a2425322677",
+      "name": "Web 3 Dollar",
+      "symbol": "USD3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38073/large/usd3%28200_x_200_px%29.png?1716449060"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x63cb9a22cbc00bf9159429e9dede4b88c3dba8ce",
+      "name": "LaunchTokenBot",
+      "symbol": "CAPO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52234/large/f22a0bcbbfa4da6930bf8c1d37c2e0a0.jpeg?1732804814"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x478e03d45716dda94f6dbc15a633b0d90c237e2f",
+      "name": "Shaka",
+      "symbol": "SHAKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36850/large/sharetheshaka.png?1712585688"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc2bc7a73613b9bd5f373fe10b55c59a69f4d617b",
+      "name": "DackieSwap",
+      "symbol": "DACKIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30752/large/dackieswap_large.png?1707290196"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x78a087d713be963bf307b18f2ff8122ef9a63ae9",
+      "name": "BaseSwap",
+      "symbol": "BSWAP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31245/large/Baseswap_LogoNew.jpg?1696530070"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x91273b316240879fd902c0c3fcf7c0158777b42f",
+      "name": "Olyn by Virtuals",
+      "symbol": "OLYN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52167/large/olyn.jpg?1732682477"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf2c862ba9edba3579dd8b37389deea0528c625c2",
+      "name": "Warpie",
+      "symbol": "WARPIE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37005/large/Warpie_Logo_transparent__%28200_x_200_px%29.png?1713071864"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf34e0cff046e154cafcae502c7541b9e5fd8c249",
+      "name": "Thales",
+      "symbol": "THALES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18388/large/CLVZJN_C_400x400.png?1696517879"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x628c5ba9b775dacecd14e237130c537f497d1cc7",
+      "name": "Jaderoll",
+      "symbol": "JADE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38926/large/Asset_2_3x.png?1719542614"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x39fed555ff57cb1154bfa6b1a2492bb914ce2d9b",
+      "name": "EchoLeaks by Virtuals",
+      "symbol": "ECHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52172/large/echoleaks.jpg?1732683705"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x99298c6be0e8ec9e56b7a2be5850abe1fc109d94",
+      "name": "Degen Capital by Virtuals",
+      "symbol": "DEGENC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52246/large/Degenc_with_Pnut_Logo.png?1733992482"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf5f2a79eeccf6e7f4c570c803f529930e29cc96b",
+      "name": "CertaiK by Virtuals",
+      "symbol": "CERTAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52488/large/download.jpeg?1733432223"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c281a39944a2319aa653d81cfd93ca10983d234",
+      "name": "Build",
+      "symbol": "BUILD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37836/large/buildlogo.png?1715741487"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x88faea256f789f8dd50de54f9c807eef24f71b16",
+      "name": "Landwolf",
+      "symbol": "WOLF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36803/large/IMG_8678.jpeg?1712469842"
     },
     {
       "chainId": 8453,
@@ -3444,14 +3444,6 @@
     },
     {
       "chainId": 8453,
-      "address": "0x3c281a39944a2319aa653d81cfd93ca10983d234",
-      "name": "Build",
-      "symbol": "BUILD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37836/large/buildlogo.png?1715741487"
-    },
-    {
-      "chainId": 8453,
       "address": "0x9a6d24c02ec35ad970287ee8296d4d6552a31dbe",
       "name": "OPEN Ticketing Ecosystem",
       "symbol": "OPN",
@@ -3460,83 +3452,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x88faea256f789f8dd50de54f9c807eef24f71b16",
-      "name": "Landwolf",
-      "symbol": "WOLF",
+      "address": "0xd5b9ddb04f20ea773c9b56607250149b26049b1f",
+      "name": "Zunami USD",
+      "symbol": "ZUNUSD",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36803/large/IMG_8678.jpeg?1712469842"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x3c4b6cd7874edc945797123fce2d9a871818524b",
-      "name": "PARADOX",
-      "symbol": "PARADOX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51590/large/IMG_1408.jpeg?1731570502"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb56d0839998fd79efcd15c27cf966250aa58d6d3",
-      "name": "Based USA",
-      "symbol": "USA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37981/large/BASE_USA_200px.png?1716203776"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfc60aa1ffca50ce08b3cdec9626c0bb9e9b09bec",
-      "name": "Envision Labs",
-      "symbol": "VIS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37142/large/Envision_Logo.png?1713421742"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x8a638ea79f71f3b91bdc96bbdf9fb27c93013d60",
-      "name": "Baby Tiger",
-      "symbol": "BBT",
-      "decimals": 5,
-      "logoURI": "https://assets.coingecko.com/coins/images/51933/large/BBT_%282%29_%281%29.png?1732205350"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd1db4851bcf5b41442caa32025ce0afe6b8eabc2",
-      "name": "Zoomer",
-      "symbol": "ZOOMER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30894/large/zoooooooooomer.jpg?1696529740"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf1143f3a8d76f1ca740d29d5671d365f66c44ed1",
-      "name": "Wrapped Bitcoin  Universal ",
-      "symbol": "UBTC",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50252/large/UA-BTC_1.png?1726721793"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x23471e7250bcd7ee21df3f39ed6151931d1e076b",
-      "name": "AI Waifu",
-      "symbol": "WAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50441/large/Logo.png?1727768050"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfb18511f1590a494360069f3640c27d55c2b5290",
-      "name": "Wild Goat Coin",
-      "symbol": "WGC",
-      "decimals": 6,
-      "logoURI": "https://assets.coingecko.com/coins/images/37966/large/COIN_200x200.png?1716778831"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x92af6f53febd6b4c6f5293840b6076a1b82c4bc2",
-      "name": "Bird Dog on Base",
-      "symbol": "BIRDDOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38437/large/birddog_logo_sticker_200x200_final_%281%29.png?1719953537"
+      "logoURI": "https://assets.coingecko.com/coins/images/37809/large/zunUSD_200x200.png?1715591997"
     },
     {
       "chainId": 8453,
@@ -3548,75 +3468,43 @@
     },
     {
       "chainId": 8453,
-      "address": "0xbd4e5c2f8de5065993d29a9794e2b7cefc41437a",
-      "name": "IPOR",
-      "symbol": "IPOR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png?1696527376"
+      "address": "0x8a638ea79f71f3b91bdc96bbdf9fb27c93013d60",
+      "name": "Baby Tiger",
+      "symbol": "BBT",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/51933/large/BBT_%282%29_%281%29.png?1732205350"
     },
     {
       "chainId": 8453,
-      "address": "0x92dc4ab92eb16e781559e612f349916988013d5a",
-      "name": "Agent Zero",
-      "symbol": "WSB",
+      "address": "0xf1143f3a8d76f1ca740d29d5671d365f66c44ed1",
+      "name": "Wrapped Bitcoin  Universal ",
+      "symbol": "UBTC",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51310/large/photo_2024-11-03_07-33-29.jpg?1730643955"
+      "logoURI": "https://assets.coingecko.com/coins/images/50252/large/UA-BTC_1.png?1726721793"
     },
     {
       "chainId": 8453,
-      "address": "0xf5e89006cbeff2dabcfda0def5bf45ebe7f8429f",
-      "name": "Ragdoll",
-      "symbol": "RAGDOLL",
+      "address": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+      "name": "Equalizer  BASE ",
+      "symbol": "SCALE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51848/large/O0_Ds5Ad_400x400.jpg?1732060576"
+      "logoURI": "https://assets.coingecko.com/coins/images/32221/large/SCALE_icon_200x200.png?1696835640"
     },
     {
       "chainId": 8453,
-      "address": "0xc55e93c62874d8100dbd2dfe307edc1036ad5434",
-      "name": "Staked BIFI",
-      "symbol": "MOOBIFI",
+      "address": "0xb56d0839998fd79efcd15c27cf966250aa58d6d3",
+      "name": "Based USA",
+      "symbol": "USA",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/32597/large/319381e63428d3c2ab6e035d5f3abd76.png?1698682355"
+      "logoURI": "https://assets.coingecko.com/coins/images/37981/large/BASE_USA_200px.png?1716203776"
     },
     {
       "chainId": 8453,
-      "address": "0x8216e8143902a8fe0b676006bc25eb23829c123d",
-      "name": "Wow",
-      "symbol": "WOW",
+      "address": "0x3c4b6cd7874edc945797123fce2d9a871818524b",
+      "name": "PARADOX",
+      "symbol": "PARADOX",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51527/large/23bafybeialew5mz6o2d6abynkd7kafunbgcgxcatyjdr5s2mgr4ae4zeltwe_%281%29.jpg?1731497334"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9de16c805a3227b9b92e39a446f9d56cf59fe640",
-      "name": "Bento",
-      "symbol": "BENTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37138/large/logo-bento-200-200.png?1713419221"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x262a9f4e84efa2816d87a68606bb4c1ea3874bf1",
-      "name": "Bangkit",
-      "symbol": "BKIT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52416/large/logo.png?1733309160"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf95e1c0a67492720ca22842122fe7fa63d5519e5",
-      "name": "Lunarlens",
-      "symbol": "LUNARLENS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39304/large/%E6%9C%88%E4%BA%AE%E5%B8%8164.png?1721633565"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcc7ff230365bd730ee4b352cc2492cedac49383e",
-      "name": "High Yield USD  Base ",
-      "symbol": "HYUSD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33636/large/hyusdlogo.png?1702536133"
+      "logoURI": "https://assets.coingecko.com/coins/images/51590/large/IMG_1408.jpeg?1731570502"
     },
     {
       "chainId": 8453,
@@ -3628,19 +3516,51 @@
     },
     {
       "chainId": 8453,
-      "address": "0x7f65323e468939073ef3b5287c73f13951b0ff5b",
-      "name": "Blue",
-      "symbol": "BLUE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51053/large/Blue200p.png?1729873273"
-    },
-    {
-      "chainId": 8453,
       "address": "0x45d9c101a3870ca5024582fd788f4e1e8f7971c3",
       "name": "MASQ",
       "symbol": "MASQ",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/13699/large/masq.png?1696513446"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x474cb5b5087e13ea006e13702e330c93c825ab5d",
+      "name": "Make Fun",
+      "symbol": "MF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51437/large/logo-128.png?1731224206"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8853f0c059c27527d33d02378e5e4f6d5afb574a",
+      "name": "AI INU",
+      "symbol": "AIINU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36902/large/aiinu.png?1712699681"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2f3b1a07e3efb1fcc64bd09b86bd0fa885d93552",
+      "name": "Meridian MST",
+      "symbol": "MST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34343/large/Meridian_Icon.png?1720634198"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x92af6f53febd6b4c6f5293840b6076a1b82c4bc2",
+      "name": "Bird Dog on Base",
+      "symbol": "BIRDDOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38437/large/birddog_logo_sticker_200x200_final_%281%29.png?1719953537"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf5e89006cbeff2dabcfda0def5bf45ebe7f8429f",
+      "name": "Ragdoll",
+      "symbol": "RAGDOLL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51848/large/O0_Ds5Ad_400x400.jpg?1732060576"
     },
     {
       "chainId": 8453,
@@ -3652,107 +3572,43 @@
     },
     {
       "chainId": 8453,
-      "address": "0x8c81b4c816d66d36c4bf348bdec01dbcbc70e987",
-      "name": "Briun Armstrung",
-      "symbol": "BRIUN",
+      "address": "0x6bc40d4099f9057b23af309c08d935b890d7adc0",
+      "name": "SnailBrook",
+      "symbol": "SNAIL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36183/large/200x200.png?1710758416"
+      "logoURI": "https://assets.coingecko.com/coins/images/29922/large/snail.jpeg?1713754058"
     },
     {
       "chainId": 8453,
-      "address": "0xc227717ef4ae4d982e14789eb33ba942243c3fee",
-      "name": "Mozaic",
-      "symbol": "MOZ",
+      "address": "0x92dc4ab92eb16e781559e612f349916988013d5a",
+      "name": "Agent Zero",
+      "symbol": "WSB",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/30100/large/Main_Logo_1-200x200jpg.jpg?1696529024"
+      "logoURI": "https://assets.coingecko.com/coins/images/51310/large/photo_2024-11-03_07-33-29.jpg?1730643955"
     },
     {
       "chainId": 8453,
-      "address": "0xcbfe8e065534d0cc117bd71a11b0249a63e247f7",
-      "name": "FrokAI",
-      "symbol": "FROKAI",
+      "address": "0x9de16c805a3227b9b92e39a446f9d56cf59fe640",
+      "name": "Bento",
+      "symbol": "BENTO",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39050/large/L8noko50_400x400.jpg?1720121982"
+      "logoURI": "https://assets.coingecko.com/coins/images/37138/large/logo-bento-200-200.png?1713419221"
     },
     {
       "chainId": 8453,
-      "address": "0xb755506531786c8ac63b756bab1ac387bacb0c04",
-      "name": "ZARP Stablecoin",
-      "symbol": "ZARP",
+      "address": "0xe13e40e8fdb815fbc4a1e2133ab5588c33bac45d",
+      "name": "TRIBAL",
+      "symbol": "TRIBAL",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/27333/large/zarp_coin.png?1696526381"
+      "logoURI": "https://assets.coingecko.com/coins/images/38531/large/7pc8ov67182ddpbqjnff20ik4oye.png?1733194448"
     },
     {
       "chainId": 8453,
-      "address": "0x698dc45e4f10966f6d1d98e3bfd7071d8144c233",
-      "name": "PEPE 0x69 ON BASE",
-      "symbol": "PEPE",
-      "decimals": 9,
-      "logoURI": "https://assets.coingecko.com/coins/images/37400/large/lOGO.jpg?1714352456"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x80b3455e1db60b4cba46aba12e8b1e256dd64979",
-      "name": "Blue Footed Booby",
-      "symbol": "BOOBY",
+      "address": "0x262a9f4e84efa2816d87a68606bb4c1ea3874bf1",
+      "name": "Bangkit",
+      "symbol": "BKIT",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38859/large/Pfp2200x200.png?1719952590"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf3708859c178709d5319ad5405bc81511b72b9e9",
-      "name": "Aethernet",
-      "symbol": "AETHER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51065/large/Aether_Farcaster_frame.png?1729943869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0c90c756350fb803a7d5d9f9ee5ac29e77369973",
-      "name": "United Base Postal",
-      "symbol": "UBPS",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37638/large/Logo-2-Dex-Tools.png?1715105556"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
-      "name": "Overnight Finance",
-      "symbol": "OVN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/31970/large/OVN.png?1696959174"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2659631cfbe9b1b6dcbc1384a3864509356e7b4d",
-      "name": "RandomDEX",
-      "symbol": "RDX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52766/large/Icon_removed_BG.png?1734268221"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xecaf81eb42cd30014eb44130b89bcd6d4ad98b92",
-      "name": "Based Chad",
-      "symbol": "CHAD",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36285/large/logo_200_200_square.jpg?1712167823"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xf8b1b47aa748f5c7b5d0e80c726a843913eb573a",
-      "name": "LibertAI",
-      "symbol": "LTAI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39288/large/LibertAI_FavIcon_Secondary.png?1721589002"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd652c5425aea2afd5fb142e120fecf79e18fafc3",
-      "name": "PoolTogether",
-      "symbol": "POOL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/14003/large/PoolTogether.png?1696513732"
+      "logoURI": "https://assets.coingecko.com/coins/images/52416/large/logo.png?1733309160"
     },
     {
       "chainId": 8453,
@@ -3764,6 +3620,30 @@
     },
     {
       "chainId": 8453,
+      "address": "0xfb18511f1590a494360069f3640c27d55c2b5290",
+      "name": "Wild Goat Coin",
+      "symbol": "WGC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37966/large/COIN_200x200.png?1716778831"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcc7ff230365bd730ee4b352cc2492cedac49383e",
+      "name": "High Yield USD  Base ",
+      "symbol": "HYUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/33636/large/hyusdlogo.png?1702536133"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2659631cfbe9b1b6dcbc1384a3864509356e7b4d",
+      "name": "RandomDEX",
+      "symbol": "RDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52766/large/Icon_removed_BG.png?1734268221"
+    },
+    {
+      "chainId": 8453,
       "address": "0x29e39327b5b1e500b87fc0fcae3856cd8f96ed2a",
       "name": "Bark Ruffalo by Virtuals",
       "symbol": "PAWSY",
@@ -3772,11 +3652,43 @@
     },
     {
       "chainId": 8453,
-      "address": "0x75e6b648c91d222b2f6318e8ceeed4b691d5323f",
-      "name": "AnonFi",
-      "symbol": "ANON",
+      "address": "0xc227717ef4ae4d982e14789eb33ba942243c3fee",
+      "name": "Mozaic",
+      "symbol": "MOZ",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50446/large/IMG_20240928_164632_277.png?1727771357"
+      "logoURI": "https://assets.coingecko.com/coins/images/30100/large/Main_Logo_1-200x200jpg.jpg?1696529024"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf3708859c178709d5319ad5405bc81511b72b9e9",
+      "name": "Aethernet",
+      "symbol": "AETHER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51065/large/Aether_Farcaster_frame.png?1729943869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x698dc45e4f10966f6d1d98e3bfd7071d8144c233",
+      "name": "PEPE 0x69 ON BASE",
+      "symbol": "PEPE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37400/large/lOGO.jpg?1714352456"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x637ca2cfa168f97caf0730d6c6012c10f49839fa",
+      "name": "Game Money",
+      "symbol": "GM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52746/large/200.png?1734316320"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0c90c756350fb803a7d5d9f9ee5ac29e77369973",
+      "name": "United Base Postal",
+      "symbol": "UBPS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37638/large/Logo-2-Dex-Tools.png?1715105556"
     },
     {
       "chainId": 8453,
@@ -3788,59 +3700,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x4e73420dcc85702ea134d91a262c8ffc0a72aa70",
-      "name": "SKI MASK PUP",
-      "symbol": "SKIPUP",
-      "decimals": 8,
-      "logoURI": "https://assets.coingecko.com/coins/images/38093/large/SkiPup_Logo.png?1716486539"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x41a22eb30df65d6ab0ce0b4cfe8f4e0eb306d471",
-      "name": "BaseBearCute",
-      "symbol": "BBQ",
+      "address": "0x75e6b648c91d222b2f6318e8ceeed4b691d5323f",
+      "name": "AnonFi",
+      "symbol": "ANON",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/40006/large/logo.jpg?1725221317"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2075f6e2147d4ac26036c9b4084f8e28b324397d",
-      "name": "BaseCTO",
-      "symbol": "CTO",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50716/large/IMG_1480.jpeg?1728792869"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x9e53e88dcff56d3062510a745952dec4cefdff9e",
-      "name": "Basic Dog Meme",
-      "symbol": "DOG",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/33749/large/Round_Logo.png?1703245893"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x6bc40d4099f9057b23af309c08d935b890d7adc0",
-      "name": "SnailBrook",
-      "symbol": "SNAIL",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/29922/large/snail.jpeg?1713754058"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb8e564b206032bbcda2c3978bc371da52152f72e",
-      "name": "Base Terminal",
-      "symbol": "BASEX",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50300/large/Base_Terminal_Logo_200x200.png?1727021406"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb0e87796380172f911214208df966a84cceaaf82",
-      "name": "DOM",
-      "symbol": "DOM",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/51723/large/463fac78-dcc9-49cf-879f-b0b1af658295.png?1731903839"
+      "logoURI": "https://assets.coingecko.com/coins/images/50446/large/IMG_20240928_164632_277.png?1727771357"
     },
     {
       "chainId": 8453,
@@ -3852,131 +3716,11 @@
     },
     {
       "chainId": 8453,
-      "address": "0x31b28012f61fc3600e1c076bafc9fd997fb2da90",
-      "name": "Mrs Miggles",
-      "symbol": "MRSMIGGLES",
+      "address": "0x7f65323e468939073ef3b5287c73f13951b0ff5b",
+      "name": "Blue",
+      "symbol": "BLUE",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39282/large/token.png?1722045136"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x7cf7132ede0ca592a236b6198a681bb7b42dd5ae",
-      "name": "BOLT on Base",
-      "symbol": "BOLT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38449/large/wwwww.png?1717557162"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xb3a9bd4861454ba94931ebff410c3d828525dce2",
-      "name": "WoofWork io",
-      "symbol": "WOOF",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28903/large/WWlogoTransparent_200x200.png?1696527879"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xde7a416ac821c77478340eebaa21b68297025ef3",
-      "name": "Beni",
-      "symbol": "BENI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36691/large/Logo_Image_Beni_Uodate.png?1732385556"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0028e1e60167b48a938b785aa5292917e7eaca8b",
-      "name": "Coinye West",
-      "symbol": "COINYE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36403/large/Coinye_West.png?1711369153"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xa617c0c739845b2941bd8edd05c9f993ecc97c18",
-      "name": "GAMER",
-      "symbol": "GMR",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/21288/large/ezgif-1-7f6a016717.jpg?1696520658"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xd20ab1015f6a2de4a6fddebab270113f689c2f7c",
-      "name": "DeHub",
-      "symbol": "DHB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/18094/large/dehub.PNG?1696517599"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xfea9dcdc9e23a9068bf557ad5b186675c61d33ea",
-      "name": "Based Shiba Inu",
-      "symbol": "BSHIB",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/36092/large/logocg.png?1710478223"
-    },
-    {
-      "chainId": 8453,
-      "address": "0xcba6fabf7df8ada1995d1f57acaf520198289ca9",
-      "name": "BeromesButt",
-      "symbol": "BUTT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52419/large/BUTT_Logo.jpg?1733326535"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x13f4196cc779275888440b3000ae533bbbbc3166",
-      "name": "Alongside Crypto Market Index",
-      "symbol": "AMKT",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/28496/large/22999.png?1696527488"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1db0fc8933f545648b54a9ee4326209a9a259643",
-      "name": "Zunami Governance Token",
-      "symbol": "ZUN",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38298/large/ZUN_200x200.png?1717194404"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x0718f45bbf4781ce891e4e18182f025725f0fc95",
-      "name": "Misser",
-      "symbol": "MISSER",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39315/large/misser_pic.png?1721707572"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x72499bddb67f4ca150e1f522ca82c87bc9fb18c8",
-      "name": "Bonk On Base",
-      "symbol": "BONK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/37123/large/200x200.png?1713367524"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x2dc90fa3a0f178ba4bee16cac5d6c9a5a7b4c6cb",
-      "name": "DRINK",
-      "symbol": "DRINK",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/50167/large/2N1fxgBw_400x400.jpg?1726136925"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x49c86046903807d0a3193a221c1a3e1b1b6c9ba3",
-      "name": "CYI by Virtuals",
-      "symbol": "CYI",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/52125/large/Cryptoyieldinfo.jpg?1732611368"
-    },
-    {
-      "chainId": 8453,
-      "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
-      "name": "Aura Finance",
-      "symbol": "AURA",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/25942/large/logo.png?1696525021"
+      "logoURI": "https://assets.coingecko.com/coins/images/51053/large/Blue200p.png?1729873273"
     },
     {
       "chainId": 8453,
@@ -3988,6 +3732,214 @@
     },
     {
       "chainId": 8453,
+      "address": "0x3c8665472ec5af30981b06b4e0143663ebedcc1e",
+      "name": "YieldWard",
+      "symbol": "WARP",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/37952/large/logo_%283%29.png?1716271202"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8c81b4c816d66d36c4bf348bdec01dbcbc70e987",
+      "name": "Briun Armstrung",
+      "symbol": "BRIUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36183/large/200x200.png?1710758416"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb755506531786c8ac63b756bab1ac387bacb0c04",
+      "name": "ZARP Stablecoin",
+      "symbol": "ZARP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27333/large/zarp_coin.png?1696526381"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x45e7eaedb8e3360f850c963c5419a5236e451217",
+      "name": "Satoshi Nakamoto",
+      "symbol": "SATOSHI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/37611/large/SATOSHI_LOGO.PNG?1715054986"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2075f6e2147d4ac26036c9b4084f8e28b324397d",
+      "name": "BaseCTO",
+      "symbol": "CTO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50716/large/IMG_1480.jpeg?1728792869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xecaf81eb42cd30014eb44130b89bcd6d4ad98b92",
+      "name": "Based Chad",
+      "symbol": "CHAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36285/large/logo_200_200_square.jpg?1712167823"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4e73420dcc85702ea134d91a262c8ffc0a72aa70",
+      "name": "SKI MASK PUP",
+      "symbol": "SKIPUP",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/38093/large/SkiPup_Logo.png?1716486539"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb3a9bd4861454ba94931ebff410c3d828525dce2",
+      "name": "WoofWork io",
+      "symbol": "WOOF",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28903/large/WWlogoTransparent_200x200.png?1696527879"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x80b3455e1db60b4cba46aba12e8b1e256dd64979",
+      "name": "Blue Footed Booby",
+      "symbol": "BOOBY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38859/large/Pfp2200x200.png?1719952590"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac27fa800955849d6d17cc8952ba9dd6eaa66187",
+      "name": "UnlockProtocolToken",
+      "symbol": "UP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51457/large/up2.png?1731318758"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa617c0c739845b2941bd8edd05c9f993ecc97c18",
+      "name": "GAMER",
+      "symbol": "GMR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21288/large/ezgif-1-7f6a016717.jpg?1696520658"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb0e87796380172f911214208df966a84cceaaf82",
+      "name": "DOM",
+      "symbol": "DOM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51723/large/463fac78-dcc9-49cf-879f-b0b1af658295.png?1731903839"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1cd38856ee0fdfd65c757e530e3b1de3061008d3",
+      "name": "GROOVE",
+      "symbol": "GROOVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38234/large/WhatsApp_Image_2024-05-25_at_15.01.21.png?1716860760"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc55e93c62874d8100dbd2dfe307edc1036ad5434",
+      "name": "Staked BIFI",
+      "symbol": "MOOBIFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32597/large/319381e63428d3c2ab6e035d5f3abd76.png?1698682355"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac86f3556cbd2b4d800d17adc3a266b500fcb9f5",
+      "name": "Etherisc DIP",
+      "symbol": "DIP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4586/large/dip.png?1696505164"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcbfe8e065534d0cc117bd71a11b0249a63e247f7",
+      "name": "FrokAI",
+      "symbol": "FROKAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39050/large/L8noko50_400x400.jpg?1720121982"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcba6fabf7df8ada1995d1f57acaf520198289ca9",
+      "name": "BeromesButt",
+      "symbol": "BUTT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52419/large/BUTT_Logo.jpg?1733326535"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7cf7132ede0ca592a236b6198a681bb7b42dd5ae",
+      "name": "BOLT on Base",
+      "symbol": "BOLT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38449/large/wwwww.png?1717557162"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfea9dcdc9e23a9068bf557ad5b186675c61d33ea",
+      "name": "Based Shiba Inu",
+      "symbol": "BSHIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36092/large/logocg.png?1710478223"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x72499bddb67f4ca150e1f522ca82c87bc9fb18c8",
+      "name": "Bonk On Base",
+      "symbol": "BONK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37123/large/200x200.png?1713367524"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd20ab1015f6a2de4a6fddebab270113f689c2f7c",
+      "name": "DeHub",
+      "symbol": "DHB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18094/large/dehub.PNG?1696517599"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x08bea95ec37829cbbda9b556f340464d38546160",
+      "name": "BABY DEGEN",
+      "symbol": "BABYDEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/52682/large/462574720_1957025031375537_1819902199019866760_n.png?1734027625"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xbd4e5c2f8de5065993d29a9794e2b7cefc41437a",
+      "name": "IPOR",
+      "symbol": "IPOR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png?1696527376"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1db0fc8933f545648b54a9ee4326209a9a259643",
+      "name": "Zunami Governance Token",
+      "symbol": "ZUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38298/large/ZUN_200x200.png?1717194404"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa3d1a8deb97b111454b294e2324efad13a9d8396",
+      "name": "Overnight Finance",
+      "symbol": "OVN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31970/large/OVN.png?1696959174"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2dc90fa3a0f178ba4bee16cac5d6c9a5a7b4c6cb",
+      "name": "DRINK",
+      "symbol": "DRINK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50167/large/2N1fxgBw_400x400.jpg?1726136925"
+    },
+    {
+      "chainId": 8453,
       "address": "0xa334884bf6b0a066d553d19e507315e839409e62",
       "name": "Ethos Reserve Note",
       "symbol": "ERN",
@@ -3996,20 +3948,68 @@
     },
     {
       "chainId": 8453,
-      "address": "0x6b9bb36519538e0c073894e964e90172e1c0b41f",
-      "name": "WEWECOIN",
-      "symbol": "WEWE",
+      "address": "0xfae89a7966d13195960459e6b483cacb9fe9cfcf",
+      "name": "B Money AKA Brett",
+      "symbol": "BMONEY",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39135/large/wewe_logo.png?1720857800"
+      "logoURI": "https://assets.coingecko.com/coins/images/52529/large/IMG_4246.JPG?1733567836"
     },
     {
       "chainId": 8453,
-      "address": "0xaec9e50e3397f9ddc635c6c429c8c7eca418a143",
-      "name": "Arcana arcUSD",
-      "symbol": "ARCUSD",
+      "address": "0xf8b1b47aa748f5c7b5d0e80c726a843913eb573a",
+      "name": "LibertAI",
+      "symbol": "LTAI",
       "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/38490/large/USDa.png?1717688209"
+      "logoURI": "https://assets.coingecko.com/coins/images/39288/large/LibertAI_FavIcon_Secondary.png?1721589002"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x31b28012f61fc3600e1c076bafc9fd997fb2da90",
+      "name": "Mrs Miggles",
+      "symbol": "MRSMIGGLES",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39282/large/token.png?1722045136"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xde7a416ac821c77478340eebaa21b68297025ef3",
+      "name": "Beni",
+      "symbol": "BENI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36691/large/Logo_Image_Beni_Uodate.png?1732385556"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8f4e4221ba88d4e9bb76ecfb91d7c5ce08d7d5b9",
+      "name": "FU Money",
+      "symbol": "FU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38629/large/FU_logo_black.png?1718170125"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x41a22eb30df65d6ab0ce0b4cfe8f4e0eb306d471",
+      "name": "BaseBearCute",
+      "symbol": "BBQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/40006/large/logo.jpg?1725221317"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x23471e7250bcd7ee21df3f39ed6151931d1e076b",
+      "name": "AI Waifu",
+      "symbol": "WAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50441/large/Logo.png?1727768050"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc2fe011c3885277c7f0e7ffd45ff90cadc8ecd12",
+      "name": "Poncho",
+      "symbol": "PONCHO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36160/large/ponchologo.PNG?1710744293"
     }
   ],
-  "timestamp": "2024-12-17T18:12:41.022Z"
+  "timestamp": "2024-12-17T20:31:05.876Z"
 }


### PR DESCRIPTION
This PR fixes the decimals for `PRO` token with address `0x18dD5B087bCA9920562aFf7A0199b96B9230438b` in Base chain. 

It had 18 decimals, but the contract has 8. See https://basescan.org/token/0x18dD5B087bCA9920562aFf7A0199b96B9230438b

I re-generated the lists too. I will point in the code the most relevant change. The rest is the update of the most trade token lists.


Why it was wrong? I'm not sure, but I think its because the token had the wrong decimals in the Coingecko list we use to load the tokens

https://tokens.coingecko.com/uniswap/all.json