### PR TITLE
Add 164 xStocks (627 entries) to CoW Swap token list

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -1,10 +1,10 @@
 {
   "name": "CoW Swap",
-  "timestamp": "2026-06-02T17:30:00+00:00",
+  "timestamp": "2026-06-05T14:38:16+00:00",
   "version": {
     "major": 7,
     "minor": 5,
-    "patch": 0
+    "patch": 164
   },
   "logoURI": "https://files.cow.fi/token-lists/images/list-logo.png",
   "keywords": [
@@ -28,6 +28,22 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x007115416ab6c266329a03b09a8aa39ac2ef7d9d/logo.png"
     },
     {
+      "address": "0x02a6c1789c3B4FDb1a7a3DfA39F90e5d3c94F4F9",
+      "symbol": "PMx",
+      "name": "Philip Morris xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PMx.png"
+    },
+    {
+      "address": "0x03183Ce31b1656B72A55fa6056e287f50C35BbEB",
+      "symbol": "ACNx",
+      "name": "Accenture xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ACNx.png"
+    },
+    {
       "address": "0x031de51f3e8016514bd0963d0b2ab825a591db9a",
       "symbol": "ESP",
       "name": "Espresso",
@@ -44,12 +60,44 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x04acaf8d2865c0714f79da09645c13fd2888977f/logo.png"
     },
     {
+      "address": "0x053C784cD87B74f42e0c089f98643E79c1A3ff16",
+      "symbol": "CSCOx",
+      "name": "Cisco xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CSCOx.png"
+    },
+    {
+      "address": "0x05473ceA3774D898C7b6dDa21e1876D6Bca7277b",
+      "symbol": "PALLx",
+      "name": "abrdn Physical Palladium Shares xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PALLx.png"
+    },
+    {
+      "address": "0x0588e851ec0418d660BeE81230d6c678dAF21d46",
+      "symbol": "MDTx",
+      "name": "Medtronic xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MDTx.png"
+    },
+    {
       "address": "0x0655977feb2f289a4ab78af67bab0d17aab84367",
       "symbol": "scrvUSD",
       "name": "Savings crvUSD",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x0655977feb2f289a4ab78af67bab0d17aab84367/logo.png"
+    },
+    {
+      "address": "0x06A0138F8c3e5110fd98e34a4473Fb08F1304b87",
+      "symbol": "MOOx",
+      "name": "VanEck Agribusiness ETF xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MOOx.png"
     },
     {
       "address": "0x07c5500359161b81eb0dfff83097d5025d3cf5a2",
@@ -66,6 +114,14 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x090185f2135308bad17527004364ebcc2d37e5f6/logo.png"
+    },
+    {
+      "address": "0x0A62dB029ab8dc0B49b3E8159431728DbD23c7BF",
+      "symbol": "VRTx",
+      "name": "Vertiv Holdings Co xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VRTx.png"
     },
     {
       "symbol": "STAKE",
@@ -116,6 +172,22 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x0d438f3b5175bebc262bf23753c1e53d03432bde/logo.png"
     },
     {
+      "address": "0x0E6607Ab45D2CA779068Cd6D9426C409773969FD",
+      "symbol": "URAx",
+      "name": "Global X Uranium ETF xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/URAx.png"
+    },
+    {
+      "address": "0x0eBe5FAD0998765187FC695B75d4115c27C953A1",
+      "symbol": "KRAQx",
+      "name": "KRAQ xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KRAQx.png"
+    },
+    {
       "symbol": "SYN",
       "name": "Synapse",
       "address": "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
@@ -148,12 +220,28 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x1202f5c7b4b9e47a1a484e8b270be34dbbc75055/logo.png"
     },
     {
+      "address": "0x12992613fDd35aBe95DEc5a4964331b1ee23B50d",
+      "symbol": "BRK.Bx",
+      "name": "Berkshire Hathaway xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BRK.Bx.png"
+    },
+    {
       "symbol": "DPI",
       "name": "DeFi Pulse Index",
       "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b/logo.png"
+    },
+    {
+      "address": "0x15059c599C16Fd8f70B633Ade165502D6402CD49",
+      "symbol": "LINx",
+      "name": "Linde xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LINx.png"
     },
     {
       "address": "0x152649ea73beab28c5b49b26eb48f7ead6d4c898",
@@ -180,6 +268,38 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x163f8c2467924be0ae7b5347228cabf260318753/logo.png"
     },
     {
+      "address": "0x167A6375DA1eFc4a5BE0f470E73eCEfd66245048",
+      "symbol": "UNHx",
+      "name": "UnitedHealth xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UNHx.png"
+    },
+    {
+      "address": "0x16b8feF54489A0BEb2cf09F6F16e4Cd31aEE195a",
+      "symbol": "FLQMx",
+      "name": "Franklin U.S. Mid Cap Multi-Factor xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FLQMx.png"
+    },
+    {
+      "address": "0x16E0B579be45bAaE54cEddd52e742B6457A7fE12",
+      "symbol": "ADBEx",
+      "name": "Adobe xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ADBEx.png"
+    },
+    {
+      "address": "0x17D8186Ed8F68059124190D147174D0f6697dc40",
+      "symbol": "MRKx",
+      "name": "Merck xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MRKx.png"
+    },
+    {
       "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
       "symbol": "tBTC",
       "name": "TBTC",
@@ -194,6 +314,14 @@
       "decimals": 16,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x19062190b1925b5b6689d7073fdfc8c2976ef8cb/logo.png"
+    },
+    {
+      "address": "0x19c41EA77b34BbDEe61c3A87A75D1ABDA2ED0be4",
+      "symbol": "LLYx",
+      "name": "Eli Lilly xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LLYx.png"
     },
     {
       "address": "0x19ebd191f7a24ece672ba13a302212b5ef7f35cb",
@@ -212,12 +340,28 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x1a88df1cfe15af22b3c4c783d4e6f7f9e0c1885d/logo.png"
     },
     {
+      "address": "0x1Aad217B8F78dbA5E6693460e8470F8b1A3977f3",
+      "symbol": "STRCx",
+      "name": "Strategy PP Variable xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/STRCx.png"
+    },
+    {
       "address": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
       "symbol": "EURC",
       "name": "Euro Coin",
       "decimals": 6,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x1abaea1f7c830bd89acc67ec4af516284b1bc33c/logo.png"
+    },
+    {
+      "address": "0x1Ac765B5BEa23184802C7d2d497f7c33f1444A9e",
+      "symbol": "PFEx",
+      "name": "Pfizer xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PFEx.png"
     },
     {
       "address": "0x1bed97cbc3c24a4fb5c069c6e311a967386131f7",
@@ -260,12 +404,60 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984/logo.png"
     },
     {
+      "address": "0x1FD2D7aDAc24B3f9552BC967bFFcDce3B92D31B8",
+      "symbol": "RCATx",
+      "name": "Red Cat xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RCATx.png"
+    },
+    {
+      "address": "0x214151022C2a5E380aB80CdaC31f23Ae554a7345",
+      "symbol": "CRWDx",
+      "name": "CrowdStrike xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRWDx.png"
+    },
+    {
       "symbol": "WBTC",
       "name": "Wrapped BTC",
       "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
       "decimals": 8,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/logo.png"
+    },
+    {
+      "address": "0x22E1991e5f82736A2a990322a46aac0e95826c5B",
+      "symbol": "BTBTx",
+      "name": "Bit Digital xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BTBTx.png"
+    },
+    {
+      "address": "0x2363FD1235C1B6d3A5088DdF8dF3A0b3A30C5293",
+      "symbol": "Vx",
+      "name": "Visa xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/Vx.png"
+    },
+    {
+      "address": "0x2380F2673C640fB67E2d6B55B44C62F0E0e69DA9",
+      "symbol": "GLDx",
+      "name": "Gold xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GLDx.png"
+    },
+    {
+      "address": "0x238C2306b77a0C33fF609e72F89bf7e1323A9999",
+      "symbol": "NLRx",
+      "name": "VanEck Uranium and Nuclear xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NLRx.png"
     },
     {
       "address": "0x24ae2da0f361aa4be46b48eb19c91e02c5e4f27e",
@@ -284,12 +476,36 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x259338656198ec7a76c729514d3cb45dfbf768a1/logo.png"
     },
     {
+      "address": "0x2782dF1cC877F720C81B4f6568Db64563F1D3AA3",
+      "symbol": "DELLx",
+      "name": "Dell Technologies Inc. xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DELLx.png"
+    },
+    {
+      "address": "0x27aD5CC5242f4258030D81A5639098ce0a96820F",
+      "symbol": "ANETx",
+      "name": "Arista Networks, Inc. xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ANETx.png"
+    },
+    {
       "address": "0x27b5739e22ad9033bcbf192059122d163b60349d",
       "symbol": "yvyCRV",
       "name": "yCRV Vault",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x27b5739e22ad9033bcbf192059122d163b60349d/logo.png"
+    },
+    {
+      "address": "0x299c95Eb52BFd5Bc98d924bCE17197b64864589B",
+      "symbol": "EWYx",
+      "name": "iShares MSCI South Korea xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWYx.png"
     },
     {
       "address": "0x2a8c22e3b10036f3aef5875d04f8441d4188b656",
@@ -324,12 +540,44 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x2b591e99afe9f32eaa6214f7b7629768c40eeb39/logo.png"
     },
     {
+      "address": "0x2daFA4732c8c1b25701a33B05F10f437F9599326",
+      "symbol": "SGOVx",
+      "name": "iShares 0-3 Month Treasury Bond ETF xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SGOVx.png"
+    },
+    {
       "symbol": "TOKE",
       "name": "Tokemak",
       "address": "0x2e9d63788249371f1dfc918a52f8d799f4a38c94",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x2e9d63788249371f1dfc918a52f8d799f4a38c94/logo.png"
+    },
+    {
+      "address": "0x2f9a35aB5dDFBc49927BFdEab98A86c53DC6E763",
+      "symbol": "AMBRx",
+      "name": "Amber xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMBRx.png"
+    },
+    {
+      "address": "0x314938c596F5ce31C3f75307d2979338C346D7F2",
+      "symbol": "BACx",
+      "name": "Bank of America xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BACx.png"
+    },
+    {
+      "address": "0x338791c58fdED314b81EAb139A1A2Fb7967D90d6",
+      "symbol": "SBETx",
+      "name": "SharpLink Gaming xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SBETx.png"
     },
     {
       "symbol": "dsETH",
@@ -356,6 +604,38 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x3472a5a71965499acd81997a54bba8d852c6e53d/logo.png"
     },
     {
+      "address": "0x3481a7c02A9B467630E77a7Cce91a25396414C6D",
+      "symbol": "FGDLx",
+      "name": "Franklin Responsibly Sourced Gold ETF xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FGDLx.png"
+    },
+    {
+      "address": "0x3522513E5F146a2006e2901b05f16B2821485E19",
+      "symbol": "AMDx",
+      "name": "AMD xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMDx.png"
+    },
+    {
+      "address": "0x3557Ba345B01EFa20A1bdDC61F573BFD87195081",
+      "symbol": "AMZNx",
+      "name": "Amazon.com xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMZNx.png"
+    },
+    {
+      "address": "0x35B8bBd1eB42bB2B5B4894D0Fe87b2812442e186",
+      "symbol": "IQMx",
+      "name": "Franklin Intelligent Machines xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IQMx.png"
+    },
+    {
       "address": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
       "symbol": "bUSD0",
       "name": "Bond USD0",
@@ -372,12 +652,44 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x35fa164735182de50811e8e2e824cfb9b6118ac2/logo.png"
     },
     {
+      "address": "0x364f210f430eC2448Fc68A49203040F6124096F0",
+      "symbol": "COINx",
+      "name": "Coinbase xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/COINx.png"
+    },
+    {
+      "address": "0x368192fEC58e3150600A1409c631c77F45745BEc",
+      "symbol": "USPXx",
+      "name": "Franklin U.S. Equity Index xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/USPXx.png"
+    },
+    {
+      "address": "0x36c424a6EC0e264b1616102Ad63eD2aD7857413e",
+      "symbol": "PEPx",
+      "name": "PepsiCo xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PEPx.png"
+    },
+    {
       "symbol": "gtcETH",
       "name": "Gitcoin Staked ETH Index",
       "address": "0x36c833Eed0D376f75D1ff9dFDeE260191336065e",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x36c833eed0d376f75d1ff9dfdee260191336065e/logo.png"
+    },
+    {
+      "address": "0x375B9F00A83132cABcDa7aBf2bfc87c14f7AC324",
+      "symbol": "ITAx",
+      "name": "iShares U.S. Aerospace & Defense ETF xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ITAx.png"
     },
     {
       "symbol": "SAND",
@@ -388,6 +700,22 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x3845badade8e6dff049820680d1f14bd3903a5d0/logo.png"
     },
     {
+      "address": "0x38BAC69cbBd28156796e4163B2B6dcb81E336565",
+      "symbol": "AVGOx",
+      "name": "Broadcom xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AVGOx.png"
+    },
+    {
+      "address": "0x38E0445308E7FcD5230F2DF6b52B36DD4FF313b6",
+      "symbol": "STRKx",
+      "name": "Strategy PP Fixed xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/STRKx.png"
+    },
+    {
       "address": "0x39b8b6385416f4ca36a20319f70d28621895279d",
       "symbol": "EURe",
       "name": "Monerium EURe",
@@ -396,12 +724,52 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x39b8b6385416f4ca36a20319f70d28621895279d/logo.png"
     },
     {
+      "address": "0x39c31fC6038490eA4Bf8A21Ca18CD18F33B8d3FB",
+      "symbol": "SMCIx",
+      "name": "Super Micro Computer, Inc. xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SMCIx.png"
+    },
+    {
+      "address": "0x3a62B4259E5C2E2314E254B2C79ebaF5E57e8Cf3",
+      "symbol": "GDXx",
+      "name": "VanEck Gold Miners xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GDXx.png"
+    },
+    {
+      "address": "0x3bf2E3be4A829Bb3a5f5BE450AE4c8Eb3488da71",
+      "symbol": "JAAAx",
+      "name": "Janus Henderson AAA CLO xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JAAAx.png"
+    },
+    {
+      "address": "0x3Ee7E9B3A992fD23CD1C363B0e296856B04ab149",
+      "symbol": "GSx",
+      "name": "Goldman Sachs xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GSx.png"
+    },
+    {
       "address": "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f",
       "symbol": "GHO",
       "name": "GHO",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f/logo.png"
+    },
+    {
+      "address": "0x4177D16A5d2465CF4bd52E07c1c56ab500243FD4",
+      "symbol": "LRCXx",
+      "name": "Lam Research Corporation xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LRCXx.png"
     },
     {
       "address": "0x419905009e4656fdc02418c7df35b1e61ed5f726",
@@ -420,6 +788,22 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f/logo.png"
     },
     {
+      "address": "0x44314De3E69fd4C99fb638816B58ED2a85d466D9",
+      "symbol": "FLBLx",
+      "name": "Franklin Senior Loan xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FLBLx.png"
+    },
+    {
+      "address": "0x44E49ddE02c954cD9B67923af7B1070412e8f34e",
+      "symbol": "VIDAx",
+      "name": "Vida Global xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VIDAx.png"
+    },
+    {
       "address": "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
       "symbol": "POL",
       "name": "Polygon Ecosystem Token",
@@ -436,6 +820,14 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x465a5a630482f3abd6d3b84b39b29b07214d19e5/logo.png"
     },
     {
+      "address": "0x4833e7f4f0460f4B72A3a5879A6C9841bCC5B58B",
+      "symbol": "SLVx",
+      "name": "iShares Silver Trust xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SLVx.png"
+    },
+    {
       "address": "0x4956b52ae2ff65d74ca2d61207523288e4528f96",
       "symbol": "RLP",
       "name": "Resolv Liquidity Provider Token",
@@ -444,12 +836,36 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x4956b52ae2ff65d74ca2d61207523288e4528f96/logo.png"
     },
     {
+      "address": "0x4A4073f2EAF299A1be22254DCD2C41727F6F54a2",
+      "symbol": "CRMx",
+      "name": "Salesforce xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRMx.png"
+    },
+    {
+      "address": "0x4b0eE7C047D43cA403239f28f42115bEdB7c0076",
+      "symbol": "OKLOx",
+      "name": "Oklo xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/OKLOx.png"
+    },
+    {
       "address": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
       "symbol": "USDe",
       "name": "USDe",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x4c9edd5852cd905f086c759e8383e09bff1e68b3/logo.png"
+    },
+    {
+      "address": "0x4cbf89ED7Bb30b8a860fa86d3c96E9c72931299b",
+      "symbol": "TBLLx",
+      "name": "TBLL xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TBLLx.png"
     },
     {
       "symbol": "FTM",
@@ -468,6 +884,22 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b/logo.png"
     },
     {
+      "address": "0x50343212d7AADd7a104dCc7Ed751514aA174D9dC",
+      "symbol": "ONDSx",
+      "name": "Ondas xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ONDSx.png"
+    },
+    {
+      "address": "0x50a1291F69D9d3853Def8209cFb1AF0b46927BE1",
+      "symbol": "APPx",
+      "name": "AppLovin xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/APPx.png"
+    },
+    {
       "symbol": "LINK",
       "name": "Chain Link",
       "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -476,12 +908,76 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x514910771af9ca656af840dff83e8264ecf986ca/logo.png"
     },
     {
+      "address": "0x51eD5b74A05F256DbD9Ebb4e4f68Bb41ba10160b",
+      "symbol": "CORZx",
+      "name": "Core Scientific xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CORZx.png"
+    },
+    {
+      "address": "0x521860bB5dF5468358875266B89BFE90d990C6e7",
+      "symbol": "DFDVx",
+      "name": "DFDV xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DFDVx.png"
+    },
+    {
+      "address": "0x536825370F1159cBA953055f5c2F16DDc7B5a348",
+      "symbol": "PLx",
+      "name": "Planet Labs xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PLx.png"
+    },
+    {
+      "address": "0x53EE7F58Cf031Ea4d897FDFCDafAd124b3160689",
+      "symbol": "SOXLx",
+      "name": "Direxion Semiconductor Bull 3X xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SOXLx.png"
+    },
+    {
+      "address": "0x548308E91ec9F285C7bFf05295baDBD56a6e4971",
+      "symbol": "ORCLx",
+      "name": "Oracle xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ORCLx.png"
+    },
+    {
+      "address": "0x55600dfB3943a2db1A49b250e1E9114E4AD2174f",
+      "symbol": "HIMSx",
+      "name": "Hims & Hers xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HIMSx.png"
+    },
+    {
       "address": "0x56072c95faa701256059aa122697b133aded9279",
       "symbol": "SKY",
       "name": "SKY Governance Token",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x56072c95faa701256059aa122697b133aded9279/logo.png"
+    },
+    {
+      "address": "0x560deb3D70Ac90064fF809349cDf9A771a06fd36",
+      "symbol": "HUTx",
+      "name": "Hut 8 xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HUTx.png"
+    },
+    {
+      "address": "0x5621737f42dAE558b81269FcB9E9E70c19Aa6b35",
+      "symbol": "MSFTx",
+      "name": "Microsoft xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MSFTx.png"
     },
     {
       "address": "0x57f5e098cad7a3d1eed53991d4d66c45c9af7812",
@@ -548,12 +1044,44 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x5cb9073902f2035222b9749f8fb0c9bfe5527108/logo.png"
     },
     {
+      "address": "0x5D642505FE1a28897eb3BaBA665F454755D8daA2",
+      "symbol": "AZNx",
+      "name": "AstraZeneca xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AZNx.png"
+    },
+    {
+      "address": "0x5d8dA1417E3565eb02C9ca8cC588bE5D8F65b1c5",
+      "symbol": "RBLXx",
+      "name": "Roblox xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RBLXx.png"
+    },
+    {
       "symbol": "LUSD",
       "name": "LUSD Stablecoin",
       "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x5f98805a4e8be255a32880fdec7f6728c6568ba0/logo.png"
+    },
+    {
+      "address": "0x5FB4184F8B515B1C54d1baC839DCF81276d6b73e",
+      "symbol": "GEVx",
+      "name": "GE Vernova Inc. xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GEVx.png"
+    },
+    {
+      "address": "0x60Ae7D760a1C7B528C0384Bc945fadF1438F47A5",
+      "symbol": "BTGOx",
+      "name": "Bitgo xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BTGOx.png"
     },
     {
       "symbol": "RBN",
@@ -578,6 +1106,14 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x6243d8cea23066d098a15582d81a598b4e8391f4/logo.png"
+    },
+    {
+      "address": "0x62a48560861B0b451654bFffdb5be6E47aa8ff1B",
+      "symbol": "HONx",
+      "name": "Honeywell xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HONx.png"
     },
     {
       "address": "0x6440f144b7e50d6a8439336510312d2f54beb01d",
@@ -636,6 +1172,14 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x6810e776880c02933d47db1b9fc05908e5386b96/logo.png"
     },
     {
+      "address": "0x68F3DDEE8BAE33691E7CD0372984fD857E842760",
+      "symbol": "TMUSx",
+      "name": "T-Mobile xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TMUSx.png"
+    },
+    {
       "address": "0x6982508145454ce325ddbe47a25d4ec3d2311933",
       "symbol": "PEPE",
       "name": "PEPE",
@@ -650,6 +1194,22 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x6a547b25534234bb79ce6961a23db13de154b6f4/logo.png"
+    },
+    {
+      "address": "0x6a668332825450ACD2e449372057d31b3de16a1E",
+      "symbol": "IEMGx",
+      "name": "Core MSCI Emerging Markets xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IEMGx.png"
+    },
+    {
+      "address": "0x6Ac47387f0a2798dF4C4eE5bb31ab9517ac97cb8",
+      "symbol": "RIOTx",
+      "name": "Riot Platforms xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RIOTx.png"
     },
     {
       "symbol": "DAI",
@@ -668,12 +1228,28 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x6b3595068778dd592e39a122f4f5a5cf09c90fe2/logo.png"
     },
     {
+      "address": "0x6b9Cca56e783d1345785E4aA1188Bbd673E911A2",
+      "symbol": "XOPx",
+      "name": "SPDR S&P Oil & Gas Exploration & Production ETF xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/XOPx.png"
+    },
+    {
       "address": "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
       "symbol": "PYUSD",
       "name": "PayPal USD",
       "decimals": 6,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x6c3ea9036406852006290770bedfcaba0e23a0e8/logo.png"
+    },
+    {
+      "address": "0x6c5287b4EA247031da9e375573E5D1c8A12938EE",
+      "symbol": "EWUx",
+      "name": "iShares MSCI United Kingdom xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWUx.png"
     },
     {
       "address": "0x6c8984bc7dbbedaf4f6b2fd766f16ebb7d10aab4",
@@ -684,6 +1260,22 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x6c8984bc7dbbedaf4f6b2fd766f16ebb7d10aab4/logo.png"
     },
     {
+      "address": "0x6d482CeC5f9dd1f05CCee9Fd3ff79B246170F8e2",
+      "symbol": "PLTRx",
+      "name": "Palantir xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PLTRx.png"
+    },
+    {
+      "address": "0x6d5edEEbBc6A4099Eb8bb289EB3b80D799f7b28C",
+      "symbol": "VTx",
+      "name": "Vanguard Total World xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VTx.png"
+    },
+    {
       "symbol": "LQTY",
       "name": "LQTY",
       "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
@@ -692,12 +1284,36 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d/logo.png"
     },
     {
+      "address": "0x6e0AAfB414B620e096B9F7Fe85625D3E5cE41d3F",
+      "symbol": "VUGx",
+      "name": "Vanguard Growth ETF xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VUGx.png"
+    },
+    {
       "address": "0x6e9455d109202b426169f0d8f01a3332dae160f3",
       "symbol": "lp-yCRVv2",
       "name": "LP Yearn CRV Vault v2",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x6e9455d109202b426169f0d8f01a3332dae160f3/logo.png"
+    },
+    {
+      "address": "0x6Ee270D24B593F85863E95B6a7dd916A5957719f",
+      "symbol": "USARx",
+      "name": "USA Rare Earth Inc. xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/USARx.png"
+    },
+    {
+      "address": "0x6F75AC3b1b6Fbe8Bb5F948e25aF03620f26Ae838",
+      "symbol": "XLEx",
+      "name": "Energy Select Sector SPDR Fund xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/XLEx.png"
     },
     {
       "symbol": "MVI",
@@ -716,6 +1332,22 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x73e0c0d45e048d25fc26fa3159b0aa04bfa4db98/logo.png"
     },
     {
+      "address": "0x7636244Bab612264e1B2dFd4bA6E26d0311b1Eb7",
+      "symbol": "CEGx",
+      "name": "Constellation Energy Corporation xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CEGx.png"
+    },
+    {
+      "address": "0x766b0CD6ED6D90B5d49d2c36a3761E9728501BA9",
+      "symbol": "HDx",
+      "name": "Home Depot xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HDx.png"
+    },
+    {
       "address": "0x7751e2f4b8ae93ef6b79d86419d42fe3295a4559",
       "symbol": "wUSDL",
       "name": "Wrapped USDL (Lift Dollar)",
@@ -732,12 +1364,36 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x777172d858dc1599914a1c4c6c9fc48c99a60990/logo.png"
     },
     {
+      "address": "0x7AEfc9965699fBea943e03264d96e50CD4A97b21",
+      "symbol": "WMTx",
+      "name": "Walmart xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WMTx.png"
+    },
+    {
+      "address": "0x7B14968D19a6C051d6613716ea71f2DaDE46DB9c",
+      "symbol": "SOXXx",
+      "name": "iShares Semiconductor xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SOXXx.png"
+    },
+    {
       "symbol": "icETH",
       "name": "Interest Compounding ETH Index",
       "address": "0x7C07F7aBe10CE8e33DC6C5aD68FE033085256A84",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x7c07f7abe10ce8e33dc6c5ad68fe033085256a84/logo.png"
+    },
+    {
+      "address": "0x7c7445A40926152B8d24aBDb9020e219d3D3380a",
+      "symbol": "SATAx",
+      "name": "Strive, Inc. Series A Preferred xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SATAx.png"
     },
     {
       "symbol": "MATIC",
@@ -748,12 +1404,28 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0/logo.png"
     },
     {
+      "address": "0x7e8c89a9b9B85029caB43280AabBED600D7e8D36",
+      "symbol": "FSMLx",
+      "name": "Franklin Small Cap Enhanced xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FSMLx.png"
+    },
+    {
       "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
       "symbol": "wstETH",
       "name": "Wrapped liquid staked Ether 2.0",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0/logo.png"
+    },
+    {
+      "address": "0x7F8ba411ECBC0A135d669d5EaE5D15b0Ca0b0ea1",
+      "symbol": "SPCEx",
+      "name": "Virgin Galactic xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SPCEx.png"
     },
     {
       "symbol": "AAVE",
@@ -770,6 +1442,14 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x808507121b80c02388fad14726482e061b8da827/logo.png"
+    },
+    {
+      "address": "0x80A77a372c1e12AcCdA84299492f404902E2DA67",
+      "symbol": "MCDx",
+      "name": "McDonald's xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MCDx.png"
     },
     {
       "address": "0x81994b9607e06ab3d5cf3afff9a67374f05f27d7",
@@ -828,12 +1508,52 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab/logo.png"
     },
     {
+      "address": "0x89233399708C18Ac6887F90A2B4Cd8Ba5fEdD06e",
+      "symbol": "ABTx",
+      "name": "Abbott xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ABTx.png"
+    },
+    {
+      "address": "0x89b2607878ae19baB8020b8140eD550Ef3E953bb",
+      "symbol": "ASTSx",
+      "name": "AST SpaceMobile xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ASTSx.png"
+    },
+    {
+      "address": "0x89BAB39D627A9e34f0dc782C53457e80Ee8Fb9D9",
+      "symbol": "COPXx",
+      "name": "Global X Copper Miners xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/COPXx.png"
+    },
+    {
       "address": "0x89e93172aef8261db8437b90c3dcb61545a05317",
       "symbol": "sUSDaf",
       "name": "Savings USDaf",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x89e93172aef8261db8437b90c3dcb61545a05317/logo.png"
+    },
+    {
+      "address": "0x8aD3c73F833d3F9A523aB01476625F269aEB7Cf0",
+      "symbol": "TSLAx",
+      "name": "Tesla xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TSLAx.png"
+    },
+    {
+      "address": "0x8D512a03600981B8e86556fd5C0FbDd726Fe1821",
+      "symbol": "SMHx",
+      "name": "VanEck Semiconductor ETF xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SMHx.png"
     },
     {
       "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -844,12 +1564,52 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x8daebade922df735c38c80c7ebd708af50815faa/logo.png"
     },
     {
+      "address": "0x8e9e4a8d7f1C65dcB42D9103832b27E75946055D",
+      "symbol": "PPLTx",
+      "name": "abrdn Physical Platinum Shares xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PPLTx.png"
+    },
+    {
       "symbol": "GIV",
       "name": "Giveth",
       "address": "0x900db999074d9277c5da2a43f252d74366230da0",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x900db999074d9277c5da2a43f252d74366230da0/logo.png"
+    },
+    {
+      "address": "0x90561f53a83D97C383E4842960969a6d9cfe1Ba9",
+      "symbol": "PWRx",
+      "name": "Quanta Services, Inc. xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PWRx.png"
+    },
+    {
+      "address": "0x90A2a4c76b5D8c0bc892A69EA28Aa775a8f2dD48",
+      "symbol": "SPYx",
+      "name": "SP500 xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SPYx.png"
+    },
+    {
+      "address": "0x91Ea54a8A5426c0A0bEA55968Dd71abcE7b92751",
+      "symbol": "VXUSx",
+      "name": "Vanguard Total International Stock ETF xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VXUSx.png"
+    },
+    {
+      "address": "0x9337a8f11f777cDAa310B5682b09b44Ed8bdcbAD",
+      "symbol": "VGKx",
+      "name": "Vanguard FTSE Europe ETF xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VGKx.png"
     },
     {
       "symbol": "FEI",
@@ -866,6 +1626,14 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce/logo.png"
+    },
+    {
+      "address": "0x96702be57Cd9777f835117a809C7124fe4ec989A",
+      "symbol": "METAx",
+      "name": "Meta xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/METAx.png"
     },
     {
       "address": "0x96f6ef951840721adbf46ac996b59e0235cb985c",
@@ -892,6 +1660,22 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x990f341946a3fdb507ae7e52d17851b87168017c/logo.png"
     },
     {
+      "address": "0x995dB25F900E38851CF4e67a05960E66F774530D",
+      "symbol": "NETx",
+      "name": "Cloudflare xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NETx.png"
+    },
+    {
+      "address": "0x99A1a9BC796bAe48631a15B1C1889625C86B7b98",
+      "symbol": "TERx",
+      "name": "Teradyne, Inc. xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TERx.png"
+    },
+    {
       "symbol": "MIM",
       "name": "Magic Internet Money",
       "address": "0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
@@ -908,12 +1692,44 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x9cf12ccd6020b6888e4d4c4e4c7aca33c1eb91f8/logo.png"
     },
     {
+      "address": "0x9d275685dC284C8eB1C79f6ABA7a63Dc75ec890a",
+      "symbol": "AAPLx",
+      "name": "Apple xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AAPLx.png"
+    },
+    {
       "address": "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
       "symbol": "sUSDe",
       "name": "Staked USDe",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0x9d39a5de30e57443bff2a8307a4256c8797a3497/logo.png"
+    },
+    {
+      "address": "0x9D692bffEf6f6BedF4274053ff9998EFE3B2539E",
+      "symbol": "MARAx",
+      "name": "MARA xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MARAx.png"
+    },
+    {
+      "address": "0x9e3bf4Ecfc44EeDD624F26656B6736a3F093b073",
+      "symbol": "TSMx",
+      "name": "TSMC xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TSMx.png"
+    },
+    {
+      "address": "0x9F7371F5b85443EE59457468eDe9D244A71C08d6",
+      "symbol": "APLDx",
+      "name": "Applied Digital Corporation xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/APLDx.png"
     },
     {
       "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -943,6 +1759,30 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xa3931d71877c0e7a3148cb7eb4463524fec27fbd/logo.png"
     },
     {
+      "address": "0xA6a65AC27E76cD53cB790473E4345c46e5eBf961",
+      "symbol": "NFLXx",
+      "name": "Netflix xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NFLXx.png"
+    },
+    {
+      "address": "0xa753A7395cAe905Cd615Da0B82A53E0560f250af",
+      "symbol": "QQQx",
+      "name": "Nasdaq xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/QQQx.png"
+    },
+    {
+      "address": "0xa90424D5D3E770e8644103AB503ed775dD1318FD",
+      "symbol": "PGx",
+      "name": "Procter & Gamble xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PGx.png"
+    },
+    {
       "address": "0xa95c5ebb86e0de73b4fb8c47a45b792cfea28c23",
       "symbol": "SDL",
       "name": "stake.link",
@@ -951,12 +1791,36 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xa95c5ebb86e0de73b4fb8c47a45b792cfea28c23/logo.png"
     },
     {
+      "address": "0xa96d03Fe2479fEbC69535366933Ea053D5acF9dd",
+      "symbol": "YLDEx",
+      "name": "Franklin ClearBridge Enhanced Income xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/YLDEx.png"
+    },
+    {
+      "address": "0xAA28cB97D7f7E172f54deE950743886D2d65447d",
+      "symbol": "IJRx",
+      "name": "S&P Small Cap xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IJRx.png"
+    },
+    {
       "symbol": "ETH2x-FLI",
       "name": "ETH 2x Flexible Leverage Index",
       "address": "0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd/logo.png"
+    },
+    {
+      "address": "0xAaA9cF4E9488F5eEF064B8CFac70f5FD857669dc",
+      "symbol": "LITEx",
+      "name": "Lumentum Holdings Inc. xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LITEx.png"
     },
     {
       "address": "0xaaee1a9723aadb7afa2810263653a34ba2c21c7a",
@@ -975,6 +1839,30 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xaca92e438df0b2401ff60da7e4337b687a2435da/logo.png"
     },
     {
+      "address": "0xad5cdc3340904285B8159089974A99a1A09EB4C0",
+      "symbol": "CVXx",
+      "name": "Chevron xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CVXx.png"
+    },
+    {
+      "address": "0xAE2f842EF90C0d5213259Ab82639D5BBF649b08E",
+      "symbol": "MSTRx",
+      "name": "MicroStrategy xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MSTRx.png"
+    },
+    {
+      "address": "0xaE6D61508125bC541E367A6a8B1f594ecC42F557",
+      "symbol": "FEZx",
+      "name": "SPDR EURO STOXX 50 xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FEZx.png"
+    },
+    {
       "address": "0xae78736cd615f374d3085123a210448e74fc6393",
       "symbol": "rETH",
       "name": "Rocket Pool ETH",
@@ -989,6 +1877,30 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xae7ab96520de3a18e5e111b5eaab095312d7fe84/logo.png"
+    },
+    {
+      "address": "0xaeB681B69E5094E04d11BCeF51A71358A374C3ED",
+      "symbol": "BMNRx",
+      "name": "Bitmine xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BMNRx.png"
+    },
+    {
+      "address": "0xAF072F109A2C173D822a4fe9af311A1B18F83d19",
+      "symbol": "TMOx",
+      "name": "Thermo Fisher xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TMOx.png"
+    },
+    {
+      "address": "0xb365Cd2588065F522D379AD19e903304f6B622C6",
+      "symbol": "MAx",
+      "name": "Mastercard xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MAx.png"
     },
     {
       "address": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1",
@@ -1007,6 +1919,22 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xb58e61c3098d85632df34eecfb899a1ed80921cb/logo.png"
     },
     {
+      "address": "0xb63EFBc28860c8097e341DE1fCF59456161E9D98",
+      "symbol": "SNDKx",
+      "name": "Sandisk Corporation xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SNDKx.png"
+    },
+    {
+      "address": "0xb7e2E3eF9F5c6b72a162FFc76382e4477A44D913",
+      "symbol": "KLACx",
+      "name": "KLA Corporation xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KLACx.png"
+    },
+    {
       "address": "0xb8b295df2cd735b15be5eb419517aa626fc43cd5",
       "symbol": "stLINK",
       "name": "Staked LINK",
@@ -1023,12 +1951,44 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xba100000625a3754423978a60c9317c58a424e3d/logo.png"
     },
     {
+      "address": "0xBaC2588D2272fF6E5826E2882042Fa2926039CBa",
+      "symbol": "VCXx",
+      "name": "Fundrise Innovation Fund, LLC xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VCXx.png"
+    },
+    {
       "symbol": "alUSD",
       "name": "Alchemix USD",
       "address": "0xbc6da0fe9ad5f3b0d58160288917aa56653660e9",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xbc6da0fe9ad5f3b0d58160288917aa56653660e9/logo.png"
+    },
+    {
+      "address": "0xBC7170a1280Be28513B4e940C681537EB25e39f4",
+      "symbol": "CMCSAx",
+      "name": "Comcast xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CMCSAx.png"
+    },
+    {
+      "address": "0xBca703C64f616A17b4f2763F34f93400Dbe20F17",
+      "symbol": "ETNx",
+      "name": "Eaton Corporation plc xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ETNx.png"
+    },
+    {
+      "address": "0xbD730E618bcD88C82dDeE52e10275CF2f88A4777",
+      "symbol": "VTIx",
+      "name": "Vanguard xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VTIx.png"
     },
     {
       "address": "0xbdc7c08592ee4aa51d06c27ee23d5087d65adbcd",
@@ -1045,6 +2005,14 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xbe9895146f7af43049ca1c1ae358b0541ea49704/logo.png"
+    },
+    {
+      "address": "0xbEe6b69345F376598Fe16AbD5592c6F844825E66",
+      "symbol": "OPENx",
+      "name": "OPEN xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/OPENx.png"
     },
     {
       "address": "0xbf5495efe5db9ce00f80364c8b423567e58d2110",
@@ -1069,6 +2037,22 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/logo.png"
+    },
+    {
+      "address": "0xC0B417e7F83db438631Eb5E096684dd742E5294F",
+      "symbol": "ASMLx",
+      "name": "ASML xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ASMLx.png"
+    },
+    {
+      "address": "0xC0c2150cf0870E2d7aBc7cDe17C20A542faFBB9B",
+      "symbol": "WULFx",
+      "name": "TeraWulf xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WULFx.png"
     },
     {
       "symbol": "AURA",
@@ -1111,6 +2095,14 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xc2544a32872a91f4a553b404c6950e89de901fdb/logo.png"
     },
     {
+      "address": "0xc435b3C41AE56d9Bc57b8525F4d522C978F168e8",
+      "symbol": "WBDx",
+      "name": "Warner Bros. Discovery xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WBDx.png"
+    },
+    {
       "symbol": "HOP",
       "name": "Hop",
       "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
@@ -1133,6 +2125,14 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xc7283b66eb1eb5fb86327f08e1b5816b0720212b/logo.png"
+    },
+    {
+      "address": "0xc845b2894dBddd03858fd2D643B4eF725fE0849d",
+      "symbol": "NVDAx",
+      "name": "NVIDIA xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NVDAx.png"
     },
     {
       "address": "0xcacd6fd266af91b8aed52accc382b4e165586e29",
@@ -1183,6 +2183,14 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xcf62f905562626cfcdd2261162a51fd02fc9c5b6/logo.png"
     },
     {
+      "address": "0xD0194F0f077968DA8ca59811e9407f54AE6c9432",
+      "symbol": "CLSKx",
+      "name": "CleanSpark xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CLSKx.png"
+    },
+    {
       "symbol": "FOLD",
       "name": "Manifold Finance",
       "address": "0xd084944d3c05cd115c09d072b9f44ba3e0e45921",
@@ -1223,12 +2231,68 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xd533a949740bb3306d119cc777fa900ba034cd52/logo.png"
     },
     {
+      "address": "0xD5859517180e639D50003FdB434E690aB1FBD21b",
+      "symbol": "MDLNx",
+      "name": "Medline xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MDLNx.png"
+    },
+    {
+      "address": "0xd9913208647671Fe0F48F7F260076B2C6F310Aac",
+      "symbol": "IBMx",
+      "name": "International Business Machines xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IBMx.png"
+    },
+    {
+      "address": "0xD9FC3E075d45254a1D834fEa18AF8041207DeA0A",
+      "symbol": "JPMx",
+      "name": "JPMorgan Chase xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JPMx.png"
+    },
+    {
       "symbol": "USDT",
       "name": "Tether USD",
       "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
       "decimals": 6,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xdac17f958d2ee523a2206206994597c13d831ec7/logo.png"
+    },
+    {
+      "address": "0xdadfb355c6110eda0908740d52c834d6C2BCDDc7",
+      "symbol": "IWMx",
+      "name": "Russell 2000 xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IWMx.png"
+    },
+    {
+      "address": "0xdb0482cfaD4789798623E64b15eebA01b16e917C",
+      "symbol": "JNJx",
+      "name": "Johnson & Johnson xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JNJx.png"
+    },
+    {
+      "address": "0xdb9783Ca04bBD64fe2c6d7B9503A979b3DE30729",
+      "symbol": "UBERx",
+      "name": "Uber xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UBERx.png"
+    },
+    {
+      "address": "0xdbA228936F4079DaF9Aa906fd48a87f2300405F4",
+      "symbol": "DHRx",
+      "name": "Danaher xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DHRx.png"
     },
     {
       "symbol": "ALCX",
@@ -1245,6 +2309,22 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xdc035d45d973e3ec169d2276ddab16f1e407384f/logo.png"
+    },
+    {
+      "address": "0xdCC1a2699441079dA889B1F49e12B69cC791129b",
+      "symbol": "KOx",
+      "name": "Coca-Cola xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KOx.png"
+    },
+    {
+      "address": "0xdce993F8a6DbcE7F27434874F5DFe9A8d58509c9",
+      "symbol": "LNGx",
+      "name": "Cheniere Energy xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LNGx.png"
     },
     {
       "address": "0xdd1ad9a21ce722c151a836373babe42c868ce9a4",
@@ -1287,6 +2367,38 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xe07f9d810a48ab5c3c914ba3ca53af14e4491e8a/logo.png"
     },
     {
+      "address": "0xE0F324A026ca55492637009d98034103Db4a6967",
+      "symbol": "SLMTx",
+      "name": "Brera xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SLMTx.png"
+    },
+    {
+      "address": "0xe12BB32D77BE4DB10DDC82088b230D35d097E9C5",
+      "symbol": "PANWx",
+      "name": "Palo Alto Networks xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PANWx.png"
+    },
+    {
+      "address": "0xE1385FDd5ffB10081Cd52C56584F25EFa9084015",
+      "symbol": "HOODx",
+      "name": "Robinhood xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HOODx.png"
+    },
+    {
+      "address": "0xE1435b2f302edf42AE84a306a5e1948b270B6CCb",
+      "symbol": "BITXx",
+      "name": "Volatility Shares 2x Bitcoin Strategy xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BITXx.png"
+    },
+    {
       "address": "0xe1753f2e00940cc31213dd92013cf019dfe4ca1d",
       "symbol": "sGHO",
       "name": "Savings GHO",
@@ -1311,12 +2423,44 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xe3668873d944e4a949da05fc8bde419eff543882/logo.png"
     },
     {
+      "address": "0xE49922893496b17AC12Fdd7c74720a92010d889D",
+      "symbol": "JPSTx",
+      "name": "JPMorgan Ultra-Short Income xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JPSTx.png"
+    },
+    {
+      "address": "0xE5f6d3b2405ABdfE6F660e63202B25D23763160d",
+      "symbol": "GMEx",
+      "name": "Gamestop xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GMEx.png"
+    },
+    {
       "address": "0xe60779cc1b2c1d0580611c526a8df0e3f870ec48",
       "symbol": "USH",
       "name": "unshETHing_Token",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xe60779cc1b2c1d0580611c526a8df0e3f870ec48/logo.png"
+    },
+    {
+      "address": "0xe75AfF5123D9De91A1c27167C6C01B1f5b1eAb14",
+      "symbol": "ENHAx",
+      "name": "Enhanced Group xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ENHAx.png"
+    },
+    {
+      "address": "0xe92f673Ca36C5E2Efd2DE7628f815f84807e803F",
+      "symbol": "GOOGLx",
+      "name": "Alphabet xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GOOGLx.png"
     },
     {
       "address": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
@@ -1327,12 +2471,52 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xe95a203b1a91a908f9b9ce46459d101078c2c3cb/logo.png"
     },
     {
+      "address": "0xe95ab205e333443D7970336D5fD827eF9eD97608",
+      "symbol": "TONXx",
+      "name": "TON xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TONXx.png"
+    },
+    {
+      "address": "0xe9FA01197B7E836982a1cab03FE591F7e331E313",
+      "symbol": "AMATx",
+      "name": "Applied Materials, Inc. xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMATx.png"
+    },
+    {
+      "address": "0xeAAd46F4146Ded5a47B55AA7F6c48c191dEAEC88",
+      "symbol": "MRVLx",
+      "name": "Marvell xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MRVLx.png"
+    },
+    {
+      "address": "0xebb35d5b5Bf82203812e3C02797EF0cBDBb81146",
+      "symbol": "EWQx",
+      "name": "iShares MSCI France xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWQx.png"
+    },
+    {
       "address": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
       "symbol": "EIGEN",
       "name": "EIGEN",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xec53bf9167f50cdeb3ae105f56099aaab9061f83/logo.png"
+    },
+    {
+      "address": "0xeD2Bdd82366728C1F2A7E8B93C4dD4A58404BF65",
+      "symbol": "EWGx",
+      "name": "iShares MSCI Germany xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWGx.png"
     },
     {
       "symbol": "WARP",
@@ -1343,12 +2527,84 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xed40834a13129509a89be39a9be9c0e96a0ddd71/logo.png"
     },
     {
+      "address": "0xEd579847e45B0c48cfd608Da829073B2F7e65Cf0",
+      "symbol": "UUUUx",
+      "name": "Energy Fuels Inc. xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UUUUx.png"
+    },
+    {
+      "address": "0xEEdb0273c5Af792745180e9fF568cD01550fFA13",
+      "symbol": "XOMx",
+      "name": "Exxon Mobil xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/XOMx.png"
+    },
+    {
       "symbol": "ICE",
       "name": "IceToken",
       "address": "0xf16e81dce15b08f326220742020379b855b87df9",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xf16e81dce15b08f326220742020379b855b87df9/logo.png"
+    },
+    {
+      "address": "0xF51565240E667176c532DB4139386E6A6E506d99",
+      "symbol": "FAAAx",
+      "name": "Fidelity AAA CLO xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FAAAx.png"
+    },
+    {
+      "address": "0xf6a873BAe4Ba1B304e45dF52A4b7D176E1C6a8c4",
+      "symbol": "MUx",
+      "name": "Micron Technology xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MUx.png"
+    },
+    {
+      "address": "0xF6D87E523512704C29E9b7cA3e9e6226bDCE3EA1",
+      "symbol": "SCHFx",
+      "name": "Schwab International Equity xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SCHFx.png"
+    },
+    {
+      "address": "0xf706585e7e8900bE0267bEE3B9A2F70835EC6628",
+      "symbol": "PYPLx",
+      "name": "PayPal xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PYPLx.png"
+    },
+    {
+      "address": "0xf7F4fAC56f012dE7Dd6adFF54C761986B9E0655a",
+      "symbol": "GLXYx",
+      "name": "Galaxy Digital xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GLXYx.png"
+    },
+    {
+      "address": "0xF8228D64435B55687157a5C9b132642FE04aC381",
+      "symbol": "SMRx",
+      "name": "NuScale Power Corporation xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SMRx.png"
+    },
+    {
+      "address": "0xf8A80D1cb9cFD70D03D655D9dF42339846F3B3C8",
+      "symbol": "INTCx",
+      "name": "Intel xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/INTCx.png"
     },
     {
       "symbol": "VISR",
@@ -1375,6 +2631,14 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xf951e335afb289353dc249e82926178eac7ded78/logo.png"
     },
     {
+      "address": "0xF9523E369c5f55ad72DbAA75B0a9b92B3D8b147e",
+      "symbol": "NVOx",
+      "name": "Novo Nordisk xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NVOx.png"
+    },
+    {
       "address": "0xfa2b947eec368f42195f24f36d2af29f7c24cec2",
       "symbol": "USDf",
       "name": "Falcon USD",
@@ -1389,6 +2653,22 @@
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xfae103dc9cf190ed75350761e95403b7b8afa6c0/logo.png"
+    },
+    {
+      "address": "0xfBF2398dF672cEE4aFcC2A4A733222331c742a6A",
+      "symbol": "ABBVx",
+      "name": "AbbVie xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ABBVx.png"
+    },
+    {
+      "address": "0xfBfc1FD14EeC970276c8a3BF5e6131cD751cC0B9",
+      "symbol": "IRENx",
+      "name": "IREN xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IRENx.png"
     },
     {
       "address": "0xfcc5c47be19d06bf83eb04298b026f81069ff65b",
@@ -1415,12 +2695,188 @@
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xfd0205066521550d7d7ab19da8f72bb004b4c341/logo.png"
     },
     {
+      "address": "0xfDDDb57878eF9D6f681Ec4381DCB626b9E69AC86",
+      "symbol": "TQQQx",
+      "name": "TQQQ xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TQQQx.png"
+    },
+    {
       "address": "0xfe4bce4b3949c35fb17691d8b03c3cadbe2e5e23",
       "symbol": "stRESOLV",
       "name": "Staked Resolv",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://files.cow.fi/token-lists/images/1/0xfe4bce4b3949c35fb17691d8b03c3cadbe2e5e23/logo.png"
+    },
+    {
+      "address": "0xFe7B11D43cfD9fd6010f1b3F9cC86e5BCDb2bc78",
+      "symbol": "DAXx",
+      "name": "Global X DAX Germany xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DAXx.png"
+    },
+    {
+      "address": "0xfEbDEd1B0986a8ee107f5AB1a1c5a813491DeCEB",
+      "symbol": "CRCLx",
+      "name": "Circle xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRCLx.png"
+    },
+    {
+      "address": "0xFfAE0B911CB2cb7B49FD75011D99D137C040A9eF",
+      "symbol": "VOOx",
+      "name": "Vanguard S&P 500 xStock",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VOOx.png"
+    },
+    {
+      "address": "0x02a6c1789c3B4FDb1a7a3DfA39F90e5d3c94F4F9",
+      "symbol": "PMx",
+      "name": "Philip Morris xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PMx.png"
+    },
+    {
+      "address": "0x03183Ce31b1656B72A55fa6056e287f50C35BbEB",
+      "symbol": "ACNx",
+      "name": "Accenture xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ACNx.png"
+    },
+    {
+      "address": "0x053C784cD87B74f42e0c089f98643E79c1A3ff16",
+      "symbol": "CSCOx",
+      "name": "Cisco xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CSCOx.png"
+    },
+    {
+      "address": "0x05473ceA3774D898C7b6dDa21e1876D6Bca7277b",
+      "symbol": "PALLx",
+      "name": "abrdn Physical Palladium Shares xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PALLx.png"
+    },
+    {
+      "address": "0x0588e851ec0418d660BeE81230d6c678dAF21d46",
+      "symbol": "MDTx",
+      "name": "Medtronic xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MDTx.png"
+    },
+    {
+      "address": "0x06A0138F8c3e5110fd98e34a4473Fb08F1304b87",
+      "symbol": "MOOx",
+      "name": "VanEck Agribusiness ETF xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MOOx.png"
+    },
+    {
+      "address": "0x0A62dB029ab8dc0B49b3E8159431728DbD23c7BF",
+      "symbol": "VRTx",
+      "name": "Vertiv Holdings Co xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VRTx.png"
+    },
+    {
+      "address": "0x0E6607Ab45D2CA779068Cd6D9426C409773969FD",
+      "symbol": "URAx",
+      "name": "Global X Uranium ETF xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/URAx.png"
+    },
+    {
+      "address": "0x0eBe5FAD0998765187FC695B75d4115c27C953A1",
+      "symbol": "KRAQx",
+      "name": "KRAQ xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KRAQx.png"
+    },
+    {
+      "address": "0x12992613fDd35aBe95DEc5a4964331b1ee23B50d",
+      "symbol": "BRK.Bx",
+      "name": "Berkshire Hathaway xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BRK.Bx.png"
+    },
+    {
+      "address": "0x15059c599C16Fd8f70B633Ade165502D6402CD49",
+      "symbol": "LINx",
+      "name": "Linde xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LINx.png"
+    },
+    {
+      "address": "0x167A6375DA1eFc4a5BE0f470E73eCEfd66245048",
+      "symbol": "UNHx",
+      "name": "UnitedHealth xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UNHx.png"
+    },
+    {
+      "address": "0x16b8feF54489A0BEb2cf09F6F16e4Cd31aEE195a",
+      "symbol": "FLQMx",
+      "name": "Franklin U.S. Mid Cap Multi-Factor xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FLQMx.png"
+    },
+    {
+      "address": "0x16E0B579be45bAaE54cEddd52e742B6457A7fE12",
+      "symbol": "ADBEx",
+      "name": "Adobe xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ADBEx.png"
+    },
+    {
+      "address": "0x17D8186Ed8F68059124190D147174D0f6697dc40",
+      "symbol": "MRKx",
+      "name": "Merck xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MRKx.png"
+    },
+    {
+      "address": "0x19c41EA77b34BbDEe61c3A87A75D1ABDA2ED0be4",
+      "symbol": "LLYx",
+      "name": "Eli Lilly xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LLYx.png"
+    },
+    {
+      "address": "0x1Aad217B8F78dbA5E6693460e8470F8b1A3977f3",
+      "symbol": "STRCx",
+      "name": "Strategy PP Variable xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/STRCx.png"
+    },
+    {
+      "address": "0x1Ac765B5BEa23184802C7d2d497f7c33f1444A9e",
+      "symbol": "PFEx",
+      "name": "Pfizer xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PFEx.png"
     },
     {
       "address": "0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3",
@@ -1439,12 +2895,364 @@
       "logoURI": "https://files.cow.fi/token-lists/images/56/0x1ba42e5193dfa8b03d15dd1b86a3113bbbef8eeb/logo.png"
     },
     {
+      "address": "0x1FD2D7aDAc24B3f9552BC967bFFcDce3B92D31B8",
+      "symbol": "RCATx",
+      "name": "Red Cat xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RCATx.png"
+    },
+    {
+      "address": "0x214151022C2a5E380aB80CdaC31f23Ae554a7345",
+      "symbol": "CRWDx",
+      "name": "CrowdStrike xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRWDx.png"
+    },
+    {
+      "address": "0x22E1991e5f82736A2a990322a46aac0e95826c5B",
+      "symbol": "BTBTx",
+      "name": "Bit Digital xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BTBTx.png"
+    },
+    {
+      "address": "0x2363FD1235C1B6d3A5088DdF8dF3A0b3A30C5293",
+      "symbol": "Vx",
+      "name": "Visa xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/Vx.png"
+    },
+    {
+      "address": "0x2380F2673C640fB67E2d6B55B44C62F0E0e69DA9",
+      "symbol": "GLDx",
+      "name": "Gold xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GLDx.png"
+    },
+    {
+      "address": "0x238C2306b77a0C33fF609e72F89bf7e1323A9999",
+      "symbol": "NLRx",
+      "name": "VanEck Uranium and Nuclear xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NLRx.png"
+    },
+    {
+      "address": "0x2782dF1cC877F720C81B4f6568Db64563F1D3AA3",
+      "symbol": "DELLx",
+      "name": "Dell Technologies Inc. xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DELLx.png"
+    },
+    {
+      "address": "0x27aD5CC5242f4258030D81A5639098ce0a96820F",
+      "symbol": "ANETx",
+      "name": "Arista Networks, Inc. xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ANETx.png"
+    },
+    {
+      "address": "0x299c95Eb52BFd5Bc98d924bCE17197b64864589B",
+      "symbol": "EWYx",
+      "name": "iShares MSCI South Korea xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWYx.png"
+    },
+    {
+      "address": "0x2daFA4732c8c1b25701a33B05F10f437F9599326",
+      "symbol": "SGOVx",
+      "name": "iShares 0-3 Month Treasury Bond ETF xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SGOVx.png"
+    },
+    {
+      "address": "0x2f9a35aB5dDFBc49927BFdEab98A86c53DC6E763",
+      "symbol": "AMBRx",
+      "name": "Amber xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMBRx.png"
+    },
+    {
+      "address": "0x314938c596F5ce31C3f75307d2979338C346D7F2",
+      "symbol": "BACx",
+      "name": "Bank of America xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BACx.png"
+    },
+    {
+      "address": "0x338791c58fdED314b81EAb139A1A2Fb7967D90d6",
+      "symbol": "SBETx",
+      "name": "SharpLink Gaming xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SBETx.png"
+    },
+    {
+      "address": "0x3481a7c02A9B467630E77a7Cce91a25396414C6D",
+      "symbol": "FGDLx",
+      "name": "Franklin Responsibly Sourced Gold ETF xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FGDLx.png"
+    },
+    {
+      "address": "0x3522513E5F146a2006e2901b05f16B2821485E19",
+      "symbol": "AMDx",
+      "name": "AMD xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMDx.png"
+    },
+    {
+      "address": "0x3557Ba345B01EFa20A1bdDC61F573BFD87195081",
+      "symbol": "AMZNx",
+      "name": "Amazon.com xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMZNx.png"
+    },
+    {
+      "address": "0x35B8bBd1eB42bB2B5B4894D0Fe87b2812442e186",
+      "symbol": "IQMx",
+      "name": "Franklin Intelligent Machines xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IQMx.png"
+    },
+    {
+      "address": "0x364f210f430eC2448Fc68A49203040F6124096F0",
+      "symbol": "COINx",
+      "name": "Coinbase xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/COINx.png"
+    },
+    {
+      "address": "0x368192fEC58e3150600A1409c631c77F45745BEc",
+      "symbol": "USPXx",
+      "name": "Franklin U.S. Equity Index xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/USPXx.png"
+    },
+    {
+      "address": "0x36c424a6EC0e264b1616102Ad63eD2aD7857413e",
+      "symbol": "PEPx",
+      "name": "PepsiCo xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PEPx.png"
+    },
+    {
+      "address": "0x375B9F00A83132cABcDa7aBf2bfc87c14f7AC324",
+      "symbol": "ITAx",
+      "name": "iShares U.S. Aerospace & Defense ETF xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ITAx.png"
+    },
+    {
+      "address": "0x38BAC69cbBd28156796e4163B2B6dcb81E336565",
+      "symbol": "AVGOx",
+      "name": "Broadcom xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AVGOx.png"
+    },
+    {
+      "address": "0x38E0445308E7FcD5230F2DF6b52B36DD4FF313b6",
+      "symbol": "STRKx",
+      "name": "Strategy PP Fixed xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/STRKx.png"
+    },
+    {
+      "address": "0x39c31fC6038490eA4Bf8A21Ca18CD18F33B8d3FB",
+      "symbol": "SMCIx",
+      "name": "Super Micro Computer, Inc. xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SMCIx.png"
+    },
+    {
+      "address": "0x3a62B4259E5C2E2314E254B2C79ebaF5E57e8Cf3",
+      "symbol": "GDXx",
+      "name": "VanEck Gold Miners xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GDXx.png"
+    },
+    {
+      "address": "0x3bf2E3be4A829Bb3a5f5BE450AE4c8Eb3488da71",
+      "symbol": "JAAAx",
+      "name": "Janus Henderson AAA CLO xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JAAAx.png"
+    },
+    {
+      "address": "0x3Ee7E9B3A992fD23CD1C363B0e296856B04ab149",
+      "symbol": "GSx",
+      "name": "Goldman Sachs xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GSx.png"
+    },
+    {
+      "address": "0x4177D16A5d2465CF4bd52E07c1c56ab500243FD4",
+      "symbol": "LRCXx",
+      "name": "Lam Research Corporation xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LRCXx.png"
+    },
+    {
+      "address": "0x44314De3E69fd4C99fb638816B58ED2a85d466D9",
+      "symbol": "FLBLx",
+      "name": "Franklin Senior Loan xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FLBLx.png"
+    },
+    {
+      "address": "0x44E49ddE02c954cD9B67923af7B1070412e8f34e",
+      "symbol": "VIDAx",
+      "name": "Vida Global xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VIDAx.png"
+    },
+    {
+      "address": "0x4833e7f4f0460f4B72A3a5879A6C9841bCC5B58B",
+      "symbol": "SLVx",
+      "name": "iShares Silver Trust xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SLVx.png"
+    },
+    {
+      "address": "0x4A4073f2EAF299A1be22254DCD2C41727F6F54a2",
+      "symbol": "CRMx",
+      "name": "Salesforce xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRMx.png"
+    },
+    {
+      "address": "0x4b0eE7C047D43cA403239f28f42115bEdB7c0076",
+      "symbol": "OKLOx",
+      "name": "Oklo xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/OKLOx.png"
+    },
+    {
+      "address": "0x4cbf89ED7Bb30b8a860fa86d3c96E9c72931299b",
+      "symbol": "TBLLx",
+      "name": "TBLL xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TBLLx.png"
+    },
+    {
+      "address": "0x50343212d7AADd7a104dCc7Ed751514aA174D9dC",
+      "symbol": "ONDSx",
+      "name": "Ondas xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ONDSx.png"
+    },
+    {
+      "address": "0x50a1291F69D9d3853Def8209cFb1AF0b46927BE1",
+      "symbol": "APPx",
+      "name": "AppLovin xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/APPx.png"
+    },
+    {
+      "address": "0x51eD5b74A05F256DbD9Ebb4e4f68Bb41ba10160b",
+      "symbol": "CORZx",
+      "name": "Core Scientific xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CORZx.png"
+    },
+    {
+      "address": "0x521860bB5dF5468358875266B89BFE90d990C6e7",
+      "symbol": "DFDVx",
+      "name": "DFDV xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DFDVx.png"
+    },
+    {
+      "address": "0x536825370F1159cBA953055f5c2F16DDc7B5a348",
+      "symbol": "PLx",
+      "name": "Planet Labs xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PLx.png"
+    },
+    {
+      "address": "0x53EE7F58Cf031Ea4d897FDFCDafAd124b3160689",
+      "symbol": "SOXLx",
+      "name": "Direxion Semiconductor Bull 3X xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SOXLx.png"
+    },
+    {
+      "address": "0x548308E91ec9F285C7bFf05295baDBD56a6e4971",
+      "symbol": "ORCLx",
+      "name": "Oracle xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ORCLx.png"
+    },
+    {
+      "address": "0x55600dfB3943a2db1A49b250e1E9114E4AD2174f",
+      "symbol": "HIMSx",
+      "name": "Hims & Hers xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HIMSx.png"
+    },
+    {
       "address": "0x55d398326f99059ff775485246999027b3197955",
       "symbol": "USDT",
       "name": "Tether USD",
       "decimals": 18,
       "chainId": 56,
       "logoURI": "https://files.cow.fi/token-lists/images/56/0x55d398326f99059ff775485246999027b3197955/logo.png"
+    },
+    {
+      "address": "0x560deb3D70Ac90064fF809349cDf9A771a06fd36",
+      "symbol": "HUTx",
+      "name": "Hut 8 xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HUTx.png"
+    },
+    {
+      "address": "0x5621737f42dAE558b81269FcB9E9E70c19Aa6b35",
+      "symbol": "MSFTx",
+      "name": "Microsoft xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MSFTx.png"
     },
     {
       "address": "0x5bfdaa3f7c28b9994b56135403bf1acea02595b0",
@@ -1455,12 +3263,220 @@
       "logoURI": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/images/56/0x5bfdaa3f7c28b9994b56135403bf1acea02595b0/logo.png"
     },
     {
+      "address": "0x5D642505FE1a28897eb3BaBA665F454755D8daA2",
+      "symbol": "AZNx",
+      "name": "AstraZeneca xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AZNx.png"
+    },
+    {
+      "address": "0x5d8dA1417E3565eb02C9ca8cC588bE5D8F65b1c5",
+      "symbol": "RBLXx",
+      "name": "Roblox xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RBLXx.png"
+    },
+    {
+      "address": "0x5FB4184F8B515B1C54d1baC839DCF81276d6b73e",
+      "symbol": "GEVx",
+      "name": "GE Vernova Inc. xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GEVx.png"
+    },
+    {
+      "address": "0x60Ae7D760a1C7B528C0384Bc945fadF1438F47A5",
+      "symbol": "BTGOx",
+      "name": "Bitgo xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BTGOx.png"
+    },
+    {
+      "address": "0x62a48560861B0b451654bFffdb5be6E47aa8ff1B",
+      "symbol": "HONx",
+      "name": "Honeywell xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HONx.png"
+    },
+    {
+      "address": "0x68F3DDEE8BAE33691E7CD0372984fD857E842760",
+      "symbol": "TMUSx",
+      "name": "T-Mobile xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TMUSx.png"
+    },
+    {
+      "address": "0x6a668332825450ACD2e449372057d31b3de16a1E",
+      "symbol": "IEMGx",
+      "name": "Core MSCI Emerging Markets xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IEMGx.png"
+    },
+    {
+      "address": "0x6Ac47387f0a2798dF4C4eE5bb31ab9517ac97cb8",
+      "symbol": "RIOTx",
+      "name": "Riot Platforms xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RIOTx.png"
+    },
+    {
+      "address": "0x6b9Cca56e783d1345785E4aA1188Bbd673E911A2",
+      "symbol": "XOPx",
+      "name": "SPDR S&P Oil & Gas Exploration & Production ETF xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/XOPx.png"
+    },
+    {
+      "address": "0x6c5287b4EA247031da9e375573E5D1c8A12938EE",
+      "symbol": "EWUx",
+      "name": "iShares MSCI United Kingdom xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWUx.png"
+    },
+    {
+      "address": "0x6d482CeC5f9dd1f05CCee9Fd3ff79B246170F8e2",
+      "symbol": "PLTRx",
+      "name": "Palantir xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PLTRx.png"
+    },
+    {
+      "address": "0x6d5edEEbBc6A4099Eb8bb289EB3b80D799f7b28C",
+      "symbol": "VTx",
+      "name": "Vanguard Total World xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VTx.png"
+    },
+    {
+      "address": "0x6e0AAfB414B620e096B9F7Fe85625D3E5cE41d3F",
+      "symbol": "VUGx",
+      "name": "Vanguard Growth ETF xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VUGx.png"
+    },
+    {
+      "address": "0x6Ee270D24B593F85863E95B6a7dd916A5957719f",
+      "symbol": "USARx",
+      "name": "USA Rare Earth Inc. xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/USARx.png"
+    },
+    {
+      "address": "0x6F75AC3b1b6Fbe8Bb5F948e25aF03620f26Ae838",
+      "symbol": "XLEx",
+      "name": "Energy Select Sector SPDR Fund xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/XLEx.png"
+    },
+    {
       "address": "0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c",
       "symbol": "BTCB",
       "name": "Binance-Peg BTCB Token",
       "decimals": 18,
       "chainId": 56,
       "logoURI": "https://files.cow.fi/token-lists/images/56/0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c/logo.png"
+    },
+    {
+      "address": "0x7636244Bab612264e1B2dFd4bA6E26d0311b1Eb7",
+      "symbol": "CEGx",
+      "name": "Constellation Energy Corporation xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CEGx.png"
+    },
+    {
+      "address": "0x766b0CD6ED6D90B5d49d2c36a3761E9728501BA9",
+      "symbol": "HDx",
+      "name": "Home Depot xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HDx.png"
+    },
+    {
+      "address": "0x7AEfc9965699fBea943e03264d96e50CD4A97b21",
+      "symbol": "WMTx",
+      "name": "Walmart xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WMTx.png"
+    },
+    {
+      "address": "0x7B14968D19a6C051d6613716ea71f2DaDE46DB9c",
+      "symbol": "SOXXx",
+      "name": "iShares Semiconductor xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SOXXx.png"
+    },
+    {
+      "address": "0x7c7445A40926152B8d24aBDb9020e219d3D3380a",
+      "symbol": "SATAx",
+      "name": "Strive, Inc. Series A Preferred xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SATAx.png"
+    },
+    {
+      "address": "0x7e8c89a9b9B85029caB43280AabBED600D7e8D36",
+      "symbol": "FSMLx",
+      "name": "Franklin Small Cap Enhanced xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FSMLx.png"
+    },
+    {
+      "address": "0x7F8ba411ECBC0A135d669d5EaE5D15b0Ca0b0ea1",
+      "symbol": "SPCEx",
+      "name": "Virgin Galactic xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SPCEx.png"
+    },
+    {
+      "address": "0x80A77a372c1e12AcCdA84299492f404902E2DA67",
+      "symbol": "MCDx",
+      "name": "McDonald's xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MCDx.png"
+    },
+    {
+      "address": "0x89233399708C18Ac6887F90A2B4Cd8Ba5fEdD06e",
+      "symbol": "ABTx",
+      "name": "Abbott xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ABTx.png"
+    },
+    {
+      "address": "0x89b2607878ae19baB8020b8140eD550Ef3E953bb",
+      "symbol": "ASTSx",
+      "name": "AST SpaceMobile xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ASTSx.png"
+    },
+    {
+      "address": "0x89BAB39D627A9e34f0dc782C53457e80Ee8Fb9D9",
+      "symbol": "COPXx",
+      "name": "Global X Copper Miners xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/COPXx.png"
     },
     {
       "address": "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
@@ -1471,6 +3487,238 @@
       "logoURI": "https://files.cow.fi/token-lists/images/56/0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d/logo.png"
     },
     {
+      "address": "0x8aD3c73F833d3F9A523aB01476625F269aEB7Cf0",
+      "symbol": "TSLAx",
+      "name": "Tesla xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TSLAx.png"
+    },
+    {
+      "address": "0x8D512a03600981B8e86556fd5C0FbDd726Fe1821",
+      "symbol": "SMHx",
+      "name": "VanEck Semiconductor ETF xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SMHx.png"
+    },
+    {
+      "address": "0x8e9e4a8d7f1C65dcB42D9103832b27E75946055D",
+      "symbol": "PPLTx",
+      "name": "abrdn Physical Platinum Shares xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PPLTx.png"
+    },
+    {
+      "address": "0x90561f53a83D97C383E4842960969a6d9cfe1Ba9",
+      "symbol": "PWRx",
+      "name": "Quanta Services, Inc. xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PWRx.png"
+    },
+    {
+      "address": "0x90A2a4c76b5D8c0bc892A69EA28Aa775a8f2dD48",
+      "symbol": "SPYx",
+      "name": "SP500 xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SPYx.png"
+    },
+    {
+      "address": "0x91Ea54a8A5426c0A0bEA55968Dd71abcE7b92751",
+      "symbol": "VXUSx",
+      "name": "Vanguard Total International Stock ETF xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VXUSx.png"
+    },
+    {
+      "address": "0x9337a8f11f777cDAa310B5682b09b44Ed8bdcbAD",
+      "symbol": "VGKx",
+      "name": "Vanguard FTSE Europe ETF xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VGKx.png"
+    },
+    {
+      "address": "0x96702be57Cd9777f835117a809C7124fe4ec989A",
+      "symbol": "METAx",
+      "name": "Meta xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/METAx.png"
+    },
+    {
+      "address": "0x995dB25F900E38851CF4e67a05960E66F774530D",
+      "symbol": "NETx",
+      "name": "Cloudflare xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NETx.png"
+    },
+    {
+      "address": "0x99A1a9BC796bAe48631a15B1C1889625C86B7b98",
+      "symbol": "TERx",
+      "name": "Teradyne, Inc. xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TERx.png"
+    },
+    {
+      "address": "0x9d275685dC284C8eB1C79f6ABA7a63Dc75ec890a",
+      "symbol": "AAPLx",
+      "name": "Apple xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AAPLx.png"
+    },
+    {
+      "address": "0x9D692bffEf6f6BedF4274053ff9998EFE3B2539E",
+      "symbol": "MARAx",
+      "name": "MARA xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MARAx.png"
+    },
+    {
+      "address": "0x9e3bf4Ecfc44EeDD624F26656B6736a3F093b073",
+      "symbol": "TSMx",
+      "name": "TSMC xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TSMx.png"
+    },
+    {
+      "address": "0x9F7371F5b85443EE59457468eDe9D244A71C08d6",
+      "symbol": "APLDx",
+      "name": "Applied Digital Corporation xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/APLDx.png"
+    },
+    {
+      "address": "0xA6a65AC27E76cD53cB790473E4345c46e5eBf961",
+      "symbol": "NFLXx",
+      "name": "Netflix xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NFLXx.png"
+    },
+    {
+      "address": "0xa753A7395cAe905Cd615Da0B82A53E0560f250af",
+      "symbol": "QQQx",
+      "name": "Nasdaq xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/QQQx.png"
+    },
+    {
+      "address": "0xa90424D5D3E770e8644103AB503ed775dD1318FD",
+      "symbol": "PGx",
+      "name": "Procter & Gamble xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PGx.png"
+    },
+    {
+      "address": "0xa96d03Fe2479fEbC69535366933Ea053D5acF9dd",
+      "symbol": "YLDEx",
+      "name": "Franklin ClearBridge Enhanced Income xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/YLDEx.png"
+    },
+    {
+      "address": "0xAA28cB97D7f7E172f54deE950743886D2d65447d",
+      "symbol": "IJRx",
+      "name": "S&P Small Cap xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IJRx.png"
+    },
+    {
+      "address": "0xAaA9cF4E9488F5eEF064B8CFac70f5FD857669dc",
+      "symbol": "LITEx",
+      "name": "Lumentum Holdings Inc. xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LITEx.png"
+    },
+    {
+      "address": "0xad5cdc3340904285B8159089974A99a1A09EB4C0",
+      "symbol": "CVXx",
+      "name": "Chevron xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CVXx.png"
+    },
+    {
+      "address": "0xAE2f842EF90C0d5213259Ab82639D5BBF649b08E",
+      "symbol": "MSTRx",
+      "name": "MicroStrategy xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MSTRx.png"
+    },
+    {
+      "address": "0xaE6D61508125bC541E367A6a8B1f594ecC42F557",
+      "symbol": "FEZx",
+      "name": "SPDR EURO STOXX 50 xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FEZx.png"
+    },
+    {
+      "address": "0xaeB681B69E5094E04d11BCeF51A71358A374C3ED",
+      "symbol": "BMNRx",
+      "name": "Bitmine xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BMNRx.png"
+    },
+    {
+      "address": "0xAF072F109A2C173D822a4fe9af311A1B18F83d19",
+      "symbol": "TMOx",
+      "name": "Thermo Fisher xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TMOx.png"
+    },
+    {
+      "address": "0xb365Cd2588065F522D379AD19e903304f6B622C6",
+      "symbol": "MAx",
+      "name": "Mastercard xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MAx.png"
+    },
+    {
+      "address": "0xb63EFBc28860c8097e341DE1fCF59456161E9D98",
+      "symbol": "SNDKx",
+      "name": "Sandisk Corporation xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SNDKx.png"
+    },
+    {
+      "address": "0xb7e2E3eF9F5c6b72a162FFc76382e4477A44D913",
+      "symbol": "KLACx",
+      "name": "KLA Corporation xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KLACx.png"
+    },
+    {
+      "address": "0xBaC2588D2272fF6E5826E2882042Fa2926039CBa",
+      "symbol": "VCXx",
+      "name": "Fundrise Innovation Fund, LLC xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VCXx.png"
+    },
+    {
       "address": "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c",
       "symbol": "WBNB",
       "name": "Wrapped BNB",
@@ -1479,12 +3727,388 @@
       "logoURI": "https://files.cow.fi/token-lists/images/56/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c/logo.png"
     },
     {
+      "address": "0xBC7170a1280Be28513B4e940C681537EB25e39f4",
+      "symbol": "CMCSAx",
+      "name": "Comcast xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CMCSAx.png"
+    },
+    {
+      "address": "0xBca703C64f616A17b4f2763F34f93400Dbe20F17",
+      "symbol": "ETNx",
+      "name": "Eaton Corporation plc xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ETNx.png"
+    },
+    {
+      "address": "0xbD730E618bcD88C82dDeE52e10275CF2f88A4777",
+      "symbol": "VTIx",
+      "name": "Vanguard xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VTIx.png"
+    },
+    {
+      "address": "0xbEe6b69345F376598Fe16AbD5592c6F844825E66",
+      "symbol": "OPENx",
+      "name": "OPEN xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/OPENx.png"
+    },
+    {
+      "address": "0xC0B417e7F83db438631Eb5E096684dd742E5294F",
+      "symbol": "ASMLx",
+      "name": "ASML xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ASMLx.png"
+    },
+    {
+      "address": "0xC0c2150cf0870E2d7aBc7cDe17C20A542faFBB9B",
+      "symbol": "WULFx",
+      "name": "TeraWulf xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WULFx.png"
+    },
+    {
+      "address": "0xc435b3C41AE56d9Bc57b8525F4d522C978F168e8",
+      "symbol": "WBDx",
+      "name": "Warner Bros. Discovery xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WBDx.png"
+    },
+    {
+      "address": "0xc845b2894dBddd03858fd2D643B4eF725fE0849d",
+      "symbol": "NVDAx",
+      "name": "NVIDIA xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NVDAx.png"
+    },
+    {
+      "address": "0xD0194F0f077968DA8ca59811e9407f54AE6c9432",
+      "symbol": "CLSKx",
+      "name": "CleanSpark xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CLSKx.png"
+    },
+    {
+      "address": "0xD5859517180e639D50003FdB434E690aB1FBD21b",
+      "symbol": "MDLNx",
+      "name": "Medline xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MDLNx.png"
+    },
+    {
+      "address": "0xd9913208647671Fe0F48F7F260076B2C6F310Aac",
+      "symbol": "IBMx",
+      "name": "International Business Machines xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IBMx.png"
+    },
+    {
+      "address": "0xD9FC3E075d45254a1D834fEa18AF8041207DeA0A",
+      "symbol": "JPMx",
+      "name": "JPMorgan Chase xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JPMx.png"
+    },
+    {
+      "address": "0xdadfb355c6110eda0908740d52c834d6C2BCDDc7",
+      "symbol": "IWMx",
+      "name": "Russell 2000 xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IWMx.png"
+    },
+    {
+      "address": "0xdb0482cfaD4789798623E64b15eebA01b16e917C",
+      "symbol": "JNJx",
+      "name": "Johnson & Johnson xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JNJx.png"
+    },
+    {
+      "address": "0xdb9783Ca04bBD64fe2c6d7B9503A979b3DE30729",
+      "symbol": "UBERx",
+      "name": "Uber xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UBERx.png"
+    },
+    {
+      "address": "0xdbA228936F4079DaF9Aa906fd48a87f2300405F4",
+      "symbol": "DHRx",
+      "name": "Danaher xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DHRx.png"
+    },
+    {
+      "address": "0xdCC1a2699441079dA889B1F49e12B69cC791129b",
+      "symbol": "KOx",
+      "name": "Coca-Cola xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KOx.png"
+    },
+    {
+      "address": "0xdce993F8a6DbcE7F27434874F5DFe9A8d58509c9",
+      "symbol": "LNGx",
+      "name": "Cheniere Energy xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LNGx.png"
+    },
+    {
+      "address": "0xE0F324A026ca55492637009d98034103Db4a6967",
+      "symbol": "SLMTx",
+      "name": "Brera xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SLMTx.png"
+    },
+    {
+      "address": "0xe12BB32D77BE4DB10DDC82088b230D35d097E9C5",
+      "symbol": "PANWx",
+      "name": "Palo Alto Networks xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PANWx.png"
+    },
+    {
+      "address": "0xE1385FDd5ffB10081Cd52C56584F25EFa9084015",
+      "symbol": "HOODx",
+      "name": "Robinhood xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HOODx.png"
+    },
+    {
+      "address": "0xE1435b2f302edf42AE84a306a5e1948b270B6CCb",
+      "symbol": "BITXx",
+      "name": "Volatility Shares 2x Bitcoin Strategy xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BITXx.png"
+    },
+    {
+      "address": "0xE49922893496b17AC12Fdd7c74720a92010d889D",
+      "symbol": "JPSTx",
+      "name": "JPMorgan Ultra-Short Income xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JPSTx.png"
+    },
+    {
+      "address": "0xE5f6d3b2405ABdfE6F660e63202B25D23763160d",
+      "symbol": "GMEx",
+      "name": "Gamestop xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GMEx.png"
+    },
+    {
+      "address": "0xe75AfF5123D9De91A1c27167C6C01B1f5b1eAb14",
+      "symbol": "ENHAx",
+      "name": "Enhanced Group xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ENHAx.png"
+    },
+    {
+      "address": "0xe92f673Ca36C5E2Efd2DE7628f815f84807e803F",
+      "symbol": "GOOGLx",
+      "name": "Alphabet xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GOOGLx.png"
+    },
+    {
+      "address": "0xe95ab205e333443D7970336D5fD827eF9eD97608",
+      "symbol": "TONXx",
+      "name": "TON xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TONXx.png"
+    },
+    {
       "address": "0xe9e7cea3dedca5984780bafc599bd69add087d56",
       "symbol": "BUSD",
       "name": "Binance-Peg BUSD Token",
       "decimals": 18,
       "chainId": 56,
       "logoURI": "https://files.cow.fi/token-lists/images/56/0xe9e7cea3dedca5984780bafc599bd69add087d56/logo.png"
+    },
+    {
+      "address": "0xe9FA01197B7E836982a1cab03FE591F7e331E313",
+      "symbol": "AMATx",
+      "name": "Applied Materials, Inc. xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMATx.png"
+    },
+    {
+      "address": "0xeAAd46F4146Ded5a47B55AA7F6c48c191dEAEC88",
+      "symbol": "MRVLx",
+      "name": "Marvell xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MRVLx.png"
+    },
+    {
+      "address": "0xebb35d5b5Bf82203812e3C02797EF0cBDBb81146",
+      "symbol": "EWQx",
+      "name": "iShares MSCI France xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWQx.png"
+    },
+    {
+      "address": "0xeD2Bdd82366728C1F2A7E8B93C4dD4A58404BF65",
+      "symbol": "EWGx",
+      "name": "iShares MSCI Germany xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWGx.png"
+    },
+    {
+      "address": "0xEd579847e45B0c48cfd608Da829073B2F7e65Cf0",
+      "symbol": "UUUUx",
+      "name": "Energy Fuels Inc. xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UUUUx.png"
+    },
+    {
+      "address": "0xEEdb0273c5Af792745180e9fF568cD01550fFA13",
+      "symbol": "XOMx",
+      "name": "Exxon Mobil xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/XOMx.png"
+    },
+    {
+      "address": "0xF51565240E667176c532DB4139386E6A6E506d99",
+      "symbol": "FAAAx",
+      "name": "Fidelity AAA CLO xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FAAAx.png"
+    },
+    {
+      "address": "0xf6a873BAe4Ba1B304e45dF52A4b7D176E1C6a8c4",
+      "symbol": "MUx",
+      "name": "Micron Technology xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MUx.png"
+    },
+    {
+      "address": "0xF6D87E523512704C29E9b7cA3e9e6226bDCE3EA1",
+      "symbol": "SCHFx",
+      "name": "Schwab International Equity xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SCHFx.png"
+    },
+    {
+      "address": "0xf706585e7e8900bE0267bEE3B9A2F70835EC6628",
+      "symbol": "PYPLx",
+      "name": "PayPal xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PYPLx.png"
+    },
+    {
+      "address": "0xf7F4fAC56f012dE7Dd6adFF54C761986B9E0655a",
+      "symbol": "GLXYx",
+      "name": "Galaxy Digital xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GLXYx.png"
+    },
+    {
+      "address": "0xF8228D64435B55687157a5C9b132642FE04aC381",
+      "symbol": "SMRx",
+      "name": "NuScale Power Corporation xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SMRx.png"
+    },
+    {
+      "address": "0xf8A80D1cb9cFD70D03D655D9dF42339846F3B3C8",
+      "symbol": "INTCx",
+      "name": "Intel xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/INTCx.png"
+    },
+    {
+      "address": "0xF9523E369c5f55ad72DbAA75B0a9b92B3D8b147e",
+      "symbol": "NVOx",
+      "name": "Novo Nordisk xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NVOx.png"
+    },
+    {
+      "address": "0xfBF2398dF672cEE4aFcC2A4A733222331c742a6A",
+      "symbol": "ABBVx",
+      "name": "AbbVie xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ABBVx.png"
+    },
+    {
+      "address": "0xfBfc1FD14EeC970276c8a3BF5e6131cD751cC0B9",
+      "symbol": "IRENx",
+      "name": "IREN xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IRENx.png"
+    },
+    {
+      "address": "0xfDDDb57878eF9D6f681Ec4381DCB626b9E69AC86",
+      "symbol": "TQQQx",
+      "name": "TQQQ xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TQQQx.png"
+    },
+    {
+      "address": "0xFe7B11D43cfD9fd6010f1b3F9cC86e5BCDb2bc78",
+      "symbol": "DAXx",
+      "name": "Global X DAX Germany xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DAXx.png"
+    },
+    {
+      "address": "0xfEbDEd1B0986a8ee107f5AB1a1c5a813491DeCEB",
+      "symbol": "CRCLx",
+      "name": "Circle xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRCLx.png"
+    },
+    {
+      "address": "0xFfAE0B911CB2cb7B49FD75011D99D137C040A9eF",
+      "symbol": "VOOx",
+      "name": "Vanguard S&P 500 xStock",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VOOx.png"
     },
     {
       "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
@@ -1978,12 +4602,132 @@
       "logoURI": "https://files.cow.fi/token-lists/images/9745/0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb/logo.png"
     },
     {
+      "address": "0x02a6c1789c3B4FDb1a7a3DfA39F90e5d3c94F4F9",
+      "symbol": "PMx",
+      "name": "Philip Morris xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PMx.png"
+    },
+    {
+      "address": "0x03183Ce31b1656B72A55fa6056e287f50C35BbEB",
+      "symbol": "ACNx",
+      "name": "Accenture xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ACNx.png"
+    },
+    {
+      "address": "0x053C784cD87B74f42e0c089f98643E79c1A3ff16",
+      "symbol": "CSCOx",
+      "name": "Cisco xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CSCOx.png"
+    },
+    {
+      "address": "0x05473ceA3774D898C7b6dDa21e1876D6Bca7277b",
+      "symbol": "PALLx",
+      "name": "abrdn Physical Palladium Shares xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PALLx.png"
+    },
+    {
+      "address": "0x0588e851ec0418d660BeE81230d6c678dAF21d46",
+      "symbol": "MDTx",
+      "name": "Medtronic xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MDTx.png"
+    },
+    {
+      "address": "0x0eBe5FAD0998765187FC695B75d4115c27C953A1",
+      "symbol": "KRAQx",
+      "name": "KRAQ xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KRAQx.png"
+    },
+    {
+      "address": "0x12992613fDd35aBe95DEc5a4964331b1ee23B50d",
+      "symbol": "BRK.Bx",
+      "name": "Berkshire Hathaway xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BRK.Bx.png"
+    },
+    {
+      "address": "0x15059c599C16Fd8f70B633Ade165502D6402CD49",
+      "symbol": "LINx",
+      "name": "Linde xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LINx.png"
+    },
+    {
+      "address": "0x167A6375DA1eFc4a5BE0f470E73eCEfd66245048",
+      "symbol": "UNHx",
+      "name": "UnitedHealth xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UNHx.png"
+    },
+    {
+      "address": "0x16b8feF54489A0BEb2cf09F6F16e4Cd31aEE195a",
+      "symbol": "FLQMx",
+      "name": "Franklin U.S. Mid Cap Multi-Factor xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FLQMx.png"
+    },
+    {
+      "address": "0x16E0B579be45bAaE54cEddd52e742B6457A7fE12",
+      "symbol": "ADBEx",
+      "name": "Adobe xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ADBEx.png"
+    },
+    {
+      "address": "0x17D8186Ed8F68059124190D147174D0f6697dc40",
+      "symbol": "MRKx",
+      "name": "Merck xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MRKx.png"
+    },
+    {
       "address": "0x17fc002b466eec40dae837fc4be5c67993ddbd6f",
       "symbol": "FRAX",
       "name": "Frax",
       "decimals": 18,
       "chainId": 42161,
       "logoURI": "https://files.cow.fi/token-lists/images/42161/0x17fc002b466eec40dae837fc4be5c67993ddbd6f/logo.png"
+    },
+    {
+      "address": "0x19c41EA77b34BbDEe61c3A87A75D1ABDA2ED0be4",
+      "symbol": "LLYx",
+      "name": "Eli Lilly xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LLYx.png"
+    },
+    {
+      "address": "0x1Aad217B8F78dbA5E6693460e8470F8b1A3977f3",
+      "symbol": "STRCx",
+      "name": "Strategy PP Variable xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/STRCx.png"
+    },
+    {
+      "address": "0x1Ac765B5BEa23184802C7d2d497f7c33f1444A9e",
+      "symbol": "PFEx",
+      "name": "Pfizer xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PFEx.png"
     },
     {
       "address": "0x1b896893dfc86bb67cf57767298b9073d2c1ba2c",
@@ -1994,12 +4738,204 @@
       "logoURI": "https://files.cow.fi/token-lists/images/42161/0x1b896893dfc86bb67cf57767298b9073d2c1ba2c/logo.png"
     },
     {
+      "address": "0x1FD2D7aDAc24B3f9552BC967bFFcDce3B92D31B8",
+      "symbol": "RCATx",
+      "name": "Red Cat xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RCATx.png"
+    },
+    {
+      "address": "0x214151022C2a5E380aB80CdaC31f23Ae554a7345",
+      "symbol": "CRWDx",
+      "name": "CrowdStrike xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRWDx.png"
+    },
+    {
+      "address": "0x22E1991e5f82736A2a990322a46aac0e95826c5B",
+      "symbol": "BTBTx",
+      "name": "Bit Digital xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BTBTx.png"
+    },
+    {
+      "address": "0x2363FD1235C1B6d3A5088DdF8dF3A0b3A30C5293",
+      "symbol": "Vx",
+      "name": "Visa xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/Vx.png"
+    },
+    {
+      "address": "0x2380F2673C640fB67E2d6B55B44C62F0E0e69DA9",
+      "symbol": "GLDx",
+      "name": "Gold xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GLDx.png"
+    },
+    {
+      "address": "0x238C2306b77a0C33fF609e72F89bf7e1323A9999",
+      "symbol": "NLRx",
+      "name": "VanEck Uranium and Nuclear xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NLRx.png"
+    },
+    {
+      "address": "0x299c95Eb52BFd5Bc98d924bCE17197b64864589B",
+      "symbol": "EWYx",
+      "name": "iShares MSCI South Korea xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWYx.png"
+    },
+    {
+      "address": "0x2f9a35aB5dDFBc49927BFdEab98A86c53DC6E763",
+      "symbol": "AMBRx",
+      "name": "Amber xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMBRx.png"
+    },
+    {
+      "address": "0x314938c596F5ce31C3f75307d2979338C346D7F2",
+      "symbol": "BACx",
+      "name": "Bank of America xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BACx.png"
+    },
+    {
+      "address": "0x338791c58fdED314b81EAb139A1A2Fb7967D90d6",
+      "symbol": "SBETx",
+      "name": "SharpLink Gaming xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SBETx.png"
+    },
+    {
+      "address": "0x3481a7c02A9B467630E77a7Cce91a25396414C6D",
+      "symbol": "FGDLx",
+      "name": "Franklin Responsibly Sourced Gold ETF xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FGDLx.png"
+    },
+    {
+      "address": "0x3522513E5F146a2006e2901b05f16B2821485E19",
+      "symbol": "AMDx",
+      "name": "AMD xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMDx.png"
+    },
+    {
+      "address": "0x3557Ba345B01EFa20A1bdDC61F573BFD87195081",
+      "symbol": "AMZNx",
+      "name": "Amazon.com xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMZNx.png"
+    },
+    {
+      "address": "0x35B8bBd1eB42bB2B5B4894D0Fe87b2812442e186",
+      "symbol": "IQMx",
+      "name": "Franklin Intelligent Machines xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IQMx.png"
+    },
+    {
+      "address": "0x364f210f430eC2448Fc68A49203040F6124096F0",
+      "symbol": "COINx",
+      "name": "Coinbase xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/COINx.png"
+    },
+    {
+      "address": "0x368192fEC58e3150600A1409c631c77F45745BEc",
+      "symbol": "USPXx",
+      "name": "Franklin U.S. Equity Index xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/USPXx.png"
+    },
+    {
+      "address": "0x36c424a6EC0e264b1616102Ad63eD2aD7857413e",
+      "symbol": "PEPx",
+      "name": "PepsiCo xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PEPx.png"
+    },
+    {
+      "address": "0x38BAC69cbBd28156796e4163B2B6dcb81E336565",
+      "symbol": "AVGOx",
+      "name": "Broadcom xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AVGOx.png"
+    },
+    {
+      "address": "0x38E0445308E7FcD5230F2DF6b52B36DD4FF313b6",
+      "symbol": "STRKx",
+      "name": "Strategy PP Fixed xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/STRKx.png"
+    },
+    {
+      "address": "0x3a62B4259E5C2E2314E254B2C79ebaF5E57e8Cf3",
+      "symbol": "GDXx",
+      "name": "VanEck Gold Miners xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GDXx.png"
+    },
+    {
       "address": "0x3b8db18e69d6686ad9371a423afe3dd1065c94f1",
       "symbol": "ESP",
       "name": "Espresso",
       "decimals": 18,
       "chainId": 42161,
       "logoURI": "https://files.cow.fi/token-lists/images/42161/0x3b8db18e69d6686ad9371a423afe3dd1065c94f1/logo.png"
+    },
+    {
+      "address": "0x3bf2E3be4A829Bb3a5f5BE450AE4c8Eb3488da71",
+      "symbol": "JAAAx",
+      "name": "Janus Henderson AAA CLO xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JAAAx.png"
+    },
+    {
+      "address": "0x3Ee7E9B3A992fD23CD1C363B0e296856B04ab149",
+      "symbol": "GSx",
+      "name": "Goldman Sachs xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GSx.png"
+    },
+    {
+      "address": "0x44314De3E69fd4C99fb638816B58ED2a85d466D9",
+      "symbol": "FLBLx",
+      "name": "Franklin Senior Loan xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FLBLx.png"
+    },
+    {
+      "address": "0x44E49ddE02c954cD9B67923af7B1070412e8f34e",
+      "symbol": "VIDAx",
+      "name": "Vida Global xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VIDAx.png"
     },
     {
       "address": "0x4772d2e014f9fc3a820c444e3313968e9a5c8121",
@@ -2010,12 +4946,124 @@
       "logoURI": "https://files.cow.fi/token-lists/images/42161/0x4772d2e014f9fc3a820c444e3313968e9a5c8121/logo.png"
     },
     {
+      "address": "0x4833e7f4f0460f4B72A3a5879A6C9841bCC5B58B",
+      "symbol": "SLVx",
+      "name": "iShares Silver Trust xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SLVx.png"
+    },
+    {
       "address": "0x498bf2b1e120fed3ad3d42ea2165e9b73f99c1e5",
       "symbol": "crvUSD",
       "name": "Curve.Fi USD Stablecoin",
       "decimals": 18,
       "chainId": 42161,
       "logoURI": "https://files.cow.fi/token-lists/images/42161/0x498bf2b1e120fed3ad3d42ea2165e9b73f99c1e5/logo.png"
+    },
+    {
+      "address": "0x4A4073f2EAF299A1be22254DCD2C41727F6F54a2",
+      "symbol": "CRMx",
+      "name": "Salesforce xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRMx.png"
+    },
+    {
+      "address": "0x4b0eE7C047D43cA403239f28f42115bEdB7c0076",
+      "symbol": "OKLOx",
+      "name": "Oklo xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/OKLOx.png"
+    },
+    {
+      "address": "0x4cbf89ED7Bb30b8a860fa86d3c96E9c72931299b",
+      "symbol": "TBLLx",
+      "name": "TBLL xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TBLLx.png"
+    },
+    {
+      "address": "0x50343212d7AADd7a104dCc7Ed751514aA174D9dC",
+      "symbol": "ONDSx",
+      "name": "Ondas xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ONDSx.png"
+    },
+    {
+      "address": "0x50a1291F69D9d3853Def8209cFb1AF0b46927BE1",
+      "symbol": "APPx",
+      "name": "AppLovin xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/APPx.png"
+    },
+    {
+      "address": "0x51eD5b74A05F256DbD9Ebb4e4f68Bb41ba10160b",
+      "symbol": "CORZx",
+      "name": "Core Scientific xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CORZx.png"
+    },
+    {
+      "address": "0x521860bB5dF5468358875266B89BFE90d990C6e7",
+      "symbol": "DFDVx",
+      "name": "DFDV xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DFDVx.png"
+    },
+    {
+      "address": "0x536825370F1159cBA953055f5c2F16DDc7B5a348",
+      "symbol": "PLx",
+      "name": "Planet Labs xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PLx.png"
+    },
+    {
+      "address": "0x53EE7F58Cf031Ea4d897FDFCDafAd124b3160689",
+      "symbol": "SOXLx",
+      "name": "Direxion Semiconductor Bull 3X xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SOXLx.png"
+    },
+    {
+      "address": "0x548308E91ec9F285C7bFf05295baDBD56a6e4971",
+      "symbol": "ORCLx",
+      "name": "Oracle xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ORCLx.png"
+    },
+    {
+      "address": "0x55600dfB3943a2db1A49b250e1E9114E4AD2174f",
+      "symbol": "HIMSx",
+      "name": "Hims & Hers xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HIMSx.png"
+    },
+    {
+      "address": "0x560deb3D70Ac90064fF809349cDf9A771a06fd36",
+      "symbol": "HUTx",
+      "name": "Hut 8 xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HUTx.png"
+    },
+    {
+      "address": "0x5621737f42dAE558b81269FcB9E9E70c19Aa6b35",
+      "symbol": "MSFTx",
+      "name": "Microsoft xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MSFTx.png"
     },
     {
       "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
@@ -2034,12 +5082,316 @@
       "logoURI": "https://files.cow.fi/token-lists/images/42161/0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34/logo.png"
     },
     {
+      "address": "0x5D642505FE1a28897eb3BaBA665F454755D8daA2",
+      "symbol": "AZNx",
+      "name": "AstraZeneca xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AZNx.png"
+    },
+    {
+      "address": "0x5d8dA1417E3565eb02C9ca8cC588bE5D8F65b1c5",
+      "symbol": "RBLXx",
+      "name": "Roblox xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RBLXx.png"
+    },
+    {
+      "address": "0x60Ae7D760a1C7B528C0384Bc945fadF1438F47A5",
+      "symbol": "BTGOx",
+      "name": "Bitgo xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BTGOx.png"
+    },
+    {
+      "address": "0x62a48560861B0b451654bFffdb5be6E47aa8ff1B",
+      "symbol": "HONx",
+      "name": "Honeywell xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HONx.png"
+    },
+    {
+      "address": "0x68F3DDEE8BAE33691E7CD0372984fD857E842760",
+      "symbol": "TMUSx",
+      "name": "T-Mobile xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TMUSx.png"
+    },
+    {
       "address": "0x69420f9e38a4e60a62224c489be4bf7a94402496",
       "symbol": "MONEY",
       "name": "DEFI MONEY",
       "decimals": 18,
       "chainId": 42161,
       "logoURI": "https://files.cow.fi/token-lists/images/42161/0x69420f9e38a4e60a62224c489be4bf7a94402496/logo.png"
+    },
+    {
+      "address": "0x6a668332825450ACD2e449372057d31b3de16a1E",
+      "symbol": "IEMGx",
+      "name": "Core MSCI Emerging Markets xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IEMGx.png"
+    },
+    {
+      "address": "0x6Ac47387f0a2798dF4C4eE5bb31ab9517ac97cb8",
+      "symbol": "RIOTx",
+      "name": "Riot Platforms xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RIOTx.png"
+    },
+    {
+      "address": "0x6c5287b4EA247031da9e375573E5D1c8A12938EE",
+      "symbol": "EWUx",
+      "name": "iShares MSCI United Kingdom xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWUx.png"
+    },
+    {
+      "address": "0x6d482CeC5f9dd1f05CCee9Fd3ff79B246170F8e2",
+      "symbol": "PLTRx",
+      "name": "Palantir xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PLTRx.png"
+    },
+    {
+      "address": "0x6d5edEEbBc6A4099Eb8bb289EB3b80D799f7b28C",
+      "symbol": "VTx",
+      "name": "Vanguard Total World xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VTx.png"
+    },
+    {
+      "address": "0x766b0CD6ED6D90B5d49d2c36a3761E9728501BA9",
+      "symbol": "HDx",
+      "name": "Home Depot xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HDx.png"
+    },
+    {
+      "address": "0x7AEfc9965699fBea943e03264d96e50CD4A97b21",
+      "symbol": "WMTx",
+      "name": "Walmart xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WMTx.png"
+    },
+    {
+      "address": "0x7B14968D19a6C051d6613716ea71f2DaDE46DB9c",
+      "symbol": "SOXXx",
+      "name": "iShares Semiconductor xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SOXXx.png"
+    },
+    {
+      "address": "0x7c7445A40926152B8d24aBDb9020e219d3D3380a",
+      "symbol": "SATAx",
+      "name": "Strive, Inc. Series A Preferred xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SATAx.png"
+    },
+    {
+      "address": "0x7e8c89a9b9B85029caB43280AabBED600D7e8D36",
+      "symbol": "FSMLx",
+      "name": "Franklin Small Cap Enhanced xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FSMLx.png"
+    },
+    {
+      "address": "0x7F8ba411ECBC0A135d669d5EaE5D15b0Ca0b0ea1",
+      "symbol": "SPCEx",
+      "name": "Virgin Galactic xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SPCEx.png"
+    },
+    {
+      "address": "0x80A77a372c1e12AcCdA84299492f404902E2DA67",
+      "symbol": "MCDx",
+      "name": "McDonald's xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MCDx.png"
+    },
+    {
+      "address": "0x89233399708C18Ac6887F90A2B4Cd8Ba5fEdD06e",
+      "symbol": "ABTx",
+      "name": "Abbott xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ABTx.png"
+    },
+    {
+      "address": "0x89b2607878ae19baB8020b8140eD550Ef3E953bb",
+      "symbol": "ASTSx",
+      "name": "AST SpaceMobile xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ASTSx.png"
+    },
+    {
+      "address": "0x89BAB39D627A9e34f0dc782C53457e80Ee8Fb9D9",
+      "symbol": "COPXx",
+      "name": "Global X Copper Miners xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/COPXx.png"
+    },
+    {
+      "address": "0x8aD3c73F833d3F9A523aB01476625F269aEB7Cf0",
+      "symbol": "TSLAx",
+      "name": "Tesla xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TSLAx.png"
+    },
+    {
+      "address": "0x8e9e4a8d7f1C65dcB42D9103832b27E75946055D",
+      "symbol": "PPLTx",
+      "name": "abrdn Physical Platinum Shares xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PPLTx.png"
+    },
+    {
+      "address": "0x90A2a4c76b5D8c0bc892A69EA28Aa775a8f2dD48",
+      "symbol": "SPYx",
+      "name": "SP500 xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SPYx.png"
+    },
+    {
+      "address": "0x96702be57Cd9777f835117a809C7124fe4ec989A",
+      "symbol": "METAx",
+      "name": "Meta xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/METAx.png"
+    },
+    {
+      "address": "0x995dB25F900E38851CF4e67a05960E66F774530D",
+      "symbol": "NETx",
+      "name": "Cloudflare xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NETx.png"
+    },
+    {
+      "address": "0x9d275685dC284C8eB1C79f6ABA7a63Dc75ec890a",
+      "symbol": "AAPLx",
+      "name": "Apple xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AAPLx.png"
+    },
+    {
+      "address": "0x9D692bffEf6f6BedF4274053ff9998EFE3B2539E",
+      "symbol": "MARAx",
+      "name": "MARA xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MARAx.png"
+    },
+    {
+      "address": "0x9e3bf4Ecfc44EeDD624F26656B6736a3F093b073",
+      "symbol": "TSMx",
+      "name": "TSMC xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TSMx.png"
+    },
+    {
+      "address": "0xA6a65AC27E76cD53cB790473E4345c46e5eBf961",
+      "symbol": "NFLXx",
+      "name": "Netflix xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NFLXx.png"
+    },
+    {
+      "address": "0xa753A7395cAe905Cd615Da0B82A53E0560f250af",
+      "symbol": "QQQx",
+      "name": "Nasdaq xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/QQQx.png"
+    },
+    {
+      "address": "0xa90424D5D3E770e8644103AB503ed775dD1318FD",
+      "symbol": "PGx",
+      "name": "Procter & Gamble xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PGx.png"
+    },
+    {
+      "address": "0xa96d03Fe2479fEbC69535366933Ea053D5acF9dd",
+      "symbol": "YLDEx",
+      "name": "Franklin ClearBridge Enhanced Income xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/YLDEx.png"
+    },
+    {
+      "address": "0xAA28cB97D7f7E172f54deE950743886D2d65447d",
+      "symbol": "IJRx",
+      "name": "S&P Small Cap xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IJRx.png"
+    },
+    {
+      "address": "0xad5cdc3340904285B8159089974A99a1A09EB4C0",
+      "symbol": "CVXx",
+      "name": "Chevron xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CVXx.png"
+    },
+    {
+      "address": "0xAE2f842EF90C0d5213259Ab82639D5BBF649b08E",
+      "symbol": "MSTRx",
+      "name": "MicroStrategy xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MSTRx.png"
+    },
+    {
+      "address": "0xaE6D61508125bC541E367A6a8B1f594ecC42F557",
+      "symbol": "FEZx",
+      "name": "SPDR EURO STOXX 50 xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FEZx.png"
+    },
+    {
+      "address": "0xaeB681B69E5094E04d11BCeF51A71358A374C3ED",
+      "symbol": "BMNRx",
+      "name": "Bitmine xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BMNRx.png"
+    },
+    {
+      "address": "0xAF072F109A2C173D822a4fe9af311A1B18F83d19",
+      "symbol": "TMOx",
+      "name": "Thermo Fisher xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TMOx.png"
     },
     {
       "symbol": "USDC",
@@ -2053,6 +5405,70 @@
       ]
     },
     {
+      "address": "0xb365Cd2588065F522D379AD19e903304f6B622C6",
+      "symbol": "MAx",
+      "name": "Mastercard xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MAx.png"
+    },
+    {
+      "address": "0xBC7170a1280Be28513B4e940C681537EB25e39f4",
+      "symbol": "CMCSAx",
+      "name": "Comcast xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CMCSAx.png"
+    },
+    {
+      "address": "0xbD730E618bcD88C82dDeE52e10275CF2f88A4777",
+      "symbol": "VTIx",
+      "name": "Vanguard xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VTIx.png"
+    },
+    {
+      "address": "0xbEe6b69345F376598Fe16AbD5592c6F844825E66",
+      "symbol": "OPENx",
+      "name": "OPEN xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/OPENx.png"
+    },
+    {
+      "address": "0xC0B417e7F83db438631Eb5E096684dd742E5294F",
+      "symbol": "ASMLx",
+      "name": "ASML xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ASMLx.png"
+    },
+    {
+      "address": "0xC0c2150cf0870E2d7aBc7cDe17C20A542faFBB9B",
+      "symbol": "WULFx",
+      "name": "TeraWulf xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WULFx.png"
+    },
+    {
+      "address": "0xc435b3C41AE56d9Bc57b8525F4d522C978F168e8",
+      "symbol": "WBDx",
+      "name": "Warner Bros. Discovery xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WBDx.png"
+    },
+    {
+      "address": "0xc845b2894dBddd03858fd2D643B4eF725fE0849d",
+      "symbol": "NVDAx",
+      "name": "NVIDIA xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NVDAx.png"
+    },
+    {
       "address": "0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04",
       "symbol": "COW",
       "name": "CoW Protocol Token",
@@ -2061,12 +5477,300 @@
       "logoURI": "https://files.cow.fi/token-lists/images/42161/0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04/logo.png"
     },
     {
+      "address": "0xD0194F0f077968DA8ca59811e9407f54AE6c9432",
+      "symbol": "CLSKx",
+      "name": "CleanSpark xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CLSKx.png"
+    },
+    {
       "address": "0xd09acb80c1e8f2291862c4978a008791c9167003",
       "symbol": "tETH",
       "name": "Treehouse ETH",
       "decimals": 18,
       "chainId": 42161,
       "logoURI": "https://files.cow.fi/token-lists/images/42161/0xd09acb80c1e8f2291862c4978a008791c9167003/logo.png"
+    },
+    {
+      "address": "0xD5859517180e639D50003FdB434E690aB1FBD21b",
+      "symbol": "MDLNx",
+      "name": "Medline xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MDLNx.png"
+    },
+    {
+      "address": "0xd9913208647671Fe0F48F7F260076B2C6F310Aac",
+      "symbol": "IBMx",
+      "name": "International Business Machines xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IBMx.png"
+    },
+    {
+      "address": "0xD9FC3E075d45254a1D834fEa18AF8041207DeA0A",
+      "symbol": "JPMx",
+      "name": "JPMorgan Chase xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JPMx.png"
+    },
+    {
+      "address": "0xdadfb355c6110eda0908740d52c834d6C2BCDDc7",
+      "symbol": "IWMx",
+      "name": "Russell 2000 xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IWMx.png"
+    },
+    {
+      "address": "0xdb0482cfaD4789798623E64b15eebA01b16e917C",
+      "symbol": "JNJx",
+      "name": "Johnson & Johnson xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JNJx.png"
+    },
+    {
+      "address": "0xdb9783Ca04bBD64fe2c6d7B9503A979b3DE30729",
+      "symbol": "UBERx",
+      "name": "Uber xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UBERx.png"
+    },
+    {
+      "address": "0xdbA228936F4079DaF9Aa906fd48a87f2300405F4",
+      "symbol": "DHRx",
+      "name": "Danaher xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DHRx.png"
+    },
+    {
+      "address": "0xdCC1a2699441079dA889B1F49e12B69cC791129b",
+      "symbol": "KOx",
+      "name": "Coca-Cola xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KOx.png"
+    },
+    {
+      "address": "0xdce993F8a6DbcE7F27434874F5DFe9A8d58509c9",
+      "symbol": "LNGx",
+      "name": "Cheniere Energy xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LNGx.png"
+    },
+    {
+      "address": "0xE0F324A026ca55492637009d98034103Db4a6967",
+      "symbol": "SLMTx",
+      "name": "Brera xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SLMTx.png"
+    },
+    {
+      "address": "0xe12BB32D77BE4DB10DDC82088b230D35d097E9C5",
+      "symbol": "PANWx",
+      "name": "Palo Alto Networks xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PANWx.png"
+    },
+    {
+      "address": "0xE1385FDd5ffB10081Cd52C56584F25EFa9084015",
+      "symbol": "HOODx",
+      "name": "Robinhood xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HOODx.png"
+    },
+    {
+      "address": "0xE1435b2f302edf42AE84a306a5e1948b270B6CCb",
+      "symbol": "BITXx",
+      "name": "Volatility Shares 2x Bitcoin Strategy xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BITXx.png"
+    },
+    {
+      "address": "0xE49922893496b17AC12Fdd7c74720a92010d889D",
+      "symbol": "JPSTx",
+      "name": "JPMorgan Ultra-Short Income xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JPSTx.png"
+    },
+    {
+      "address": "0xE5f6d3b2405ABdfE6F660e63202B25D23763160d",
+      "symbol": "GMEx",
+      "name": "Gamestop xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GMEx.png"
+    },
+    {
+      "address": "0xe75AfF5123D9De91A1c27167C6C01B1f5b1eAb14",
+      "symbol": "ENHAx",
+      "name": "Enhanced Group xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ENHAx.png"
+    },
+    {
+      "address": "0xe92f673Ca36C5E2Efd2DE7628f815f84807e803F",
+      "symbol": "GOOGLx",
+      "name": "Alphabet xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GOOGLx.png"
+    },
+    {
+      "address": "0xe95ab205e333443D7970336D5fD827eF9eD97608",
+      "symbol": "TONXx",
+      "name": "TON xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TONXx.png"
+    },
+    {
+      "address": "0xeAAd46F4146Ded5a47B55AA7F6c48c191dEAEC88",
+      "symbol": "MRVLx",
+      "name": "Marvell xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MRVLx.png"
+    },
+    {
+      "address": "0xebb35d5b5Bf82203812e3C02797EF0cBDBb81146",
+      "symbol": "EWQx",
+      "name": "iShares MSCI France xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWQx.png"
+    },
+    {
+      "address": "0xeD2Bdd82366728C1F2A7E8B93C4dD4A58404BF65",
+      "symbol": "EWGx",
+      "name": "iShares MSCI Germany xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWGx.png"
+    },
+    {
+      "address": "0xEEdb0273c5Af792745180e9fF568cD01550fFA13",
+      "symbol": "XOMx",
+      "name": "Exxon Mobil xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/XOMx.png"
+    },
+    {
+      "address": "0xF51565240E667176c532DB4139386E6A6E506d99",
+      "symbol": "FAAAx",
+      "name": "Fidelity AAA CLO xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FAAAx.png"
+    },
+    {
+      "address": "0xf6a873BAe4Ba1B304e45dF52A4b7D176E1C6a8c4",
+      "symbol": "MUx",
+      "name": "Micron Technology xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MUx.png"
+    },
+    {
+      "address": "0xF6D87E523512704C29E9b7cA3e9e6226bDCE3EA1",
+      "symbol": "SCHFx",
+      "name": "Schwab International Equity xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SCHFx.png"
+    },
+    {
+      "address": "0xf706585e7e8900bE0267bEE3B9A2F70835EC6628",
+      "symbol": "PYPLx",
+      "name": "PayPal xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PYPLx.png"
+    },
+    {
+      "address": "0xf7F4fAC56f012dE7Dd6adFF54C761986B9E0655a",
+      "symbol": "GLXYx",
+      "name": "Galaxy Digital xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GLXYx.png"
+    },
+    {
+      "address": "0xf8A80D1cb9cFD70D03D655D9dF42339846F3B3C8",
+      "symbol": "INTCx",
+      "name": "Intel xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/INTCx.png"
+    },
+    {
+      "address": "0xF9523E369c5f55ad72DbAA75B0a9b92B3D8b147e",
+      "symbol": "NVOx",
+      "name": "Novo Nordisk xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NVOx.png"
+    },
+    {
+      "address": "0xfBF2398dF672cEE4aFcC2A4A733222331c742a6A",
+      "symbol": "ABBVx",
+      "name": "AbbVie xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ABBVx.png"
+    },
+    {
+      "address": "0xfBfc1FD14EeC970276c8a3BF5e6131cD751cC0B9",
+      "symbol": "IRENx",
+      "name": "IREN xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IRENx.png"
+    },
+    {
+      "address": "0xfDDDb57878eF9D6f681Ec4381DCB626b9E69AC86",
+      "symbol": "TQQQx",
+      "name": "TQQQ xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TQQQx.png"
+    },
+    {
+      "address": "0xFe7B11D43cfD9fd6010f1b3F9cC86e5BCDb2bc78",
+      "symbol": "DAXx",
+      "name": "Global X DAX Germany xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DAXx.png"
+    },
+    {
+      "address": "0xfEbDEd1B0986a8ee107f5AB1a1c5a813491DeCEB",
+      "symbol": "CRCLx",
+      "name": "Circle xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRCLx.png"
+    },
+    {
+      "address": "0xFfAE0B911CB2cb7B49FD75011D99D137C040A9eF",
+      "symbol": "VOOx",
+      "name": "Vanguard S&P 500 xStock",
+      "decimals": 18,
+      "chainId": 42161,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VOOx.png"
     },
     {
       "address": "0x14a84f1a61ccd7d1be596a6cc11fe33a36bc1646",
@@ -2110,11 +5814,227 @@
     },
     {
       "address": "0x0200c29006150606b650577bbe7b6248f58470c1",
-      "symbol": "USD\u20ae0",
-      "name": "USD\u20ae0",
+      "symbol": "USD₮0",
+      "name": "USD₮0",
       "decimals": 6,
       "chainId": 57073,
       "logoURI": "https://files.cow.fi/token-lists/images/57073/0x0200c29006150606b650577bbe7b6248f58470c1/logo.png"
+    },
+    {
+      "address": "0x02a6c1789c3B4FDb1a7a3DfA39F90e5d3c94F4F9",
+      "symbol": "PMx",
+      "name": "Philip Morris xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PMx.png"
+    },
+    {
+      "address": "0x03183Ce31b1656B72A55fa6056e287f50C35BbEB",
+      "symbol": "ACNx",
+      "name": "Accenture xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ACNx.png"
+    },
+    {
+      "address": "0x053C784cD87B74f42e0c089f98643E79c1A3ff16",
+      "symbol": "CSCOx",
+      "name": "Cisco xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CSCOx.png"
+    },
+    {
+      "address": "0x05473ceA3774D898C7b6dDa21e1876D6Bca7277b",
+      "symbol": "PALLx",
+      "name": "abrdn Physical Palladium Shares xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PALLx.png"
+    },
+    {
+      "address": "0x0588e851ec0418d660BeE81230d6c678dAF21d46",
+      "symbol": "MDTx",
+      "name": "Medtronic xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MDTx.png"
+    },
+    {
+      "address": "0x06A0138F8c3e5110fd98e34a4473Fb08F1304b87",
+      "symbol": "MOOx",
+      "name": "VanEck Agribusiness ETF xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MOOx.png"
+    },
+    {
+      "address": "0x0A62dB029ab8dc0B49b3E8159431728DbD23c7BF",
+      "symbol": "VRTx",
+      "name": "Vertiv Holdings Co xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VRTx.png"
+    },
+    {
+      "address": "0x0E6607Ab45D2CA779068Cd6D9426C409773969FD",
+      "symbol": "URAx",
+      "name": "Global X Uranium ETF xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/URAx.png"
+    },
+    {
+      "address": "0x0eBe5FAD0998765187FC695B75d4115c27C953A1",
+      "symbol": "KRAQx",
+      "name": "KRAQ xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KRAQx.png"
+    },
+    {
+      "address": "0x12992613fDd35aBe95DEc5a4964331b1ee23B50d",
+      "symbol": "BRK.Bx",
+      "name": "Berkshire Hathaway xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BRK.Bx.png"
+    },
+    {
+      "address": "0x15059c599C16Fd8f70B633Ade165502D6402CD49",
+      "symbol": "LINx",
+      "name": "Linde xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LINx.png"
+    },
+    {
+      "address": "0x167A6375DA1eFc4a5BE0f470E73eCEfd66245048",
+      "symbol": "UNHx",
+      "name": "UnitedHealth xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UNHx.png"
+    },
+    {
+      "address": "0x16b8feF54489A0BEb2cf09F6F16e4Cd31aEE195a",
+      "symbol": "FLQMx",
+      "name": "Franklin U.S. Mid Cap Multi-Factor xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FLQMx.png"
+    },
+    {
+      "address": "0x16E0B579be45bAaE54cEddd52e742B6457A7fE12",
+      "symbol": "ADBEx",
+      "name": "Adobe xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ADBEx.png"
+    },
+    {
+      "address": "0x17D8186Ed8F68059124190D147174D0f6697dc40",
+      "symbol": "MRKx",
+      "name": "Merck xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MRKx.png"
+    },
+    {
+      "address": "0x19c41EA77b34BbDEe61c3A87A75D1ABDA2ED0be4",
+      "symbol": "LLYx",
+      "name": "Eli Lilly xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LLYx.png"
+    },
+    {
+      "address": "0x1Aad217B8F78dbA5E6693460e8470F8b1A3977f3",
+      "symbol": "STRCx",
+      "name": "Strategy PP Variable xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/STRCx.png"
+    },
+    {
+      "address": "0x1Ac765B5BEa23184802C7d2d497f7c33f1444A9e",
+      "symbol": "PFEx",
+      "name": "Pfizer xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PFEx.png"
+    },
+    {
+      "address": "0x1FD2D7aDAc24B3f9552BC967bFFcDce3B92D31B8",
+      "symbol": "RCATx",
+      "name": "Red Cat xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RCATx.png"
+    },
+    {
+      "address": "0x214151022C2a5E380aB80CdaC31f23Ae554a7345",
+      "symbol": "CRWDx",
+      "name": "CrowdStrike xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRWDx.png"
+    },
+    {
+      "address": "0x22E1991e5f82736A2a990322a46aac0e95826c5B",
+      "symbol": "BTBTx",
+      "name": "Bit Digital xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BTBTx.png"
+    },
+    {
+      "address": "0x2363FD1235C1B6d3A5088DdF8dF3A0b3A30C5293",
+      "symbol": "Vx",
+      "name": "Visa xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/Vx.png"
+    },
+    {
+      "address": "0x2380F2673C640fB67E2d6B55B44C62F0E0e69DA9",
+      "symbol": "GLDx",
+      "name": "Gold xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GLDx.png"
+    },
+    {
+      "address": "0x238C2306b77a0C33fF609e72F89bf7e1323A9999",
+      "symbol": "NLRx",
+      "name": "VanEck Uranium and Nuclear xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NLRx.png"
+    },
+    {
+      "address": "0x2782dF1cC877F720C81B4f6568Db64563F1D3AA3",
+      "symbol": "DELLx",
+      "name": "Dell Technologies Inc. xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DELLx.png"
+    },
+    {
+      "address": "0x27aD5CC5242f4258030D81A5639098ce0a96820F",
+      "symbol": "ANETx",
+      "name": "Arista Networks, Inc. xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ANETx.png"
+    },
+    {
+      "address": "0x299c95Eb52BFd5Bc98d924bCE17197b64864589B",
+      "symbol": "EWYx",
+      "name": "iShares MSCI South Korea xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWYx.png"
     },
     {
       "address": "0x2d270e6886d130d724215a266106e6832161eaed",
@@ -2125,12 +6045,908 @@
       "logoURI": "https://files.cow.fi/token-lists/images/57073/0x2d270e6886d130d724215a266106e6832161eaed/logo.png"
     },
     {
+      "address": "0x2daFA4732c8c1b25701a33B05F10f437F9599326",
+      "symbol": "SGOVx",
+      "name": "iShares 0-3 Month Treasury Bond ETF xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SGOVx.png"
+    },
+    {
+      "address": "0x2f9a35aB5dDFBc49927BFdEab98A86c53DC6E763",
+      "symbol": "AMBRx",
+      "name": "Amber xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMBRx.png"
+    },
+    {
+      "address": "0x314938c596F5ce31C3f75307d2979338C346D7F2",
+      "symbol": "BACx",
+      "name": "Bank of America xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BACx.png"
+    },
+    {
+      "address": "0x338791c58fdED314b81EAb139A1A2Fb7967D90d6",
+      "symbol": "SBETx",
+      "name": "SharpLink Gaming xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SBETx.png"
+    },
+    {
+      "address": "0x3481a7c02A9B467630E77a7Cce91a25396414C6D",
+      "symbol": "FGDLx",
+      "name": "Franklin Responsibly Sourced Gold ETF xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FGDLx.png"
+    },
+    {
+      "address": "0x3522513E5F146a2006e2901b05f16B2821485E19",
+      "symbol": "AMDx",
+      "name": "AMD xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMDx.png"
+    },
+    {
+      "address": "0x3557Ba345B01EFa20A1bdDC61F573BFD87195081",
+      "symbol": "AMZNx",
+      "name": "Amazon.com xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMZNx.png"
+    },
+    {
+      "address": "0x35B8bBd1eB42bB2B5B4894D0Fe87b2812442e186",
+      "symbol": "IQMx",
+      "name": "Franklin Intelligent Machines xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IQMx.png"
+    },
+    {
+      "address": "0x364f210f430eC2448Fc68A49203040F6124096F0",
+      "symbol": "COINx",
+      "name": "Coinbase xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/COINx.png"
+    },
+    {
+      "address": "0x368192fEC58e3150600A1409c631c77F45745BEc",
+      "symbol": "USPXx",
+      "name": "Franklin U.S. Equity Index xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/USPXx.png"
+    },
+    {
+      "address": "0x36c424a6EC0e264b1616102Ad63eD2aD7857413e",
+      "symbol": "PEPx",
+      "name": "PepsiCo xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PEPx.png"
+    },
+    {
+      "address": "0x375B9F00A83132cABcDa7aBf2bfc87c14f7AC324",
+      "symbol": "ITAx",
+      "name": "iShares U.S. Aerospace & Defense ETF xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ITAx.png"
+    },
+    {
+      "address": "0x38BAC69cbBd28156796e4163B2B6dcb81E336565",
+      "symbol": "AVGOx",
+      "name": "Broadcom xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AVGOx.png"
+    },
+    {
+      "address": "0x38E0445308E7FcD5230F2DF6b52B36DD4FF313b6",
+      "symbol": "STRKx",
+      "name": "Strategy PP Fixed xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/STRKx.png"
+    },
+    {
+      "address": "0x39c31fC6038490eA4Bf8A21Ca18CD18F33B8d3FB",
+      "symbol": "SMCIx",
+      "name": "Super Micro Computer, Inc. xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SMCIx.png"
+    },
+    {
+      "address": "0x3a62B4259E5C2E2314E254B2C79ebaF5E57e8Cf3",
+      "symbol": "GDXx",
+      "name": "VanEck Gold Miners xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GDXx.png"
+    },
+    {
+      "address": "0x3bf2E3be4A829Bb3a5f5BE450AE4c8Eb3488da71",
+      "symbol": "JAAAx",
+      "name": "Janus Henderson AAA CLO xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JAAAx.png"
+    },
+    {
+      "address": "0x3Ee7E9B3A992fD23CD1C363B0e296856B04ab149",
+      "symbol": "GSx",
+      "name": "Goldman Sachs xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GSx.png"
+    },
+    {
+      "address": "0x4177D16A5d2465CF4bd52E07c1c56ab500243FD4",
+      "symbol": "LRCXx",
+      "name": "Lam Research Corporation xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LRCXx.png"
+    },
+    {
       "address": "0x4200000000000000000000000000000000000006",
       "symbol": "WETH",
       "name": "Wrapped Ether",
       "decimals": 18,
       "chainId": 57073,
       "logoURI": "https://files.cow.fi/token-lists/images/57073/0x4200000000000000000000000000000000000006/logo.png"
+    },
+    {
+      "address": "0x44314De3E69fd4C99fb638816B58ED2a85d466D9",
+      "symbol": "FLBLx",
+      "name": "Franklin Senior Loan xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FLBLx.png"
+    },
+    {
+      "address": "0x44E49ddE02c954cD9B67923af7B1070412e8f34e",
+      "symbol": "VIDAx",
+      "name": "Vida Global xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VIDAx.png"
+    },
+    {
+      "address": "0x4833e7f4f0460f4B72A3a5879A6C9841bCC5B58B",
+      "symbol": "SLVx",
+      "name": "iShares Silver Trust xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SLVx.png"
+    },
+    {
+      "address": "0x4A4073f2EAF299A1be22254DCD2C41727F6F54a2",
+      "symbol": "CRMx",
+      "name": "Salesforce xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRMx.png"
+    },
+    {
+      "address": "0x4b0eE7C047D43cA403239f28f42115bEdB7c0076",
+      "symbol": "OKLOx",
+      "name": "Oklo xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/OKLOx.png"
+    },
+    {
+      "address": "0x4cbf89ED7Bb30b8a860fa86d3c96E9c72931299b",
+      "symbol": "TBLLx",
+      "name": "TBLL xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TBLLx.png"
+    },
+    {
+      "address": "0x50343212d7AADd7a104dCc7Ed751514aA174D9dC",
+      "symbol": "ONDSx",
+      "name": "Ondas xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ONDSx.png"
+    },
+    {
+      "address": "0x50a1291F69D9d3853Def8209cFb1AF0b46927BE1",
+      "symbol": "APPx",
+      "name": "AppLovin xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/APPx.png"
+    },
+    {
+      "address": "0x51eD5b74A05F256DbD9Ebb4e4f68Bb41ba10160b",
+      "symbol": "CORZx",
+      "name": "Core Scientific xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CORZx.png"
+    },
+    {
+      "address": "0x521860bB5dF5468358875266B89BFE90d990C6e7",
+      "symbol": "DFDVx",
+      "name": "DFDV xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DFDVx.png"
+    },
+    {
+      "address": "0x536825370F1159cBA953055f5c2F16DDc7B5a348",
+      "symbol": "PLx",
+      "name": "Planet Labs xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PLx.png"
+    },
+    {
+      "address": "0x53EE7F58Cf031Ea4d897FDFCDafAd124b3160689",
+      "symbol": "SOXLx",
+      "name": "Direxion Semiconductor Bull 3X xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SOXLx.png"
+    },
+    {
+      "address": "0x548308E91ec9F285C7bFf05295baDBD56a6e4971",
+      "symbol": "ORCLx",
+      "name": "Oracle xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ORCLx.png"
+    },
+    {
+      "address": "0x55600dfB3943a2db1A49b250e1E9114E4AD2174f",
+      "symbol": "HIMSx",
+      "name": "Hims & Hers xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HIMSx.png"
+    },
+    {
+      "address": "0x560deb3D70Ac90064fF809349cDf9A771a06fd36",
+      "symbol": "HUTx",
+      "name": "Hut 8 xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HUTx.png"
+    },
+    {
+      "address": "0x5621737f42dAE558b81269FcB9E9E70c19Aa6b35",
+      "symbol": "MSFTx",
+      "name": "Microsoft xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MSFTx.png"
+    },
+    {
+      "address": "0x5D642505FE1a28897eb3BaBA665F454755D8daA2",
+      "symbol": "AZNx",
+      "name": "AstraZeneca xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AZNx.png"
+    },
+    {
+      "address": "0x5d8dA1417E3565eb02C9ca8cC588bE5D8F65b1c5",
+      "symbol": "RBLXx",
+      "name": "Roblox xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RBLXx.png"
+    },
+    {
+      "address": "0x5FB4184F8B515B1C54d1baC839DCF81276d6b73e",
+      "symbol": "GEVx",
+      "name": "GE Vernova Inc. xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GEVx.png"
+    },
+    {
+      "address": "0x60Ae7D760a1C7B528C0384Bc945fadF1438F47A5",
+      "symbol": "BTGOx",
+      "name": "Bitgo xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BTGOx.png"
+    },
+    {
+      "address": "0x62a48560861B0b451654bFffdb5be6E47aa8ff1B",
+      "symbol": "HONx",
+      "name": "Honeywell xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HONx.png"
+    },
+    {
+      "address": "0x68F3DDEE8BAE33691E7CD0372984fD857E842760",
+      "symbol": "TMUSx",
+      "name": "T-Mobile xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TMUSx.png"
+    },
+    {
+      "address": "0x6a668332825450ACD2e449372057d31b3de16a1E",
+      "symbol": "IEMGx",
+      "name": "Core MSCI Emerging Markets xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IEMGx.png"
+    },
+    {
+      "address": "0x6Ac47387f0a2798dF4C4eE5bb31ab9517ac97cb8",
+      "symbol": "RIOTx",
+      "name": "Riot Platforms xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/RIOTx.png"
+    },
+    {
+      "address": "0x6b9Cca56e783d1345785E4aA1188Bbd673E911A2",
+      "symbol": "XOPx",
+      "name": "SPDR S&P Oil & Gas Exploration & Production ETF xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/XOPx.png"
+    },
+    {
+      "address": "0x6c5287b4EA247031da9e375573E5D1c8A12938EE",
+      "symbol": "EWUx",
+      "name": "iShares MSCI United Kingdom xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWUx.png"
+    },
+    {
+      "address": "0x6d482CeC5f9dd1f05CCee9Fd3ff79B246170F8e2",
+      "symbol": "PLTRx",
+      "name": "Palantir xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PLTRx.png"
+    },
+    {
+      "address": "0x6d5edEEbBc6A4099Eb8bb289EB3b80D799f7b28C",
+      "symbol": "VTx",
+      "name": "Vanguard Total World xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VTx.png"
+    },
+    {
+      "address": "0x6e0AAfB414B620e096B9F7Fe85625D3E5cE41d3F",
+      "symbol": "VUGx",
+      "name": "Vanguard Growth ETF xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VUGx.png"
+    },
+    {
+      "address": "0x6Ee270D24B593F85863E95B6a7dd916A5957719f",
+      "symbol": "USARx",
+      "name": "USA Rare Earth Inc. xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/USARx.png"
+    },
+    {
+      "address": "0x6F75AC3b1b6Fbe8Bb5F948e25aF03620f26Ae838",
+      "symbol": "XLEx",
+      "name": "Energy Select Sector SPDR Fund xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/XLEx.png"
+    },
+    {
+      "address": "0x7636244Bab612264e1B2dFd4bA6E26d0311b1Eb7",
+      "symbol": "CEGx",
+      "name": "Constellation Energy Corporation xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CEGx.png"
+    },
+    {
+      "address": "0x766b0CD6ED6D90B5d49d2c36a3761E9728501BA9",
+      "symbol": "HDx",
+      "name": "Home Depot xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HDx.png"
+    },
+    {
+      "address": "0x7AEfc9965699fBea943e03264d96e50CD4A97b21",
+      "symbol": "WMTx",
+      "name": "Walmart xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WMTx.png"
+    },
+    {
+      "address": "0x7B14968D19a6C051d6613716ea71f2DaDE46DB9c",
+      "symbol": "SOXXx",
+      "name": "iShares Semiconductor xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SOXXx.png"
+    },
+    {
+      "address": "0x7c7445A40926152B8d24aBDb9020e219d3D3380a",
+      "symbol": "SATAx",
+      "name": "Strive, Inc. Series A Preferred xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SATAx.png"
+    },
+    {
+      "address": "0x7e8c89a9b9B85029caB43280AabBED600D7e8D36",
+      "symbol": "FSMLx",
+      "name": "Franklin Small Cap Enhanced xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FSMLx.png"
+    },
+    {
+      "address": "0x7F8ba411ECBC0A135d669d5EaE5D15b0Ca0b0ea1",
+      "symbol": "SPCEx",
+      "name": "Virgin Galactic xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SPCEx.png"
+    },
+    {
+      "address": "0x80A77a372c1e12AcCdA84299492f404902E2DA67",
+      "symbol": "MCDx",
+      "name": "McDonald's xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MCDx.png"
+    },
+    {
+      "address": "0x89233399708C18Ac6887F90A2B4Cd8Ba5fEdD06e",
+      "symbol": "ABTx",
+      "name": "Abbott xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ABTx.png"
+    },
+    {
+      "address": "0x89b2607878ae19baB8020b8140eD550Ef3E953bb",
+      "symbol": "ASTSx",
+      "name": "AST SpaceMobile xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ASTSx.png"
+    },
+    {
+      "address": "0x89BAB39D627A9e34f0dc782C53457e80Ee8Fb9D9",
+      "symbol": "COPXx",
+      "name": "Global X Copper Miners xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/COPXx.png"
+    },
+    {
+      "address": "0x8aD3c73F833d3F9A523aB01476625F269aEB7Cf0",
+      "symbol": "TSLAx",
+      "name": "Tesla xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TSLAx.png"
+    },
+    {
+      "address": "0x8D512a03600981B8e86556fd5C0FbDd726Fe1821",
+      "symbol": "SMHx",
+      "name": "VanEck Semiconductor ETF xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SMHx.png"
+    },
+    {
+      "address": "0x8e9e4a8d7f1C65dcB42D9103832b27E75946055D",
+      "symbol": "PPLTx",
+      "name": "abrdn Physical Platinum Shares xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PPLTx.png"
+    },
+    {
+      "address": "0x90561f53a83D97C383E4842960969a6d9cfe1Ba9",
+      "symbol": "PWRx",
+      "name": "Quanta Services, Inc. xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PWRx.png"
+    },
+    {
+      "address": "0x90A2a4c76b5D8c0bc892A69EA28Aa775a8f2dD48",
+      "symbol": "SPYx",
+      "name": "SP500 xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SPYx.png"
+    },
+    {
+      "address": "0x91Ea54a8A5426c0A0bEA55968Dd71abcE7b92751",
+      "symbol": "VXUSx",
+      "name": "Vanguard Total International Stock ETF xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VXUSx.png"
+    },
+    {
+      "address": "0x9337a8f11f777cDAa310B5682b09b44Ed8bdcbAD",
+      "symbol": "VGKx",
+      "name": "Vanguard FTSE Europe ETF xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VGKx.png"
+    },
+    {
+      "address": "0x96702be57Cd9777f835117a809C7124fe4ec989A",
+      "symbol": "METAx",
+      "name": "Meta xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/METAx.png"
+    },
+    {
+      "address": "0x995dB25F900E38851CF4e67a05960E66F774530D",
+      "symbol": "NETx",
+      "name": "Cloudflare xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NETx.png"
+    },
+    {
+      "address": "0x99A1a9BC796bAe48631a15B1C1889625C86B7b98",
+      "symbol": "TERx",
+      "name": "Teradyne, Inc. xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TERx.png"
+    },
+    {
+      "address": "0x9d275685dC284C8eB1C79f6ABA7a63Dc75ec890a",
+      "symbol": "AAPLx",
+      "name": "Apple xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AAPLx.png"
+    },
+    {
+      "address": "0x9D692bffEf6f6BedF4274053ff9998EFE3B2539E",
+      "symbol": "MARAx",
+      "name": "MARA xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MARAx.png"
+    },
+    {
+      "address": "0x9e3bf4Ecfc44EeDD624F26656B6736a3F093b073",
+      "symbol": "TSMx",
+      "name": "TSMC xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TSMx.png"
+    },
+    {
+      "address": "0x9F7371F5b85443EE59457468eDe9D244A71C08d6",
+      "symbol": "APLDx",
+      "name": "Applied Digital Corporation xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/APLDx.png"
+    },
+    {
+      "address": "0xA6a65AC27E76cD53cB790473E4345c46e5eBf961",
+      "symbol": "NFLXx",
+      "name": "Netflix xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NFLXx.png"
+    },
+    {
+      "address": "0xa753A7395cAe905Cd615Da0B82A53E0560f250af",
+      "symbol": "QQQx",
+      "name": "Nasdaq xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/QQQx.png"
+    },
+    {
+      "address": "0xa90424D5D3E770e8644103AB503ed775dD1318FD",
+      "symbol": "PGx",
+      "name": "Procter & Gamble xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PGx.png"
+    },
+    {
+      "address": "0xa96d03Fe2479fEbC69535366933Ea053D5acF9dd",
+      "symbol": "YLDEx",
+      "name": "Franklin ClearBridge Enhanced Income xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/YLDEx.png"
+    },
+    {
+      "address": "0xAA28cB97D7f7E172f54deE950743886D2d65447d",
+      "symbol": "IJRx",
+      "name": "S&P Small Cap xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IJRx.png"
+    },
+    {
+      "address": "0xAaA9cF4E9488F5eEF064B8CFac70f5FD857669dc",
+      "symbol": "LITEx",
+      "name": "Lumentum Holdings Inc. xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LITEx.png"
+    },
+    {
+      "address": "0xad5cdc3340904285B8159089974A99a1A09EB4C0",
+      "symbol": "CVXx",
+      "name": "Chevron xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CVXx.png"
+    },
+    {
+      "address": "0xAE2f842EF90C0d5213259Ab82639D5BBF649b08E",
+      "symbol": "MSTRx",
+      "name": "MicroStrategy xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MSTRx.png"
+    },
+    {
+      "address": "0xaE6D61508125bC541E367A6a8B1f594ecC42F557",
+      "symbol": "FEZx",
+      "name": "SPDR EURO STOXX 50 xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FEZx.png"
+    },
+    {
+      "address": "0xaeB681B69E5094E04d11BCeF51A71358A374C3ED",
+      "symbol": "BMNRx",
+      "name": "Bitmine xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BMNRx.png"
+    },
+    {
+      "address": "0xAF072F109A2C173D822a4fe9af311A1B18F83d19",
+      "symbol": "TMOx",
+      "name": "Thermo Fisher xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TMOx.png"
+    },
+    {
+      "address": "0xb365Cd2588065F522D379AD19e903304f6B622C6",
+      "symbol": "MAx",
+      "name": "Mastercard xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MAx.png"
+    },
+    {
+      "address": "0xb63EFBc28860c8097e341DE1fCF59456161E9D98",
+      "symbol": "SNDKx",
+      "name": "Sandisk Corporation xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SNDKx.png"
+    },
+    {
+      "address": "0xb7e2E3eF9F5c6b72a162FFc76382e4477A44D913",
+      "symbol": "KLACx",
+      "name": "KLA Corporation xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KLACx.png"
+    },
+    {
+      "address": "0xBaC2588D2272fF6E5826E2882042Fa2926039CBa",
+      "symbol": "VCXx",
+      "name": "Fundrise Innovation Fund, LLC xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VCXx.png"
+    },
+    {
+      "address": "0xBC7170a1280Be28513B4e940C681537EB25e39f4",
+      "symbol": "CMCSAx",
+      "name": "Comcast xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CMCSAx.png"
+    },
+    {
+      "address": "0xBca703C64f616A17b4f2763F34f93400Dbe20F17",
+      "symbol": "ETNx",
+      "name": "Eaton Corporation plc xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ETNx.png"
+    },
+    {
+      "address": "0xbD730E618bcD88C82dDeE52e10275CF2f88A4777",
+      "symbol": "VTIx",
+      "name": "Vanguard xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VTIx.png"
+    },
+    {
+      "address": "0xbEe6b69345F376598Fe16AbD5592c6F844825E66",
+      "symbol": "OPENx",
+      "name": "OPEN xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/OPENx.png"
+    },
+    {
+      "address": "0xC0B417e7F83db438631Eb5E096684dd742E5294F",
+      "symbol": "ASMLx",
+      "name": "ASML xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ASMLx.png"
+    },
+    {
+      "address": "0xC0c2150cf0870E2d7aBc7cDe17C20A542faFBB9B",
+      "symbol": "WULFx",
+      "name": "TeraWulf xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WULFx.png"
+    },
+    {
+      "address": "0xc435b3C41AE56d9Bc57b8525F4d522C978F168e8",
+      "symbol": "WBDx",
+      "name": "Warner Bros. Discovery xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/WBDx.png"
+    },
+    {
+      "address": "0xc845b2894dBddd03858fd2D643B4eF725fE0849d",
+      "symbol": "NVDAx",
+      "name": "NVIDIA xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NVDAx.png"
+    },
+    {
+      "address": "0xD0194F0f077968DA8ca59811e9407f54AE6c9432",
+      "symbol": "CLSKx",
+      "name": "CleanSpark xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CLSKx.png"
+    },
+    {
+      "address": "0xD5859517180e639D50003FdB434E690aB1FBD21b",
+      "symbol": "MDLNx",
+      "name": "Medline xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MDLNx.png"
+    },
+    {
+      "address": "0xd9913208647671Fe0F48F7F260076B2C6F310Aac",
+      "symbol": "IBMx",
+      "name": "International Business Machines xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IBMx.png"
+    },
+    {
+      "address": "0xD9FC3E075d45254a1D834fEa18AF8041207DeA0A",
+      "symbol": "JPMx",
+      "name": "JPMorgan Chase xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JPMx.png"
+    },
+    {
+      "address": "0xdadfb355c6110eda0908740d52c834d6C2BCDDc7",
+      "symbol": "IWMx",
+      "name": "Russell 2000 xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IWMx.png"
+    },
+    {
+      "address": "0xdb0482cfaD4789798623E64b15eebA01b16e917C",
+      "symbol": "JNJx",
+      "name": "Johnson & Johnson xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JNJx.png"
+    },
+    {
+      "address": "0xdb9783Ca04bBD64fe2c6d7B9503A979b3DE30729",
+      "symbol": "UBERx",
+      "name": "Uber xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UBERx.png"
+    },
+    {
+      "address": "0xdbA228936F4079DaF9Aa906fd48a87f2300405F4",
+      "symbol": "DHRx",
+      "name": "Danaher xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DHRx.png"
+    },
+    {
+      "address": "0xdCC1a2699441079dA889B1F49e12B69cC791129b",
+      "symbol": "KOx",
+      "name": "Coca-Cola xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/KOx.png"
+    },
+    {
+      "address": "0xdce993F8a6DbcE7F27434874F5DFe9A8d58509c9",
+      "symbol": "LNGx",
+      "name": "Cheniere Energy xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/LNGx.png"
+    },
+    {
+      "address": "0xE0F324A026ca55492637009d98034103Db4a6967",
+      "symbol": "SLMTx",
+      "name": "Brera xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SLMTx.png"
+    },
+    {
+      "address": "0xe12BB32D77BE4DB10DDC82088b230D35d097E9C5",
+      "symbol": "PANWx",
+      "name": "Palo Alto Networks xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PANWx.png"
+    },
+    {
+      "address": "0xE1385FDd5ffB10081Cd52C56584F25EFa9084015",
+      "symbol": "HOODx",
+      "name": "Robinhood xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/HOODx.png"
+    },
+    {
+      "address": "0xE1435b2f302edf42AE84a306a5e1948b270B6CCb",
+      "symbol": "BITXx",
+      "name": "Volatility Shares 2x Bitcoin Strategy xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/BITXx.png"
     },
     {
       "address": "0xe343167631d89b6ffc58b88d6b7fb0228795491d",
@@ -2141,12 +6957,212 @@
       "logoURI": "https://files.cow.fi/token-lists/images/57073/0xe343167631d89b6ffc58b88d6b7fb0228795491d/logo.png"
     },
     {
+      "address": "0xE49922893496b17AC12Fdd7c74720a92010d889D",
+      "symbol": "JPSTx",
+      "name": "JPMorgan Ultra-Short Income xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/JPSTx.png"
+    },
+    {
+      "address": "0xE5f6d3b2405ABdfE6F660e63202B25D23763160d",
+      "symbol": "GMEx",
+      "name": "Gamestop xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GMEx.png"
+    },
+    {
+      "address": "0xe75AfF5123D9De91A1c27167C6C01B1f5b1eAb14",
+      "symbol": "ENHAx",
+      "name": "Enhanced Group xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ENHAx.png"
+    },
+    {
+      "address": "0xe92f673Ca36C5E2Efd2DE7628f815f84807e803F",
+      "symbol": "GOOGLx",
+      "name": "Alphabet xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GOOGLx.png"
+    },
+    {
+      "address": "0xe95ab205e333443D7970336D5fD827eF9eD97608",
+      "symbol": "TONXx",
+      "name": "TON xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TONXx.png"
+    },
+    {
+      "address": "0xe9FA01197B7E836982a1cab03FE591F7e331E313",
+      "symbol": "AMATx",
+      "name": "Applied Materials, Inc. xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMATx.png"
+    },
+    {
+      "address": "0xeAAd46F4146Ded5a47B55AA7F6c48c191dEAEC88",
+      "symbol": "MRVLx",
+      "name": "Marvell xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MRVLx.png"
+    },
+    {
+      "address": "0xebb35d5b5Bf82203812e3C02797EF0cBDBb81146",
+      "symbol": "EWQx",
+      "name": "iShares MSCI France xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWQx.png"
+    },
+    {
+      "address": "0xeD2Bdd82366728C1F2A7E8B93C4dD4A58404BF65",
+      "symbol": "EWGx",
+      "name": "iShares MSCI Germany xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/EWGx.png"
+    },
+    {
+      "address": "0xEd579847e45B0c48cfd608Da829073B2F7e65Cf0",
+      "symbol": "UUUUx",
+      "name": "Energy Fuels Inc. xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/UUUUx.png"
+    },
+    {
+      "address": "0xEEdb0273c5Af792745180e9fF568cD01550fFA13",
+      "symbol": "XOMx",
+      "name": "Exxon Mobil xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/XOMx.png"
+    },
+    {
       "address": "0xf1815bd50389c46847f0bda824ec8da914045d14",
       "symbol": "USDC.e",
       "name": "Bridged USDC (Stargate)",
       "decimals": 6,
       "chainId": 57073,
       "logoURI": "https://files.cow.fi/token-lists/images/57073/0xf1815bd50389c46847f0bda824ec8da914045d14/logo.png"
+    },
+    {
+      "address": "0xF51565240E667176c532DB4139386E6A6E506d99",
+      "symbol": "FAAAx",
+      "name": "Fidelity AAA CLO xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/FAAAx.png"
+    },
+    {
+      "address": "0xf6a873BAe4Ba1B304e45dF52A4b7D176E1C6a8c4",
+      "symbol": "MUx",
+      "name": "Micron Technology xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/MUx.png"
+    },
+    {
+      "address": "0xF6D87E523512704C29E9b7cA3e9e6226bDCE3EA1",
+      "symbol": "SCHFx",
+      "name": "Schwab International Equity xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SCHFx.png"
+    },
+    {
+      "address": "0xf706585e7e8900bE0267bEE3B9A2F70835EC6628",
+      "symbol": "PYPLx",
+      "name": "PayPal xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/PYPLx.png"
+    },
+    {
+      "address": "0xf7F4fAC56f012dE7Dd6adFF54C761986B9E0655a",
+      "symbol": "GLXYx",
+      "name": "Galaxy Digital xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/GLXYx.png"
+    },
+    {
+      "address": "0xF8228D64435B55687157a5C9b132642FE04aC381",
+      "symbol": "SMRx",
+      "name": "NuScale Power Corporation xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/SMRx.png"
+    },
+    {
+      "address": "0xf8A80D1cb9cFD70D03D655D9dF42339846F3B3C8",
+      "symbol": "INTCx",
+      "name": "Intel xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/INTCx.png"
+    },
+    {
+      "address": "0xF9523E369c5f55ad72DbAA75B0a9b92B3D8b147e",
+      "symbol": "NVOx",
+      "name": "Novo Nordisk xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NVOx.png"
+    },
+    {
+      "address": "0xfBF2398dF672cEE4aFcC2A4A733222331c742a6A",
+      "symbol": "ABBVx",
+      "name": "AbbVie xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/ABBVx.png"
+    },
+    {
+      "address": "0xfBfc1FD14EeC970276c8a3BF5e6131cD751cC0B9",
+      "symbol": "IRENx",
+      "name": "IREN xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/IRENx.png"
+    },
+    {
+      "address": "0xfDDDb57878eF9D6f681Ec4381DCB626b9E69AC86",
+      "symbol": "TQQQx",
+      "name": "TQQQ xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/TQQQx.png"
+    },
+    {
+      "address": "0xFe7B11D43cfD9fd6010f1b3F9cC86e5BCDb2bc78",
+      "symbol": "DAXx",
+      "name": "Global X DAX Germany xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/DAXx.png"
+    },
+    {
+      "address": "0xfEbDEd1B0986a8ee107f5AB1a1c5a813491DeCEB",
+      "symbol": "CRCLx",
+      "name": "Circle xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/CRCLx.png"
+    },
+    {
+      "address": "0xFfAE0B911CB2cb7B49FD75011D99D137C040A9eF",
+      "symbol": "VOOx",
+      "name": "Vanguard S&P 500 xStock",
+      "decimals": 18,
+      "chainId": 57073,
+      "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/VOOx.png"
     },
     {
       "address": "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",


### PR DESCRIPTION
**Adding 163 xStocks** (623 chain entries total) to the CoW Swap token list.

All tokens are tokenised equities issued by Backed Finance — fully-backed.
Website: https://xstocks.fi · Docs: https://docs.xstocks.fi

Chain coverage: Ethereum (chainId 1), BSC (56), Arbitrum (42161), Ink (57073) — the four chains CoW Swap supports. xStocks also deploy to Mantle, HyperEVM, Solana, and TON; those are intentionally omitted from this PR since they aren't in CoW Swap's chain set.

---

_Updated on 2026-05-21: this PR has been re-pushed with the current xStocks catalogue (163 tokens, +30 since the original submission) and the live product branding (Backed Finance as legal issuer; xStocks as the product brand across website, socials, and contact). The previous content has been superseded; the diff against `main` reflects the canonical version. Apologies for the churn — happy to discuss anything that surfaces in re-review._
