### PR TITLE
fix(permits): support salt for eip712

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "(MIT OR Apache-2.0)",
   "dependencies": {
     "@cowprotocol/cow-sdk": "6.0.0-RC.63",
-    "@cowprotocol/permit-utils": "^0.7.0-RC.0",
+    "@cowprotocol/permit-utils": "^0.7.0-RC.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "ajv": "^8.17.1",
     "ajv-cli": "^5.0.0",

--- a/src/permitInfo/fetchPermitInfo.ts
+++ b/src/permitInfo/fetchPermitInfo.ts
@@ -53,10 +53,11 @@ export type FetchPermitInfoOptions = {
   rpcUrl?: string
   recheckUnsupported?: boolean
   forceRecheck?: boolean
+  token?: string
 }
 
 export async function fetchPermitInfo(options: FetchPermitInfoOptions): Promise<void> {
-  const { chainId, tokenListPath, rpcUrl, recheckUnsupported, forceRecheck } = options
+  const { chainId, tokenListPath, rpcUrl, recheckUnsupported, forceRecheck, token } = options
   // Load existing permitInfo.json file for given chainId
   const permitInfoPath = path.join(BASE_PATH, `PermitInfo.${chainId}.json`)
 
@@ -84,6 +85,20 @@ export async function fetchPermitInfo(options: FetchPermitInfoOptions): Promise<
   const tokens = recheckUnsupported
     ? getUnsupportedTokensFromPermitInfo(chainId, allPermitInfo)
     : await getTokensFromTokenList(chainId, tokenListPath)
+
+  if (token) {
+    const lowerCaseToken = token.toLowerCase()
+    const filteredTokens = tokens.filter((t) => t.address.toLowerCase() === lowerCaseToken)
+
+    if (filteredTokens.length === 0) {
+      console.log(`No token found with address: ${lowerCaseToken}`)
+      return
+    }
+
+    console.log(`Fetching permit info for specific token: ${filteredTokens[0].symbol} (${filteredTokens[0].address})`)
+    tokens.length = 0
+    tokens.push(...filteredTokens)
+  }
 
   // Create a list of promises to check all tokens
   const fetchAllPermits = tokens.map((token) => {

--- a/src/permitInfo/fetchPermitInfoByChain.ts
+++ b/src/permitInfo/fetchPermitInfoByChain.ts
@@ -5,7 +5,7 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { fetchPermitInfo } from './fetchPermitInfo'
 
 function fetchPermitInfoByChain() {
-  const [, scriptPath, chainId, tokenListPath, rpcUrl, recheckUnsupported, forceRecheck] = argv
+  const [, scriptPath, chainId, tokenListPath, rpcUrl, recheckUnsupported, forceRecheck, token] = argv
 
   if (!chainId) {
     console.error('ChainId is missing. Invoke the script with the chainId as the first parameter.')
@@ -22,6 +22,7 @@ function fetchPermitInfoByChain() {
     rpcUrl,
     recheckUnsupported: recheckUnsupported === 'true',
     forceRecheck: forceRecheck === 'true',
+    token: token,
   }).then(() => console.info(`Done 🏁`))
 }
 

--- a/src/public/PermitInfo.137.json
+++ b/src/public/PermitInfo.137.json
@@ -94,6 +94,11 @@
     "version": "1",
     "name": "Veloce"
   },
+  "0x2791bca1f2de4661ed88a30c99a7a9449aa84174": {
+    "type": "eip-2612",
+    "version": "1",
+    "name": "USD Coin (PoS)"
+  },
   "0x2bc07124d8dac638e290f401046ad584546bc47b": {
     "type": "eip-2612",
     "version": "1",
@@ -1094,10 +1099,6 @@
   "0x276c9cbaa4bdf57d7109a41e67bd09699536fa3d": {
     "type": "unsupported",
     "name": "Somnium Space Cubes (PoS)"
-  },
-  "0x2791bca1f2de4661ed88a30c99a7a9449aa84174": {
-    "type": "unsupported",
-    "name": "USD Coin (PoS)"
   },
   "0x27ab6e82f3458edbc0703db2756391b899ce6324": {
     "type": "unsupported",

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,10 +92,10 @@
     graphql-request "^4.3.0"
     limiter "^3.0.0"
 
-"@cowprotocol/permit-utils@^0.7.0-RC.0":
-  version "0.7.0-RC.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/permit-utils/-/permit-utils-0.7.0-RC.0.tgz#a7efce813b68b4d1d2d937ef8a0de21a93901bb5"
-  integrity sha512-qbJ9RFO65M2UYodKojlxv4jAclUFqLprmwR5sZZwd3eHSUQ4Nc6sJ6yK5uj1KfMOOz0C1dgqnfBYRwHzYAXIGw==
+"@cowprotocol/permit-utils@^0.7.0-RC.1":
+  version "0.7.0-RC.1"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/permit-utils/-/permit-utils-0.7.0-RC.1.tgz#16a4d7ecfc49848d4740b3867832de5aa5fb4a4a"
+  integrity sha512-KhP85HBkpAsYRBQmQ86NuIZWInI0VnAQ/7cAtlPg8z1ETfsZqf7kVD227DlHI/WfX1vFvWGrhyoCLEr4JFdrYg==
   dependencies:
     "@1inch/permit-signed-approvals-utils" "^1.4.10"
     "@cowprotocol/app-data" "^1.1.0"


### PR DESCRIPTION
# Summary

Fixes #[6082](https://github.com/cowprotocol/cowswap/issues/6082) 

This token contract accepts salt for eip712 domain structure instead of chainId
<img width="979" height="385" alt="image" src="https://github.com/user-attachments/assets/5e83ff22-e1af-43e3-91d5-5bbbf528ba0b" />

permit-utils lib that we use supports this type of permits, I've just added the flag to add this check for this token:

https://github.com/1inch/permit-signed-approvals-utils/blob/fde3bc38d6179f4d3ab9fac8b1b5f9834521eace/src/eip-2612-permit.const.ts#L31

Also I added an [ability](https://github.com/cowprotocol/token-lists/pull/1056/files#diff-9974a23a696c8eb4e85794018216600f233096d86d4eb9eec0c24f072565bb68R89) to check only specific token address by adding new parameter in cli



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a token address to filter permit info results.
* **Bug Fixes**
  * Updated token classification so that "USD Coin (PoS)" is now recognized as EIP-2612 supported.
* **Chores**
  * Updated a dependency version for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->