### PR TITLE
fix: remove backed tokens

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -132,14 +132,6 @@
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b/logo.png"
     },
     {
-      "address": "0x14a5f2872396802c3cc8942a39ab3e4118ee5038",
-      "symbol": "bTSLA",
-      "name": "Backed Tesla",
-      "decimals": 18,
-      "chainId": 1,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x14a5f2872396802c3cc8942a39ab3e4118ee5038/logo.png"
-    },
-    {
       "address": "0x152649ea73beab28c5b49b26eb48f7ead6d4c898",
       "symbol": "CAKE",
       "name": "PancakeSwap Token",
@@ -188,14 +180,6 @@
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x19ebd191f7a24ece672ba13a302212b5ef7f35cb/logo.png"
     },
     {
-      "address": "0x1a4f71b0ff3c22540887bcf83b50054a213c673d",
-      "symbol": "wbMSTR",
-      "name": "Wrapped Backed Strategy",
-      "decimals": 18,
-      "chainId": 1,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x1a4f71b0ff3c22540887bcf83b50054a213c673d/logo.png"
-    },
-    {
       "address": "0x1a88df1cfe15af22b3c4c783d4e6f7f9e0c1885d",
       "symbol": "stkGHO",
       "name": "Aave stkGHO",
@@ -234,22 +218,6 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44/logo.png"
-    },
-    {
-      "address": "0x1e2c4fb7ede391d116e6b41cd0608260e8801d59",
-      "symbol": "bCSPX",
-      "name": "Backed CSPX S&P 500",
-      "decimals": 18,
-      "chainId": 1,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x1e2c4fb7ede391d116e6b41cd0608260e8801d59/logo.png"
-    },
-    {
-      "address": "0x1f82284c1658ad71c576f7230e6c2dee7901c1fa",
-      "symbol": "wbTSLA",
-      "name": "Wrapped Backed Tesla",
-      "decimals": 18,
-      "chainId": 1,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x1f82284c1658ad71c576f7230e6c2dee7901c1fa/logo.png"
     },
     {
       "symbol": "UNI",
@@ -732,14 +700,6 @@
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0/logo.png"
     },
     {
-      "address": "0x7e8101a1c322d394b3961498c7d40d2dfa94c392",
-      "symbol": "wbNVDA",
-      "name": "Wrapped Backed NVIDIA",
-      "decimals": 18,
-      "chainId": 1,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0x7e8101a1c322d394b3961498c7d40d2dfa94c392/logo.png"
-    },
-    {
       "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
       "symbol": "wstETH",
       "name": "Wrapped liquid staked Ether 2.0",
@@ -895,14 +855,6 @@
       ]
     },
     {
-      "address": "0xa34c5e0abe843e10461e2c9586ea03e55dbcc495",
-      "symbol": "bNVDA",
-      "name": "Backed NVIDIA",
-      "decimals": 18,
-      "chainId": 1,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xa34c5e0abe843e10461e2c9586ea03e55dbcc495/logo.png"
-    },
-    {
       "address": "0xa3931d71877c0e7a3148cb7eb4463524fec27fbd",
       "symbol": "sUSDS",
       "name": "Savings USDS",
@@ -925,22 +877,6 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xaaee1a9723aadb7afa2810263653a34ba2c21c7a/logo.png"
-    },
-    {
-      "address": "0xac28c9178acc8ba4a11a29e013a3a2627086e422",
-      "symbol": "bMSTR",
-      "name": "Backed Strategy",
-      "decimals": 18,
-      "chainId": 1,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xac28c9178acc8ba4a11a29e013a3a2627086e422/logo.png"
-    },
-    {
-      "address": "0xac28c9178acc8ba4a11a29e013a3a2627086e422",
-      "symbol": "bMSTR",
-      "name": "Backed Strategy",
-      "decimals": 18,
-      "chainId": 1,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0xac28c9178acc8ba4a11a29e013a3a2627086e422/logo.png"
     },
     {
       "address": "0xae78736cd615f374d3085123a210448e74fc6393",
@@ -973,14 +909,6 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xba100000625a3754423978a60c9317c58a424e3d/logo.png"
-    },
-    {
-      "address": "0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9",
-      "symbol": "bCOIN",
-      "name": "Backed Coinbase",
-      "decimals": 18,
-      "chainId": 1,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9/logo.png"
     },
     {
       "symbol": "alUSD",
@@ -1207,14 +1135,6 @@
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f/logo.png"
     },
     {
-      "address": "0xdec933e2392ad908263e70a386fbf34e703ffe8f",
-      "symbol": "wbCOIN",
-      "name": "Wrapped Backed Coinbase",
-      "decimals": 18,
-      "chainId": 1,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/1/0xdec933e2392ad908263e70a386fbf34e703ffe8f/logo.png"
-    },
-    {
       "symbol": "COW",
       "name": "CoW Protocol Token",
       "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
@@ -1367,14 +1287,6 @@
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/56/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c/logo.png"
     },
     {
-      "address": "0x14a5f2872396802c3cc8942a39ab3e4118ee5038",
-      "symbol": "bTSLA",
-      "name": "Backed Tesla",
-      "decimals": 18,
-      "chainId": 100,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0x14a5f2872396802c3cc8942a39ab3e4118ee5038/logo.png"
-    },
-    {
       "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
       "symbol": "AURA",
       "name": "Aura Finance",
@@ -1389,30 +1301,6 @@
       "decimals": 18,
       "chainId": 100,
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0x177127622c4a00f3d409b75571e12cb3c8973d3c/logo.png"
-    },
-    {
-      "address": "0x1a4f71b0ff3c22540887bcf83b50054a213c673d",
-      "symbol": "wbMSTR",
-      "name": "Wrapped Backed Strategy",
-      "decimals": 18,
-      "chainId": 100,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0x1a4f71b0ff3c22540887bcf83b50054a213c673d/logo.png"
-    },
-    {
-      "address": "0x1e2c4fb7ede391d116e6b41cd0608260e8801d59",
-      "symbol": "bCSPX",
-      "name": "Backed CSPX S&P 500",
-      "decimals": 18,
-      "chainId": 100,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0x1e2c4fb7ede391d116e6b41cd0608260e8801d59/logo.png"
-    },
-    {
-      "address": "0x1f82284c1658ad71c576f7230e6c2dee7901c1fa",
-      "symbol": "wbTSLA",
-      "name": "Wrapped Backed Tesla",
-      "decimals": 18,
-      "chainId": 100,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0x1f82284c1658ad71c576f7230e6c2dee7901c1fa/logo.png"
     },
     {
       "address": "0x2a22f9c3b484c3629090feed35f17ff8f88f76f0",
@@ -1511,14 +1399,6 @@
       "logoURI": "https://raw.githubusercontent.com/centfinance/assets/master/blockchains/xdai/assets/0x71850b7E9Ee3f13Ab46d67167341E4bDc905Eef9/logo.png"
     },
     {
-      "address": "0x7e8101a1c322d394b3961498c7d40d2dfa94c392",
-      "symbol": "wbNVDA",
-      "name": "Wrapped Backed NVIDIA",
-      "decimals": 18,
-      "chainId": 100,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0x7e8101a1c322d394b3961498c7d40d2dfa94c392/logo.png"
-    },
-    {
       "address": "0x8e5bBbb09Ed1ebdE8674Cda39A0c169401db4252",
       "chainId": 100,
       "name": "Wrapped BTC on Gnosis Chain",
@@ -1535,14 +1415,6 @@
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0x9c58bacc331c9aa871afd802db6379a98e80cedb/logo.png"
     },
     {
-      "address": "0xa34c5e0abe843e10461e2c9586ea03e55dbcc495",
-      "symbol": "bNVDA",
-      "name": "Backed NVIDIA",
-      "decimals": 18,
-      "chainId": 100,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0xa34c5e0abe843e10461e2c9586ea03e55dbcc495/logo.png"
-    },
-    {
       "address": "0xA4eF9Da5BA71Cc0D2e5E877a910A37eC43420445",
       "chainId": 100,
       "name": "StakeWise Staked GNO (sGNO)",
@@ -1557,14 +1429,6 @@
       "decimals": 18,
       "chainId": 100,
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0xabef652195f98a91e490f047a5006b71c85f058d/logo.png"
-    },
-    {
-      "address": "0xac28c9178acc8ba4a11a29e013a3a2627086e422",
-      "symbol": "bMSTR",
-      "name": "Backed Strategy",
-      "decimals": 18,
-      "chainId": 100,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0xac28c9178acc8ba4a11a29e013a3a2627086e422/logo.png"
     },
     {
       "address": "0xaf204776c7245bf4147c2612bf6e5972ee483701",
@@ -1589,14 +1453,6 @@
       "symbol": "STAKE",
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/centfinance/assets/master/blockchains/ethereum/assets/0x0Ae055097C6d159879521C384F1D2123D1f195e6/logo.png"
-    },
-    {
-      "address": "0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9",
-      "symbol": "bCOIN",
-      "name": "Backed Coinbase",
-      "decimals": 18,
-      "chainId": 100,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9/logo.png"
     },
     {
       "address": "0xC45b3C1c24d5F54E7a2cF288ac668c74Dd507a84",
@@ -1661,14 +1517,6 @@
       "symbol": "USDC",
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0xddafbb505ad214d7b80b1f830fccc89b60fb7a83/logo.png"
-    },
-    {
-      "address": "0xdec933e2392ad908263e70a386fbf34e703ffe8f",
-      "symbol": "wbCOIN",
-      "name": "Wrapped Backed Coinbase",
-      "decimals": 18,
-      "chainId": 100,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/100/0xdec933e2392ad908263e70a386fbf34e703ffe8f/logo.png"
     },
     {
       "address": "0xE2e73A1c69ecF83F464EFCE6A5be353a37cA09b2",
@@ -1775,30 +1623,6 @@
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0x04d5ddf5f3a8939889f11e97f8c4bb48317f1938/logo.png"
     },
     {
-      "address": "0x14a5f2872396802c3cc8942a39ab3e4118ee5038",
-      "symbol": "bTSLA",
-      "name": "Backed Tesla",
-      "decimals": 18,
-      "chainId": 8453,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0x14a5f2872396802c3cc8942a39ab3e4118ee5038/logo.png"
-    },
-    {
-      "address": "0x1a4f71b0ff3c22540887bcf83b50054a213c673d",
-      "symbol": "wbMSTR",
-      "name": "Wrapped Backed Strategy",
-      "decimals": 18,
-      "chainId": 8453,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0x1a4f71b0ff3c22540887bcf83b50054a213c673d/logo.png"
-    },
-    {
-      "address": "0x1f82284c1658ad71c576f7230e6c2dee7901c1fa",
-      "symbol": "wbTSLA",
-      "name": "Wrapped Backed Tesla",
-      "decimals": 18,
-      "chainId": 8453,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0x1f82284c1658ad71c576f7230e6c2dee7901c1fa/logo.png"
-    },
-    {
       "address": "0x35e5db674d8e93a03d814fa0ada70731efe8a4b9",
       "symbol": "USR",
       "name": "Resolv USD",
@@ -1847,14 +1671,6 @@
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42/logo.png"
     },
     {
-      "address": "0x7e8101a1c322d394b3961498c7d40d2dfa94c392",
-      "symbol": "wbNVDA",
-      "name": "Wrapped Backed NVIDIA",
-      "decimals": 18,
-      "chainId": 8453,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0x7e8101a1c322d394b3961498c7d40d2dfa94c392/logo.png"
-    },
-    {
       "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
       "symbol": "USDC",
       "name": "USDC",
@@ -1864,14 +1680,6 @@
       "tags": [
         "circle"
       ]
-    },
-    {
-      "address": "0xa34c5e0abe843e10461e2c9586ea03e55dbcc495",
-      "symbol": "bNVDA",
-      "name": "Backed NVIDIA",
-      "decimals": 18,
-      "chainId": 8453,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0xa34c5e0abe843e10461e2c9586ea03e55dbcc495/logo.png"
     },
     {
       "address": "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376",
@@ -1890,14 +1698,6 @@
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0xbaa5cc21fd487b8fcc2f632f3f4e8d37262a0842/logo.png"
     },
     {
-      "address": "0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9",
-      "symbol": "bCOIN",
-      "name": "Backed Coinbase",
-      "decimals": 18,
-      "chainId": 8453,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9/logo.png"
-    },
-    {
       "address": "0xbcbc8cb4d1e8ed048a6276a5e94a3e952660bcbc",
       "symbol": "yoBTC",
       "name": "Yield Optimizer BTC",
@@ -1912,14 +1712,6 @@
       "decimals": 18,
       "chainId": 8453,
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0xc31389794ffac23331e0d9f611b7953f90aa5fdc/logo.png"
-    },
-    {
-      "address": "0xc3ce78b037dda1b966d31ec7979d3f3a38571a8e",
-      "symbol": "bCSPX",
-      "name": "Backed CSPX S&P 500",
-      "decimals": 18,
-      "chainId": 8453,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0xc3ce78b037dda1b966d31ec7979d3f3a38571a8e/logo.png"
     },
     {
       "address": "0xc694a91e6b071bf030a18bd3053a7fe09b6dae69",
@@ -1952,14 +1744,6 @@
       "decimals": 18,
       "chainId": 8453,
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4/logo.png"
-    },
-    {
-      "address": "0xdec933e2392ad908263e70a386fbf34e703ffe8f",
-      "symbol": "wbCOIN",
-      "name": "Wrapped Backed Coinbase",
-      "decimals": 18,
-      "chainId": 8453,
-      "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/8453/0xdec933e2392ad908263e70a386fbf34e703ffe8f/logo.png"
     },
     {
       "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",

--- a/src/public/images/1/0x14a5f2872396802c3cc8942a39ab3e4118ee5038/info.json
+++ b/src/public/images/1/0x14a5f2872396802c3cc8942a39ab3e4118ee5038/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x14a5f2872396802c3cc8942a39ab3e4118ee5038",
   "symbol": "bTSLA",
   "name": "Backed Tesla",

--- a/src/public/images/1/0x1a4f71b0ff3c22540887bcf83b50054a213c673d/info.json
+++ b/src/public/images/1/0x1a4f71b0ff3c22540887bcf83b50054a213c673d/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x1a4f71b0ff3c22540887bcf83b50054a213c673d",
   "symbol": "wbMSTR",
   "name": "Wrapped Backed Strategy",

--- a/src/public/images/1/0x1e2c4fb7ede391d116e6b41cd0608260e8801d59/info.json
+++ b/src/public/images/1/0x1e2c4fb7ede391d116e6b41cd0608260e8801d59/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x1e2c4fb7ede391d116e6b41cd0608260e8801d59",
   "symbol": "bCSPX",
   "name": "Backed CSPX S&P 500",

--- a/src/public/images/1/0x1f82284c1658ad71c576f7230e6c2dee7901c1fa/info.json
+++ b/src/public/images/1/0x1f82284c1658ad71c576f7230e6c2dee7901c1fa/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x1f82284c1658ad71c576f7230e6c2dee7901c1fa",
   "symbol": "wbTSLA",
   "name": "Wrapped Backed Tesla",

--- a/src/public/images/1/0x7e8101a1c322d394b3961498c7d40d2dfa94c392/info.json
+++ b/src/public/images/1/0x7e8101a1c322d394b3961498c7d40d2dfa94c392/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x7e8101a1c322d394b3961498c7d40d2dfa94c392",
   "symbol": "wbNVDA",
   "name": "Wrapped Backed NVIDIA",

--- a/src/public/images/1/0xa34c5e0abe843e10461e2c9586ea03e55dbcc495/info.json
+++ b/src/public/images/1/0xa34c5e0abe843e10461e2c9586ea03e55dbcc495/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xa34c5e0abe843e10461e2c9586ea03e55dbcc495",
   "symbol": "bNVDA",
   "name": "Backed NVIDIA",

--- a/src/public/images/1/0xac28c9178acc8ba4a11a29e013a3a2627086e422/info.json
+++ b/src/public/images/1/0xac28c9178acc8ba4a11a29e013a3a2627086e422/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xac28c9178acc8ba4a11a29e013a3a2627086e422",
   "symbol": "bMSTR",
   "name": "Backed Strategy",

--- a/src/public/images/1/0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9/info.json
+++ b/src/public/images/1/0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9",
   "symbol": "bCOIN",
   "name": "Backed Coinbase Global",

--- a/src/public/images/1/0xdec933e2392ad908263e70a386fbf34e703ffe8f/info.json
+++ b/src/public/images/1/0xdec933e2392ad908263e70a386fbf34e703ffe8f/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xdec933e2392ad908263e70a386fbf34e703ffe8f",
   "symbol": "wbCOIN",
   "name": "Wrapped Backed Coinbase Global",

--- a/src/public/images/100/0x14a5f2872396802c3cc8942a39ab3e4118ee5038/info.json
+++ b/src/public/images/100/0x14a5f2872396802c3cc8942a39ab3e4118ee5038/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x14a5f2872396802c3cc8942a39ab3e4118ee5038",
   "symbol": "bTSLA",
   "name": "Backed Tesla",

--- a/src/public/images/100/0x1a4f71b0ff3c22540887bcf83b50054a213c673d/info.json
+++ b/src/public/images/100/0x1a4f71b0ff3c22540887bcf83b50054a213c673d/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x1a4f71b0ff3c22540887bcf83b50054a213c673d",
   "symbol": "wbMSTR",
   "name": "Wrapped Backed Strategy",

--- a/src/public/images/100/0x1e2c4fb7ede391d116e6b41cd0608260e8801d59/info.json
+++ b/src/public/images/100/0x1e2c4fb7ede391d116e6b41cd0608260e8801d59/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x1e2c4fb7ede391d116e6b41cd0608260e8801d59",
   "symbol": "bCSPX",
   "name": "Backed CSPX S&P 500",

--- a/src/public/images/100/0x1f82284c1658ad71c576f7230e6c2dee7901c1fa/info.json
+++ b/src/public/images/100/0x1f82284c1658ad71c576f7230e6c2dee7901c1fa/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x1f82284c1658ad71c576f7230e6c2dee7901c1fa",
   "symbol": "wbTSLA",
   "name": "Wrapped Backed Tesla",

--- a/src/public/images/100/0x7e8101a1c322d394b3961498c7d40d2dfa94c392/info.json
+++ b/src/public/images/100/0x7e8101a1c322d394b3961498c7d40d2dfa94c392/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x7e8101a1c322d394b3961498c7d40d2dfa94c392",
   "symbol": "wbNVDA",
   "name": "Wrapped Backed NVIDIA",

--- a/src/public/images/100/0xa34c5e0abe843e10461e2c9586ea03e55dbcc495/info.json
+++ b/src/public/images/100/0xa34c5e0abe843e10461e2c9586ea03e55dbcc495/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xa34c5e0abe843e10461e2c9586ea03e55dbcc495",
   "symbol": "bNVDA",
   "name": "Backed NVIDIA",

--- a/src/public/images/100/0xac28c9178acc8ba4a11a29e013a3a2627086e422/info.json
+++ b/src/public/images/100/0xac28c9178acc8ba4a11a29e013a3a2627086e422/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xac28c9178acc8ba4a11a29e013a3a2627086e422",
   "symbol": "bMSTR",
   "name": "Backed Strategy",

--- a/src/public/images/100/0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9/info.json
+++ b/src/public/images/100/0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9",
   "symbol": "bCOIN",
   "name": "Backed Coinbase Global",

--- a/src/public/images/100/0xdec933e2392ad908263e70a386fbf34e703ffe8f/info.json
+++ b/src/public/images/100/0xdec933e2392ad908263e70a386fbf34e703ffe8f/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xdec933e2392ad908263e70a386fbf34e703ffe8f",
   "symbol": "wbCOIN",
   "name": "Wrapped Backed Coinbase Global",

--- a/src/public/images/8453/0x14a5f2872396802c3cc8942a39ab3e4118ee5038/info.json
+++ b/src/public/images/8453/0x14a5f2872396802c3cc8942a39ab3e4118ee5038/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x14a5f2872396802c3cc8942a39ab3e4118ee5038",
   "symbol": "bTSLA",
   "name": "Backed Tesla",

--- a/src/public/images/8453/0x1a4f71b0ff3c22540887bcf83b50054a213c673d/info.json
+++ b/src/public/images/8453/0x1a4f71b0ff3c22540887bcf83b50054a213c673d/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x1a4f71b0ff3c22540887bcf83b50054a213c673d",
   "symbol": "wbMSTR",
   "name": "Wrapped Backed Strategy",

--- a/src/public/images/8453/0x1f82284c1658ad71c576f7230e6c2dee7901c1fa/info.json
+++ b/src/public/images/8453/0x1f82284c1658ad71c576f7230e6c2dee7901c1fa/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x1f82284c1658ad71c576f7230e6c2dee7901c1fa",
   "symbol": "wbTSLA",
   "name": "Wrapped Backed Tesla",

--- a/src/public/images/8453/0x7e8101a1c322d394b3961498c7d40d2dfa94c392/info.json
+++ b/src/public/images/8453/0x7e8101a1c322d394b3961498c7d40d2dfa94c392/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0x7e8101a1c322d394b3961498c7d40d2dfa94c392",
   "symbol": "wbNVDA",
   "name": "Wrapped Backed NVIDIA",

--- a/src/public/images/8453/0xa34c5e0abe843e10461e2c9586ea03e55dbcc495/info.json
+++ b/src/public/images/8453/0xa34c5e0abe843e10461e2c9586ea03e55dbcc495/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xa34c5e0abe843e10461e2c9586ea03e55dbcc495",
   "symbol": "bNVDA",
   "name": "Backed NVIDIA",

--- a/src/public/images/8453/0xac28c9178acc8ba4a11a29e013a3a2627086e422/info.json
+++ b/src/public/images/8453/0xac28c9178acc8ba4a11a29e013a3a2627086e422/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xac28c9178acc8ba4a11a29e013a3a2627086e422",
   "symbol": "bMSTR",
   "name": "Backed Strategy",

--- a/src/public/images/8453/0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9/info.json
+++ b/src/public/images/8453/0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9",
   "symbol": "bCOIN",
   "name": "Backed Coinbase Global",

--- a/src/public/images/8453/0xc3ce78b037dda1b966d31ec7979d3f3a38571a8e/info.json
+++ b/src/public/images/8453/0xc3ce78b037dda1b966d31ec7979d3f3a38571a8e/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xc3ce78b037dda1b966d31ec7979d3f3a38571a8e",
   "symbol": "bCSPX",
   "name": "Backed CSPX S&P 500",

--- a/src/public/images/8453/0xdec933e2392ad908263e70a386fbf34e703ffe8f/info.json
+++ b/src/public/images/8453/0xdec933e2392ad908263e70a386fbf34e703ffe8f/info.json
@@ -1,5 +1,5 @@
 {
-  "removed": false,
+  "removed": true,
   "address": "0xdec933e2392ad908263e70a386fbf34e703ffe8f",
   "symbol": "wbCOIN",
   "name": "Wrapped Backed Coinbase Global",


### PR DESCRIPTION
# Summary

Remove backed tokens as they are currently not supported/have no liquidity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Removed the following tokens across multiple networks: bTSLA, wbTSLA, bNVDA, wbNVDA, bCOIN, wbCOIN, bCSPX, bMSTR, wbMSTR.
  * Marked these assets as removed so they no longer appear in search, token lists, balances, quotes, or swap selection.
  * Updated associated metadata to reflect removal. No new tokens were added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->