### PR TITLE
chore: bump list version to 6.2.0

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -1,10 +1,10 @@
 {
   "name": "CoW Swap",
-  "timestamp": "2025-08-26T09:15:00+00:00",
+  "timestamp": "2025-08-27T21:30:00+00:00",
   "version": {
     "major": 6,
     "minor": 1,
-    "patch": 0
+    "patch": 1
   },
   "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/list-logo.png",
   "keywords": [

--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -3,8 +3,8 @@
   "timestamp": "2025-08-27T21:30:00+00:00",
   "version": {
     "major": 6,
-    "minor": 1,
-    "patch": 1
+    "minor": 2,
+    "patch": 0
   },
   "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/list-logo.png",
   "keywords": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated public app metadata timestamp to reflect the latest build.
  * Incremented the minor version for release tracking.
  * No functional or user-facing changes introduced.
  * Ensures accurate versioning and release tracking across environments.
  * Minor housekeeping to keep release information current and consistent.
  * Minor formatting update for metadata file consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->