### PR TITLE
fix: delete old (untracked) files in s3

### DIFF
--- a/.github/workflows/s3Deploy.yml
+++ b/.github/workflows/s3Deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload to S3
         run: |
           aws s3 cp src/public/CowSwap.json s3://files.cow.fi/tokens/CowSwap.json
-          aws s3 sync src/public s3://files.cow.fi/token-lists
+          aws s3 sync src/public s3://files.cow.fi/token-lists --delete
 
       - name: Invalidate CloudFront cache
         run: |


### PR DESCRIPTION
Builds on #1274

This changes makes it so that files that are no longer in the `src/public` dir will get deleted from s3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved S3 deployment process to remove orphaned files during sync operations, ensuring cleaner deployments and better resource management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->