### PR TITLE
Tag official EURC tokens as Circle issued

### DIFF
--- a/src/public/CowSwap.json
+++ b/src/public/CowSwap.json
@@ -217,7 +217,10 @@
       "name": "Euro Coin",
       "decimals": 6,
       "chainId": 1,
-      "logoURI": "https://files.cow.fi/token-lists/images/1/0x1abaea1f7c830bd89acc67ec4af516284b1bc33c/logo.png"
+      "logoURI": "https://files.cow.fi/token-lists/images/1/0x1abaea1f7c830bd89acc67ec4af516284b1bc33c/logo.png",
+      "tags": [
+        "circle"
+      ]
     },
     {
       "address": "0x1bed97cbc3c24a4fb5c069c6e311a967386131f7",
@@ -1868,7 +1871,10 @@
       "name": "EURC",
       "decimals": 6,
       "chainId": 8453,
-      "logoURI": "https://files.cow.fi/token-lists/images/8453/0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42/logo.png"
+      "logoURI": "https://files.cow.fi/token-lists/images/8453/0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42/logo.png",
+      "tags": [
+        "circle"
+      ]
     },
     {
       "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",


### PR DESCRIPTION
## What changed
- Added the existing `circle` tag to official EURC entries on Ethereum and Base in `CowSwap.json`.

## Why
- USDC entries already identify Circle-issued tokens with the `circle` tag.
- Circle lists both tagged EURC contracts as official mainnet deployments, so EURC should be tagged consistently:
  - Ethereum EURC: `0x1abaea1f7c830bd89acc67ec4af516284b1bc33c` in Circle docs: https://developers.circle.com/stablecoins/eurc-contract-addresses
  - Base EURC: `0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42` in Circle docs: https://developers.circle.com/stablecoins/eurc-contract-addresses

## Validation
- `yarn validate:schema`
- `yarn validate:chains`