### PR TITLE
fix: manually override decimals for ynETHx on base

### DIFF
--- a/src/public/CoinGecko.8453.json
+++ b/src/public/CoinGecko.8453.json
@@ -3310,7 +3310,7 @@
       "address": "0xe231db5f348d709239ef1741ea30961b3b635a61",
       "name": "ynETH MAX",
       "symbol": "YNETHX",
-      "decimals": 16,
+      "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/51623/large/ynETHx.png?1731659494"
     },
     {

--- a/src/scripts/auxLists/index.ts
+++ b/src/scripts/auxLists/index.ts
@@ -5,6 +5,7 @@ import { getCoingeckoTokenIdsMap, OverridesPerChain } from './utils'
 
 const OVERRIDES: OverridesPerChain = mapSupportedNetworks(() => ({}))
 OVERRIDES[SupportedChainId.BASE]['0x18dd5b087bca9920562aff7a0199b96b9230438b'] = { decimals: 8 } // incorrect decimals set on CoinGecko's list
+OVERRIDES[SupportedChainId.BASE]['0xe231db5f348d709239ef1741ea30961b3b635a61'] = { decimals: 18 } // incorrect decimals set on CoinGecko's list
 
 async function main(): Promise<void> {
   const COINGECKO_IDS_MAP = await getCoingeckoTokenIdsMap()


### PR DESCRIPTION
# Summary

Manually override decimals for ynETHx on base.

It has 18, but coingecko is returning 16 https://basescan.org/token/0xe231db5f348d709239ef1741ea30961b3b635a61