### PR TITLE
fix: change number of decimals for Safe token on Gnosis

### DIFF
--- a/src/public/Uniswap.100.json
+++ b/src/public/Uniswap.100.json
@@ -101,7 +101,7 @@
       "address": "0x4d18815d14fe5c3304e87b3fa18318baa5c23820",
       "name": "Safe",
       "symbol": "SAFE",
-      "decimals": 15,
+      "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/27032/large/Artboard_1_copy_8circle-1.png?1696526084"
     },
     {


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/cowswap/issues/6242

Safe token has a wrong number of decimals in this list https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.100.json
<img width="906" height="139" alt="image" src="https://github.com/user-attachments/assets/421fcbde-2886-4193-bba8-4181998a24ae" />

The PR updates this number to 18 decimals. 
<img width="687" height="116" alt="image" src="https://github.com/user-attachments/assets/7cdbffc4-afa6-477e-8b75-ca0284bbf31d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SAFE token decimal precision to 18 on Gnosis (chainId 100), ensuring accurate balances, price quotes, and transaction amounts.

* **Chores**
  * Minor file formatting cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->