### PR TITLE
Add Anisian (ANI) – Base

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -4,7 +4,7 @@
   "version": {
     "major": 7,
     "minor": 4,
-    "patch": 0
+    "patch": 1
   },
   "logoURI": "https://files.cow.fi/token-lists/images/list-logo.png",
   "keywords": [
@@ -1944,6 +1944,14 @@
       "decimals": 18,
       "chainId": 8453,
       "logoURI": "https://files.cow.fi/token-lists/images/8453/0xd09acb80c1e8f2291862c4978a008791c9167003/logo.png"
+    },
+    {
+      "address": "0xe378841a3970fd43ac8ad4d1d77b068c87287e5f",
+      "symbol": "ANI",
+      "name": "Anisian",
+      "decimals": 18,
+      "chainId": 8453,
+      "logoURI": "https://raw.githubusercontent.com/anisiananifree/anisian_contracts/main/ipfs/ani-logo-256.png"
     },
     {
       "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",


### PR DESCRIPTION
## Add Anisian (ANI) on Base

- **Token:** Anisian (`ANI`), 18 decimals
- **Chain:** Base mainnet (chainId `8453`)
- **Contract:** `0xE378841a3970FD43ac8aD4D1D77b068C87287e5f`
  ([verified on Basescan](https://basescan.org/token/0xE378841a3970FD43ac8aD4D1D77b068C87287e5f#code))
- **Liquidity:** Aerodrome pool `0x2F947691C97244D845B2db2f86489D21c4c919bD`
- **Source / metadata / docs:** https://github.com/anisiananifree/anisian_contracts (MIT-licensed)
- **Logo:** 256×256 PNG hosted in the source repo

### About

Anisian is a **fixed-supply, immutable** ERC-20 on Base with a deflationary halving burn schedule:

- 100,000,000 ANI minted once at deployment. No further minting.
- ~79,000,000 ANI scheduled to be burned over ~14 years via a **permissionless** burn vault (`triggerBurn()` callable by anyone).
- **No owner, no admin, no mint, no pause, no upgrade.** The deployer has no special on-chain powers after `initialize()`.

This PR only adds the token entry; no scripts, lockfiles, or unrelated files are modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the ANI (Anisian) token to the platform

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/token-lists/pull/1436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->