### PR TITLE
fix: overwrite wxDAI name & symbol coming from Coingecko

### DIFF
--- a/src/public/CoinGecko.100.json
+++ b/src/public/CoinGecko.100.json
@@ -189,8 +189,8 @@
     {
       "chainId": 100,
       "address": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
-      "name": "XDAI",
-      "symbol": "XDAI",
+      "name": "Wrapped wxDAI",
+      "symbol": "wxDAI",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/11062/large/Identity-Primary-DarkBG.png?1696511004"
     },

--- a/src/scripts/auxLists/index.ts
+++ b/src/scripts/auxLists/index.ts
@@ -6,6 +6,10 @@ import { getCoingeckoTokenIdsMap, OverridesPerChain } from './utils'
 const OVERRIDES: OverridesPerChain = mapSupportedNetworks(() => ({}))
 OVERRIDES[SupportedChainId.BASE]['0x18dd5b087bca9920562aff7a0199b96b9230438b'] = { decimals: 8 } // incorrect decimals set on CoinGecko's list
 OVERRIDES[SupportedChainId.BASE]['0xe231db5f348d709239ef1741ea30961b3b635a61'] = { decimals: 18 } // incorrect decimals set on CoinGecko's list
+OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0xe91d153e0b41518a2ce8dd3d7944fa863463a97d'] = {
+  symbol: 'wxDAI',
+  name: 'Wrapped xDAI',
+} // incorrect symbol and name set on CoinGecko's list
 
 async function main(): Promise<void> {
   const COINGECKO_IDS_MAP = await getCoingeckoTokenIdsMap()


### PR DESCRIPTION
# Summary

Coingecko returns wxDAI token on gnosis chain labeled as xdai

From: https://tokens.coingecko.com/xdai/all.json

![image](https://github.com/user-attachments/assets/d9f4d72e-c02c-4dc1-b5ba-6b02607dccde)

This change overwrites it using the correct values.