### PR TITLE
feat: merge uni existing list

### DIFF
--- a/src/public/Uniswap.100.json
+++ b/src/public/Uniswap.100.json
@@ -4,8 +4,8 @@
   ],
   "version": {
     "major": 0,
-    "minor": 0,
-    "patch": 1
+    "minor": 1,
+    "patch": 0
   },
   "tokens": [
     {
@@ -127,6 +127,686 @@
       "symbol": "YFI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/11849/large/yearn.jpg?1696511720"
+    },
+    {
+      "chainId": 100,
+      "address": "0x7f7440c5098462f833e123b44b8a03e1d9785bab",
+      "name": "1inch",
+      "symbol": "1INCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028"
+    },
+    {
+      "chainId": 100,
+      "address": "0xdf613af6b44a31299e48131e9347f034347e2f00",
+      "name": "Aave",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
+    },
+    {
+      "chainId": 100,
+      "address": "0x55b6228758fcdb9135db500bc184473ad5fccd98",
+      "name": "agEur",
+      "symbol": "agEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/standard/agEUR.png?1696518915"
+    },
+    {
+      "chainId": 100,
+      "address": "0x4bc97997883c0397f556bd0f9da6fb71da22f9a2",
+      "name": "Aleph im",
+      "symbol": "ALEPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725"
+    },
+    {
+      "chainId": 100,
+      "address": "0x260b0cc1de83e4f8db8361e81acf73d1f597a695",
+      "name": "Amp",
+      "symbol": "AMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1599625397"
+    },
+    {
+      "name": "Aragon",
+      "address": "0x6eeceab954efdbd7a8a8d9387bc719959b04b9ca",
+      "symbol": "ANT",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://assets.coingecko.com/coins/images/681/thumb/JelZ58cv_400x400.png?1601449653"
+    },
+    {
+      "chainId": 100,
+      "address": "0x44b6bba599f100006143e82a60462d71ac1331da",
+      "name": "API3",
+      "symbol": "API3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1606751424"
+    },
+    {
+      "chainId": 100,
+      "address": "0x743a991365ba94bfc90ad0002cad433c7a33cb4a",
+      "name": "AirSwap",
+      "symbol": "AST",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1630903484"
+    },
+    {
+      "chainId": 100,
+      "address": "0x8a95ea379e1fa4c749dd0a7a21377162028c479e",
+      "name": "Audius",
+      "symbol": "AUDIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1603425727"
+    },
+    {
+      "chainId": 100,
+      "address": "0xaf3e09f831dc59c709da1ba20dd0d9602635a6c0",
+      "name": "Axelar",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg"
+    },
+    {
+      "chainId": 100,
+      "address": "0x0987c6b9357dee87404dfea0483c337de530be5a",
+      "name": "Axie Infinity",
+      "symbol": "AXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082"
+    },
+    {
+      "chainId": 100,
+      "address": "0xe154a435408211ac89757b76c4fbe4dc9ed2ef27",
+      "name": "Band Protocol",
+      "symbol": "BAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/band-protocol.png?1568730326"
+    },
+    {
+      "chainId": 100,
+      "address": "0xc6cc63f4aa25bbd4453eb5f3a0dfe546fef9b2f3",
+      "name": "Basic Attention Token",
+      "symbol": "BAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427"
+    },
+    {
+      "name": "Bancor Network Token",
+      "address": "0x9a495a281d959192343b0e007284bf130bd05f86",
+      "symbol": "BNT",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0xb31a2595e4cf66efbc1fe348b1429e5730891382",
+      "name": "BarnBridge",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853"
+    },
+    {
+      "chainId": 100,
+      "address": "0xd5fe5f651dde69f6fc444d123f2c0cfb804542cd",
+      "name": "Binance USD",
+      "symbol": "BUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766"
+    },
+    {
+      "chainId": 100,
+      "address": "0xe0cf6c7ed5ca334bd39f86366defbc3fc6dbbcab",
+      "name": "Coinbase Wrapped Staked ETH",
+      "symbol": "cbETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0x248c54b3fc3bc8b20d0cdee059e17c67e4a3299d",
+      "name": "Celer Network",
+      "symbol": "CELR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437"
+    },
+    {
+      "name": "Compound",
+      "address": "0xdf6ff92bfdc1e8be45177dc1f4845d391d3ad8fd",
+      "symbol": "COMP",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0x62d963c32cf49215948e2855529790e7f41bda71",
+      "name": "Circuits of Value",
+      "symbol": "COVAL",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/588/thumb/coval-logo.png?1599493950"
+    },
+    {
+      "name": "Curve DAO Token",
+      "address": "0x712b3d230f3c1c19db860d80619288b1f0bdd0bd",
+      "symbol": "CRV",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+    },
+    {
+      "name": "Dai Stablecoin",
+      "address": "0x44fa8e6f47987339850636f88629646662444217",
+      "symbol": "DAI",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0xa83eca53705f21a99e9de9eedddf2d1d9a5593c4",
+      "name": "district0x",
+      "symbol": "DNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/849/thumb/district0x.png?1547223762"
+    },
+    {
+      "chainId": 100,
+      "address": "0x5a757f0bcadfdb78651b7bdbe67e44e8fd7f7f6b",
+      "name": "Enjin Coin",
+      "symbol": "ENJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078"
+    },
+    {
+      "chainId": 100,
+      "address": "0x012e2cafebc30a603c049159d946c9d344d979a8",
+      "name": "Ethereum Name Service",
+      "symbol": "ENS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140"
+    },
+    {
+      "chainId": 100,
+      "address": "0x54e4cb2a4fa0ee46e3d9a98d13bea119666e09f6",
+      "name": "Euro Coin",
+      "symbol": "EUROC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro-coin.png?1655394420"
+    },
+    {
+      "chainId": 100,
+      "address": "0x679922d1edca00d2f41ec9aeb023ccc1d58d045f",
+      "name": "Ampleforth Governance Token",
+      "symbol": "FORTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1619020835"
+    },
+    {
+      "chainId": 100,
+      "address": "0xca5d82e40081f220d59f7ed9e2e1428deaf55355",
+      "name": "Frax",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506"
+    },
+    {
+      "chainId": 100,
+      "address": "0xeefea398213938ba56b1c5d282187862c9ca5d0d",
+      "name": "Fantom",
+      "symbol": "FTM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016"
+    },
+    {
+      "chainId": 100,
+      "address": "0xfadc59d012ba3c110b08a15b7755a5cb7cbe77d7",
+      "name": "The Graph",
+      "symbol": "GRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566"
+    },
+    {
+      "chainId": 100,
+      "address": "0x2853f6e9605419ccf38d102fb1fb3961904ae263",
+      "name": "Gitcoin",
+      "symbol": "GTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929"
+    },
+    {
+      "chainId": 100,
+      "name": "Index Cooperative",
+      "symbol": "INDEX",
+      "logoURI": "https://assets.coingecko.com/coins/images/12729/thumb/index.png?1634894321",
+      "address": "0x6052245ec516d0f653794052d24efca8a39fcbc3",
+      "decimals": 18
+    },
+    {
+      "chainId": 100,
+      "address": "0xe73d646157765f8b8b8f28506df0c99178256fb9",
+      "name": "Injective",
+      "symbol": "INJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237"
+    },
+    {
+      "chainId": 100,
+      "address": "0xfcb0320d0ce08536a58495b75bf4262e4acc04af",
+      "name": "JasmyCoin",
+      "symbol": "JASMY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1612473259"
+    },
+    {
+      "chainId": 100,
+      "address": "0x1509465afbd36c09b2f6501bcc1384a12ef22d66",
+      "name": "Keep Network",
+      "symbol": "KEEP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg?1589526336"
+    },
+    {
+      "name": "Kyber Network Crystal",
+      "address": "0x1534fb3e82849314360c267fe20df3901a2ed3f9",
+      "symbol": "KNC",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0x5b449ea0e550c143074146abc89a6328d9e70798",
+      "name": "Keep3rV1",
+      "symbol": "KP3R",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1607057458"
+    },
+    {
+      "chainId": 100,
+      "address": "0x96e334926454cd4b7b4efb8a8fcb650a738ad244",
+      "name": "Lido DAO",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644"
+    },
+    {
+      "chainId": 100,
+      "address": "0x7db0be7a41b5395268e065776e800e27181c81ab",
+      "name": "Livepeer",
+      "symbol": "LPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365"
+    },
+    {
+      "name": "LoopringCoin V2",
+      "address": "0x2be73bfeec620aa9b67535a4d3827bb1e29436d1",
+      "symbol": "LRC",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0x7838796b6802b18d7ef58fc8b757705d6c9d12b3",
+      "name": "Decentraland",
+      "symbol": "MANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745"
+    },
+    {
+      "chainId": 100,
+      "address": "0x4e1a2bffe81000f7be4807faf0315173c817d6f4",
+      "name": "Mask Network",
+      "symbol": "MASK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316"
+    },
+    {
+      "chainId": 100,
+      "name": "MATH",
+      "symbol": "MATH",
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590",
+      "address": "0xaf4d17a2077e1de12de66a44de1b4f14c120d32d",
+      "decimals": 18
+    },
+    {
+      "chainId": 100,
+      "address": "0x7122d7661c4564b7c6cd4878b06766489a6028a2",
+      "name": "Polygon",
+      "symbol": "MATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+    },
+    {
+      "chainId": 100,
+      "address": "0x1326f053e2452e73c66f38914fb338c8de331684",
+      "name": "Mirror Protocol",
+      "symbol": "MIR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13295/thumb/mirror_logo_transparent.png?1611554658"
+    },
+    {
+      "name": "Maker",
+      "address": "0x5fd896d248fbfa54d26855c267859eb1b4daee72",
+      "symbol": "MKR",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0xf0dd817ff483535f4059781441596aea4f32a4b9",
+      "name": "Melon",
+      "symbol": "MLN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295"
+    },
+    {
+      "chainId": 100,
+      "address": "0x7300aafc0ef0d47daeb850f8b6a1931b40acab33",
+      "name": "mStable USD",
+      "symbol": "MUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11576/thumb/mStable_USD.png?1595591803"
+    },
+    {
+      "chainId": 100,
+      "name": "Muse DAO",
+      "symbol": "MUSE",
+      "logoURI": "https://assets.coingecko.com/coins/images/13230/thumb/muse_logo.png?1606460453",
+      "address": "0x7671cbe4320c0772c00b5ce157ac94b936cb083f",
+      "decimals": 18
+    },
+    {
+      "name": "Numeraire",
+      "address": "0x0b7a1c1a3d314dcc271ea576da400b24e9ad3094",
+      "symbol": "NMR",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0x60e663eb97bd747566bad4fb736ddc671fabbe95",
+      "name": "NuCypher",
+      "symbol": "NU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3318/thumb/photo1198982838879365035.jpg?1547037916"
+    },
+    {
+      "chainId": 100,
+      "address": "0x51732a6fc4673d1acca4c047f5465922716508ad",
+      "name": "Ocean Protocol",
+      "symbol": "OCEAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686"
+    },
+    {
+      "chainId": 100,
+      "address": "0x8395f7123ba3ffad52e7414433d825931c81c879",
+      "name": "OMG Network",
+      "symbol": "OMG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1591167168"
+    },
+    {
+      "chainId": 100,
+      "address": "0x3e76f9caaf9b47089810b4579c598228735e7a11",
+      "name": "PAX Gold",
+      "symbol": "PAXG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxg.PNG?1568542565"
+    },
+    {
+      "chainId": 100,
+      "address": "0x75481a953a4bba6b3c445907db403e4b5d222174",
+      "name": "Polkastarter",
+      "symbol": "POLS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702"
+    },
+    {
+      "chainId": 100,
+      "address": "0xd7a28aa9c470e7e9d8c676bcd5dd2f40c5683afa",
+      "name": "Rai Reflex Index",
+      "symbol": "RAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334"
+    },
+    {
+      "chainId": 100,
+      "address": "0xb4698f7fc287eef3e70a6206110d5c4a367a0e59",
+      "name": "SuperRare",
+      "symbol": "RARE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17753/thumb/RARE.jpg?1629220534"
+    },
+    {
+      "chainId": 100,
+      "address": "0x4be85acc1cd711f403dc7bde9e6cadfc5a94744b",
+      "name": "Rarible",
+      "symbol": "RARI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953"
+    },
+    {
+      "name": "Republic Token",
+      "address": "0x0da1a02cdf84c44021671d183d616925164e08aa",
+      "symbol": "REN",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png"
+    },
+    {
+      "name": "Reputation Augur v1",
+      "address": "0x874623a3e613b43efa4dcc2cb04a03da1442db6c",
+      "symbol": "REP",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0x417ae38b3053a736b4274aed8dbd1a8a6fdbc974",
+      "name": "Rari Governance Token",
+      "symbol": "RGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014"
+    },
+    {
+      "chainId": 100,
+      "address": "0x60e668f54106222adc1da80c169281b3355b8e5d",
+      "name": "iExec RLC",
+      "symbol": "RLC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1604543202"
+    },
+    {
+      "chainId": 100,
+      "address": "0x91c22f57df810d541239fbb262afb36cef2814c5",
+      "name": "Rally",
+      "symbol": "RLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12843/thumb/image.png?1611212077"
+    },
+    {
+      "chainId": 100,
+      "name": "Rook",
+      "symbol": "ROOK",
+      "logoURI": "https://assets.coingecko.com/coins/images/13005/thumb/keeper_dao_logo.jpg?1604316506",
+      "address": "0x03959ac65e621e8c95d5e0f75ea96e5c03a15009",
+      "decimals": 18
+    },
+    {
+      "chainId": 100,
+      "address": "0x4ea1172f4c4e8e8d3c9e1be4269b696bf19d24fe",
+      "name": "Shiba Inu",
+      "symbol": "SHIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446"
+    },
+    {
+      "chainId": 100,
+      "address": "0xe7f0cfc2043b8872f35dbef4ebf6eea41a8b2bbe",
+      "name": "SKALE",
+      "symbol": "SKL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13245/thumb/SKALE_token_300x300.png?1606789574"
+    },
+    {
+      "chainId": 100,
+      "address": "0x044f6ae3aef34fdb8fddc7c05f9cc17f19acd516",
+      "name": "Status",
+      "symbol": "SNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1548610778"
+    },
+    {
+      "name": "Synthetix Network Token",
+      "address": "0x3a00e08544d589e19a8e7d97d0294331341cdbf6",
+      "symbol": "SNX",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0x35f346cb4149746272974a92d719fd48ae2f72fa",
+      "name": "Unisocks",
+      "symbol": "SOCKS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10717/thumb/qFrcoiM.png?1582525244"
+    },
+    {
+      "name": "Storj Token",
+      "address": "0xbc650b9cc12db4da14b2417c60ccd6f4d77c3998",
+      "symbol": "STORJ",
+      "decimals": 8,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png"
+    },
+    {
+      "chainId": 100,
+      "address": "0x7e40559c80e0512e75fba5e0ce80fc4d54174bb4",
+      "name": "SUKU",
+      "symbol": "SUKU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/UmfW5S6f_400x400.jpg?1596602238"
+    },
+    {
+      "name": "Synth sUSD",
+      "address": "0xb1950fb2c9c0cbc8553578c67db52aa110a93393",
+      "symbol": "sUSD",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765"
+    },
+    {
+      "chainId": 100,
+      "address": "0x2995d1317dcd4f0ab89f4ae60f3f020a4f17c7ce",
+      "name": "Sushi",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688"
+    },
+    {
+      "chainId": 100,
+      "name": "Swipe",
+      "symbol": "SXP",
+      "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1566792311",
+      "address": "0x7cc4d60a3c83e91d8c2ec2127a10bab5c6ab209d",
+      "decimals": 18
+    },
+    {
+      "chainId": 100,
+      "address": "0xeddd81e0792e764501aae206eb432399a0268db5",
+      "name": "OriginTrail",
+      "symbol": "TRAC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1635134367"
+    },
+    {
+      "chainId": 100,
+      "address": "0x4384a7c9498f905e433ee06b6552a18e1d7cd3a4",
+      "name": "TrueFi",
+      "symbol": "TRU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1617610941"
+    },
+    {
+      "chainId": 100,
+      "name": "The Virtua Kolect",
+      "symbol": "TVK",
+      "logoURI": "https://assets.coingecko.com/coins/images/13330/thumb/virtua_original.png?1656043619",
+      "address": "0xeb2bcabb0cdc099978a74cfe4ab4d45e7e677a45",
+      "decimals": 18
+    },
+    {
+      "name": "UMA Voting Token v1",
+      "address": "0x5806212bec491beb309e3f5c1f911eac6f24cd6b",
+      "symbol": "UMA",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+    },
+    {
+      "name": "USDCoin",
+      "address": "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+      "symbol": "USDC",
+      "decimals": 6,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "name": "Tether USD",
+      "address": "0x4ecaba5870353805a9f068101a40e0f32ed605c6",
+      "symbol": "USDT",
+      "decimals": 6,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "name": "Wrapped BTC",
+      "address": "0x8e5bbbb09ed1ebde8674cda39a0c169401db4252",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+    },
+    {
+      "name": "Wrapped Ether",
+      "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
+      "symbol": "WETH",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 100,
+      "name": "WOO Network",
+      "symbol": "WOO",
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367",
+      "address": "0x0e9f346de9780fb966eeb763aa89d254d606b9d8",
+      "decimals": 18
+    },
+    {
+      "chainId": 100,
+      "address": "0xfd4e5f45ea24ec50c4db4367380b014875caf219",
+      "name": "XYO Network",
+      "symbol": "XYO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819"
+    },
+    {
+      "name": "0x Protocol Token",
+      "address": "0x226bcf0e417428a25012d0fa2183d37f92bcedf6",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
     }
   ],
   "name": "Uniswap on Gnosis chain",

--- a/src/public/Uniswap.42161.json
+++ b/src/public/Uniswap.42161.json
@@ -4,8 +4,8 @@
   ],
   "version": {
     "major": 0,
-    "minor": 0,
-    "patch": 1
+    "minor": 1,
+    "patch": 0
   },
   "tokens": [
     {
@@ -2519,6 +2519,233 @@
       "symbol": "TBTC",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+      "name": "USDe",
+      "symbol": "USDe",
+      "decimals": 18,
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/usde.svg"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3d9907f9a368ad0a51be60f7da3b97cf940982d8",
+      "name": "Camelot token",
+      "symbol": "GRAIL",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x3d9907f9a368ad0a51be60f7da3b97cf940982d8/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0c880f6761f1af8d9aa9c466984b80dab9a8c9e8",
+      "name": "Pendle",
+      "symbol": "PENDLE",
+      "decimals": 18
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+      "name": "Wrapped liquid staked Ether 2.0",
+      "symbol": "wstETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x5979d7b546e38e414f7e9822514be443a4800529/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x431402e8b9dE9aa016C743880e04E517074D8cEC",
+      "name": "Hegic",
+      "symbol": "HEGIC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x431402e8b9de9aa016c743880e04e517074d8cec/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3082cc23568ea640225c2467653db90e9250aaa0",
+      "name": "Radiant",
+      "symbol": "RDNT",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x3082cc23568ea640225c2467653db90e9250aaa0/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8",
+      "name": "Rocket Pool ETH",
+      "symbol": "rETH",
+      "decimals": 18
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35751007a407ca6feffe80b3cb397736d2cf4dbe",
+      "name": "Wrapped eETH",
+      "symbol": "weETH",
+      "decimals": 18,
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/weeth.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2416092f143378750bb29b79ed961ab195cceea5",
+      "name": "Renzo Restaked ETH",
+      "symbol": "ezETH",
+      "decimals": 18,
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/ezeth.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4186bfc76e2e237523cbc30fd220fe055156b41f",
+      "name": "KelpDao Restaked ETH",
+      "symbol": "rsETH",
+      "decimals": 18
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd56734d7f9979dd94fae3d67c7e928234e71cd4c",
+      "name": "TIA",
+      "symbol": "TIA.n",
+      "decimals": 6,
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/tia.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x178412e79c25968a32e89b11f63b33f733770c2a",
+      "name": "Frax Ether",
+      "symbol": "frxETH",
+      "decimals": 18
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
+      "name": "Ankr Staked ETH",
+      "symbol": "ankrETH",
+      "decimals": 18
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb766039cc6db368759c1e56b79affe831d0cc507",
+      "name": "Rocket Pool",
+      "symbol": "RPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2090/thumb/rocket_pool_%28RPL%29.png?1696503058"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51fC0f6660482Ea73330E414eFd7808811a57Fa2",
+      "name": "Premia",
+      "symbol": "PREMIA",
+      "decimals": 18,
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/premia.jpg"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
+      "name": "Gyro Dollar",
+      "symbol": "GYD",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0xca5d8f8a8d49439357d3cf46ca2e720702f132b8/logo.png/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6",
+      "name": "Dola USD Stablecoin",
+      "symbol": "DOLA",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x6a7661795c374c0bfc635934efaddff3a7ee23b6/logo.png/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xed7f000eE335B8199b004cCA1c6f36d188CF6cb8",
+      "name": "D2",
+      "symbol": "D2",
+      "decimals": 18,
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/d2.jpg"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x18c11fd286c5ec11c3b683caa813b77f5163a122",
+      "name": "Gains Network",
+      "symbol": "GNS",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x18c11fd286c5ec11c3b683caa813b77f5163a122/logo.png/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8b0e6f19ee57089f7649a455d89d7bc6314d04e8",
+      "name": "DMT",
+      "symbol": "DMT",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x8b0e6f19ee57089f7649a455d89d7bc6314d04e8/logo.png/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x88a269df8fe7f53e590c561954c52fccc8ec0cfb",
+      "name": "Ninja Squad Token",
+      "symbol": "NST",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x88a269df8fe7f53e590c561954c52fccc8ec0cfb/logo.png/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x00cbcf7b3d37844e44b888bc747bdd75fcf4e555",
+      "name": "xPet.tech Token",
+      "symbol": "XPET",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x00cbcf7b3d37844e44b888bc747bdd75fcf4e555/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6dd963c510c2d2f09d5eddb48ede45fed063eb36",
+      "name": "Factor",
+      "symbol": "FCTR",
+      "decimals": 18,
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/fctr.jpg"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2Ac2B254Bc18cD4999f64773a966E4f4869c34Ee",
+      "name": "Penpie Token",
+      "symbol": "PNP",
+      "decimals": 18,
+      "logoURI": "https://ipfs.io/ipfs/QmQHcvw2CXmdTvjcuwrH1HtPdfDTQ4WaCY2gG4RCFtQuwd/pnp.jpg"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4cfa50b7ce747e2d61724fcac57f24b748ff2b2a",
+      "name": "Fluid USDC",
+      "symbol": "fUSDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x4cfa50b7ce747e2d61724fcac57f24b748ff2b2a/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
+      "name": "Axelar Wrapped USDC",
+      "symbol": "axlUSDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0xeb466342c4d449bc9f53a865d5cb90586f405215/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x323665443cef804a3b5206103304bd4872ea4253",
+      "name": "USDV",
+      "symbol": "USDV",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x323665443cef804a3b5206103304bd4872ea4253/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4cb9a7ae498cedcbb5eae9f25736ae7d428c9d66",
+      "name": "Xai",
+      "symbol": "XAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x4cb9a7ae498cedcbb5eae9f25736ae7d428c9d66/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x894134a25a5fac1c2c26f1d8fbf05111a3cb9487",
+      "name": "Gravita Debt Token",
+      "symbol": "GRAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/42161/0x894134a25a5fac1c2c26f1d8fbf05111a3cb9487/logo.png"
     }
   ],
   "name": "Uniswap on Arbitrum one",

--- a/src/public/Uniswap.8453.json
+++ b/src/public/Uniswap.8453.json
@@ -4,7 +4,7 @@
   ],
   "version": {
     "major": 0,
-    "minor": 1,
+    "minor": 2,
     "patch": 0
   },
   "tokens": [

--- a/src/scripts/auxLists/uniswap.ts
+++ b/src/scripts/auxLists/uniswap.ts
@@ -94,6 +94,7 @@ async function fetchAndProcessUniswapTokensForChain(
       prefix: 'Uniswap',
       logo: UNISWAP_LOGO,
       overrides,
+      replaceExisting: false,
       logMessage: `Uniswap tokens`,
     })
   } catch (error) {


### PR DESCRIPTION
# Summary

Since the generated UNI list based on Coingecko data is quite lacking for some chains, I manually merged it with the existing list generated from the bridge mapping.

This gave us a total of 100 Gnosis tokens (up from 15) and 203 Arb1 tokens (up from 174).

Also made sure to allow the script to optionally keep existing tokens rather than wiping them out on every run.

# Testing

Ran it locally