### PR TITLE
fix: fix broken gh actions

### DIFF
--- a/src/scripts/auxLists/utils.ts
+++ b/src/scripts/auxLists/utils.ts
@@ -70,7 +70,12 @@ export async function fetchWithApiKey(url: string): Promise<any> {
       throw new Error(`HTTP error! status: ${response.status}`)
     }
 
-    return response.json()
+    console.log(`Fetched from ${url}:`, response.status)
+    const data = await response.json()
+
+    console.log(`Data from ${url}:`, data)
+
+    return data
   } catch (error) {
     console.error(`Failed to fetch from ${url}:`, error)
     throw error


### PR DESCRIPTION
# Summary

Fix broken GH actions by awaiting the JSON promise before returning.

The error msg [that was being thrown was](): `Error fetching Coingecko's coin list: TypeError: terminated`

Looking at the code, it doesn't seem to indicate the request failed.
So I added a debug log that first consumes the response.json() to log it, then returns it.

That solved it.

Both entries were logged and the response returned as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging and data handling for improved debugging and monitoring capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->