### PR TITLE
chore: bump actions/upload-artifact version

### DIFF
--- a/.github/workflows/cowFi-tokens.yml
+++ b/.github/workflows/cowFi-tokens.yml
@@ -68,7 +68,7 @@ jobs:
         run: USE_CACHE=false yarn cowFi:tokens
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cowFi-tokens.json
           path: src/cowFi/cowFi-tokens.json

--- a/.github/workflows/optimizeImage.yml
+++ b/.github/workflows/optimizeImage.yml
@@ -50,7 +50,7 @@ jobs:
           fi
 
       - name: Upload img
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.address }}
           path: output.png


### PR DESCRIPTION
A couple of github actions started crashing:

<img width="1357" alt="image" src="https://github.com/user-attachments/assets/69ba5490-f0b3-403e-8840-4a40107c7aaa" />


Cause: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/