### PR TITLE
feat: add UUSD and UBQ tokens for Ethereum and Gnosis

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -2086,8 +2086,8 @@
     },
     {
       "address": "0x0200c29006150606b650577bbe7b6248f58470c1",
-      "symbol": "USD\u20ae0",
-      "name": "USD\u20ae0",
+      "symbol": "USD₮0",
+      "name": "USD₮0",
       "decimals": 6,
       "chainId": 57073,
       "logoURI": "https://files.cow.fi/token-lists/images/57073/0x0200c29006150606b650577bbe7b6248f58470c1/logo.png"
@@ -2147,6 +2147,38 @@
       "decimals": 18,
       "chainId": 59144,
       "logoURI": "https://files.cow.fi/token-lists/images/59144/0xe5d7c2a44ffddf6b295a15c148167daaaf5cf34f/logo.png"
+    },
+    {
+      "address": "0xc6ed4f520f6a4e4dc27273509239b7f8a68d2068",
+      "symbol": "UUSD",
+      "name": "Ubiquity Dollar",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/ubiquity/ubiquity-dollar/development/packages/dapp/public/tokens-icons/usdc.png"
+    },
+    {
+      "address": "0xb6919Ef2ee4aFC163BC954C5678e2BB570c2D103",
+      "symbol": "UUSD",
+      "name": "Ubiquity Dollar",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://raw.githubusercontent.com/ubiquity/ubiquity-dollar/development/packages/dapp/public/tokens-icons/usdc.png"
+    },
+    {
+      "address": "0x4e38D89362f7e5db0096CE44ebD021c3962aA9a0",
+      "symbol": "UBQ",
+      "name": "Ubiquity",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://raw.githubusercontent.com/ubiquity/ubiquity-dollar/development/packages/dapp/public/tokens-icons/ubq.png"
+    },
+    {
+      "address": "0x4e38D89362f7e5db0096CE44ebD021c3962aA9a0",
+      "symbol": "UBQ",
+      "name": "Ubiquity",
+      "decimals": 18,
+      "chainId": 100,
+      "logoURI": "https://raw.githubusercontent.com/ubiquity/ubiquity-dollar/development/packages/dapp/public/tokens-icons/ubq.png"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add Ubiquity Dollar (UUSD) and Ubiquity (UBQ) governance token to the CoW Swap default token list for both Ethereum Mainnet and Gnosis Chain.

## Token Details

### UUSD (Ubiquity Dollar)
| Chain | Address | Decimals |
|-------|---------|----------|
| Ethereum (1) | 0xb6919Ef2ee4aFC163BC954C5678e2BB570c2D103 | 18 |
| Gnosis (100) | 0xc6ed4f520f6a4e4dc27273509239b7f8a68d2068 | 18 |

### UBQ (Ubiquity Governance Token)
| Chain | Address | Decimals |
|-------|---------|----------|
| Ethereum (1) | 0x4e38D89362f7e5db0096CE44ebD021c3962aA9a0 | 18 |
| Gnosis (100) | 0x4e38D89362f7e5db0096CE44ebD021c3962aA9a0 | 18 |

## Background

Ubiquity DAO is a decentralized protocol that provides crypto-native financial services. Adding UUSD and UBQ to the CoW Swap token list will enable users to easily trade these tokens through the CoW Swap interface.

- **Website**: https://ubq.fi/
- **Documentation**: https://docs.ubq.fi/

## References

- https://github.com/devpool-directory/devpool-directory/issues/5850
- https://github.com/ubiquity/ubiquity-dollar/issues/984
- Existing token requests: cowprotocol/token-lists#797 (UUSD), cowprotocol/token-lists#798 (UBQ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for UUSD (Ubiquity Dollar) and UBQ (Ubiquity) tokens across multiple blockchain networks.

* **Bug Fixes**
  * Corrected token symbol and name display formatting for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->