### PR TITLE
feat(solana): override tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,5 @@
     "eslint": "^8.52.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"
-  },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -71,5 +71,6 @@
     "eslint": "^8.52.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/src/public/SolanaDefault.json
+++ b/src/public/SolanaDefault.json
@@ -1,10 +1,10 @@
 {
   "name": "Solana Default",
-  "timestamp": "2026-05-25T18:56:44.193Z",
+  "timestamp": "2026-07-14T11:28:18.555Z",
   "version": {
     "major": 1,
     "minor": 0,
-    "patch": 0
+    "patch": 1
   },
   "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png",
   "keywords": [
@@ -14,6 +14,14 @@
     "jupiter"
   ],
   "tokens": [
+    {
+      "chainId": 1000000001,
+      "address": "11111111111111111111111111111111",
+      "decimals": 9,
+      "name": "SOL",
+      "symbol": "SOL",
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png"
+    },
     {
       "chainId": 1000000001,
       "address": "25hAyBQfoDhfWx9ay6rarbgvWGwDdNqcHsXS3jQ3mTDJ",
@@ -72,14 +80,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "2Pp6ebUvEL9YRTauUTmGTwYZKRfyQXGM9jE4S8WPDtEy",
-      "name": "The Professor ",
-      "symbol": "LAB",
-      "decimals": 6,
-      "logoURI": "https://ipfs.io/ipfs/QmWuYLsoscsuqrcQnqjewBFiXsLeHEUUQLo3LpCf3qPHLm"
-    },
-    {
-      "chainId": 1000000001,
       "address": "2VYVwrwSNM8WxbFdPU4KQpZUB9FWCenFFoDqvpHQ7rZE",
       "name": "Jail Cat",
       "symbol": "CUFF",
@@ -115,14 +115,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "2ioyweEeV4xJCkFJvh868X9iP3L6Q31MVCawfbJLRTHq",
-      "name": "DOGWIFOUTHAT",
-      "symbol": "WIFOUT",
-      "decimals": 9,
-      "logoURI": "https://i.imgur.com/3642zZD.jpg"
-    },
-    {
-      "chainId": 1000000001,
       "address": "2u98MM7DMtVmNG4iAKRNMtynjmkzgD6fXAzB3wVfhQvg",
       "name": "Lets Fuckin Go",
       "symbol": "LFGO",
@@ -136,14 +128,6 @@
       "symbol": "MILKBAG",
       "decimals": 9,
       "logoURI": "https://www.dextools.io/resources/tokens/logos/solana/2ubuHGFS4VJVxSEpvV3kDwz6JiuXdaAoGMwrwYC87tp8.png?1711033406653"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "2wme8EVkw8qsfSk2B3QeX4S64ac6wxHPXb3GrdckEkio",
-      "name": "sols",
-      "symbol": "sols",
-      "decimals": 9,
-      "logoURI": "https://arweave.net/DjDIitc-424x1UlvJLElsmhfIK3QMuFlPnJKT3CVkWY?ext=png"
     },
     {
       "chainId": 1000000001,
@@ -227,14 +211,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "3Lec18q7nPM62LQwqXG2ddiBTDrFCiNw1NEA1ehBZPgB",
-      "name": "SoylanaManletCaptainZ",
-      "symbol": "ANSEM",
-      "decimals": 1,
-      "logoURI": "https://arweave.net/tJXiOAU5ZXS7PZbWGKrg5nNRCh5OUlr07iIY4FRWK0o"
-    },
-    {
-      "chainId": 1000000001,
       "address": "3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh",
       "name": "Wrapped BTC (Portal)",
       "symbol": "WBTC",
@@ -315,14 +291,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "3acxNNmfdKKZj9i35P4VDBFm74Ufdt8ojKWceVGynwC5",
-      "name": "GM",
-      "symbol": "GM",
-      "decimals": 4,
-      "logoURI": "https://arweave.net/jhNqKLDDC2ZtanzmFt-OZZJLFEYRpzus3rzhl7MGiOU"
-    },
-    {
-      "chainId": 1000000001,
       "address": "3ag1Mj9AKz9FAkCQ6gAEhpLSX8B2pUbPdkb9iBsDLZNB",
       "name": "Honk",
       "symbol": "HONK",
@@ -379,14 +347,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "42o42KH1dzEDjqijWpWHcNtpmW42Hxzg7YbMs1h6A5r1",
-      "name": "Pika",
-      "symbol": "Pika",
-      "decimals": 6,
-      "logoURI": "https://arweave.net/fiJkDvhbpNNUsGN25gbPfkV8doyVAsaWwi7cz_hFY4Y"
-    },
-    {
-      "chainId": 1000000001,
       "address": "45EgCwcPXYagBC7KqBin4nCFgEZWN7f3Y6nACwxqMCWX",
       "name": "Moutai",
       "symbol": "Moutai",
@@ -440,22 +400,6 @@
       "symbol": "PRCL",
       "decimals": 6,
       "logoURI": "https://delicate-amaranth-badger.myfilebase.com/ipfs/QmXPfhVt6BiuyrK5Va7y3GNqDqBDwms3uW75CknNxDHGS7"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "4LP5JKsyKC5pSAoodwcZnDCSK2ggsMcZvHKoo7HCPDCV",
-      "name": "Snoopy",
-      "symbol": "$SNOOPY",
-      "decimals": 9,
-      "logoURI": "https://bafkreih5phb36g46nyomg3gx6274wyhbgh4pyhax7noxpbhinirxtzcyum.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "4MPA8WbyYtKiufXDSdckEoMPdN5XK1Xw9S9LSLMjK5Y4",
-      "name": "Wojak",
-      "symbol": "Wojak",
-      "decimals": 9,
-      "logoURI": "https://bafybeidzhrlmyjgx52t56ribawbm6jvn5rdr2aly5mxabxjsciqmrczq4i.ipfs.nftstorage.link"
     },
     {
       "chainId": 1000000001,
@@ -547,14 +491,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "4vqYQTjmKjxrWGtbL2tVkbAU1EVAz9JwcYtd2VE3PbVU",
-      "name": "Anita Max Wynn",
-      "symbol": "WYNN",
-      "decimals": 6,
-      "logoURI": "https://bafybeiepbscydfgvbfqq4augkwub2tsvbsm3e6uau3he2mmmbj4ebuyyym.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
       "address": "4y3oUrsJfSp431R3wJrWiaLxRPsnYtpkVJmoV2bYpBiy",
       "name": "wifejak",
       "symbol": "WIFE",
@@ -586,14 +522,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "5LafQUrVco6o7KMz42eqVEJ9LW31StPyGjeeu5sKoMtA",
-      "name": "Mumu the Bull",
-      "symbol": "MUMU",
-      "decimals": 6,
-      "logoURI": "https://bafkreihszutctvdmdlyjtzfmj7rgvdorpc7jchj2td3feypc7veidbkpsu.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
       "address": "5LwseQRo8fsz4S3y7jbqqe5C7tZTz5PwhXNCHj13jLBi",
       "name": "PESHI",
       "symbol": "PESHI",
@@ -615,14 +543,6 @@
       "symbol": "SHIB",
       "decimals": 9,
       "logoURI": "https://i.ibb.co/kh4h5xd/11.png"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "5NHd3MsP6dXi9r1saPkeB2DoZyXLvPiqv4n9J54Cpump",
-      "name": "Degen Danny",
-      "symbol": "DANNY",
-      "decimals": 6,
-      "logoURI": "https://ipfs.io/ipfs/QmVDUc8Z4U3Nqt3eDdB8p53ypQ4oNXwNmzt9t4PNDVWpCp"
     },
     {
       "chainId": 1000000001,
@@ -664,14 +584,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "5jFJCvNgg8ytGWBygoquaUC6bMZyr7C5jmGHECBzrxR5",
-      "name": "Davinci Jeremie",
-      "symbol": "DVINCI",
-      "decimals": 6,
-      "logoURI": "https://bafkreihbx7trnvsdgd5gi7gzldasjcimedtnmuqpnhgen2c6vkxw44u7ky.ipfs.nftstorage.link/"
-    },
-    {
-      "chainId": 1000000001,
       "address": "5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp",
       "name": "michi",
       "symbol": "$michi",
@@ -701,14 +613,6 @@
       "symbol": "SCP",
       "decimals": 9,
       "logoURI": "https://scpri.me/files/scp/logo.png"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "5wU4tUcAbds7d5cmnGK2otHa9gbayYsD2mhz1reR6c91",
-      "name": "Tongue Cat",
-      "symbol": "LUIS",
-      "decimals": 6,
-      "logoURI": "https://bafkreihtcqx42secvikbvwtqzcrc2fldtapwl6w4qwdfu4yxh43n6l243u.ipfs.nftstorage.link/"
     },
     {
       "chainId": 1000000001,
@@ -803,14 +707,6 @@
       "symbol": "JASON",
       "decimals": 6,
       "logoURI": "https://ipfs.io/ipfs/Qma6oqZnWWzdSywJ78F3cxYJkE7cL55QNJiejuj51KKr1K"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "6U48jtR53ZK3E1MozLrpwJDTrtj74uuFhMGNzGY18YPu",
-      "name": "sharki",
-      "symbol": "SHARKI",
-      "decimals": 9,
-      "logoURI": "https://gateway.irys.xyz/V6O5BkXCXxmKNxs5NVjhvwH_NjvTAD8Jz0-2MKGM6jQ"
     },
     {
       "chainId": 1000000001,
@@ -950,14 +846,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "7JhmUcZrrfhyt5nTSu3AfsrUq2L9992a7AhwdSDxdoL2",
-      "name": "HampterFi",
-      "symbol": "HMTR",
-      "decimals": 0,
-      "logoURI": "https://arweave.net/4gD5pJQbMxu-J7tGxtoMRpbirRfAhWcjCunHuNmUqFg"
-    },
-    {
-      "chainId": 1000000001,
       "address": "7NQSHjuEGENZDWfSvPZz7oP2D6c5Jc3LjFC6uh179ufr",
       "name": ":moyai:(MOAI)",
       "symbol": "MOAI",
@@ -1040,14 +928,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "7jmaTFBooHkaSrBJDftu3LcK85KPtqWTCaFZCDxQV7ZW",
-      "name": "Boomers on Sol",
-      "symbol": "BOOMER",
-      "decimals": 6,
-      "logoURI": "https://bafybeicyv3sn4btptwdgptm3cx47xv4nrr7mpnq6kikxwfi5qrvbo4qiiy.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
       "address": "7kbnvuGBxxj8AG9qp8Scn56muWGaRaFqxg1FsRp3PaFT",
       "name": "UXD Stablecoin",
       "symbol": "UXD",
@@ -1068,14 +948,6 @@
       "name": "OmniCat (Wormhole)",
       "symbol": "OMNI",
       "decimals": 8
-    },
-    {
-      "chainId": 1000000001,
-      "address": "7p6RjGNZ7HLHpfTo6nh21XYw4CZgxXLQPzKXG72pNd2y",
-      "name": "CHUNGHWA",
-      "symbol": "CIGGS",
-      "decimals": 9,
-      "logoURI": "https://bafkreieagcborzxb4mkn37uvxjq7wzrxuuix76crpyym7by2bkkrik4jn4.ipfs.nftstorage.link"
     },
     {
       "chainId": 1000000001,
@@ -1218,14 +1090,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "8PMJczfs9W8TDKiNBD85AuqxE8tWACCDeUwxpUeadL3j",
-      "name": "CEILING CAT",
-      "symbol": "CEICAT",
-      "decimals": 9,
-      "logoURI": "https://i.imgur.com/ROCbyO3.png"
-    },
-    {
-      "chainId": 1000000001,
       "address": "8Qrc2pf9p24NyJVG1FagnqJXwKw6h5L5McxnMfJoUxev",
       "name": "Emmy",
       "symbol": "EMMY",
@@ -1250,35 +1114,11 @@
     },
     {
       "chainId": 1000000001,
-      "address": "8VJ51bdE3xorQ1zB7FEa8CsHdM4kw77xCFiCgbnL2qbT",
-      "name": "Anonymous",
-      "symbol": "ANON",
-      "decimals": 6,
-      "logoURI": "https://ipfs.io/ipfs/QmVwzQh6mv1cQ35axcyj52s183QpwrJzpooh5EeUgS5sV1"
-    },
-    {
-      "chainId": 1000000001,
       "address": "8W4qpyLx74vwBRewa3rVEPPVMnJ8VWMkCTWCTSYPQTDu",
       "name": "MemeCoinDAOai",
       "symbol": "MEMES",
       "decimals": 6,
       "logoURI": "https://arweave.net/hb9M20acG4rA6SFess40tLnhJ6RZkd0EmluNwzh11Wc?ext=png"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "8XVXzmsMMw7ufa8RC21fHcDP6TGti5y3ZidQinnYurqr",
-      "name": "Laughing Shoe",
-      "symbol": "SHOE",
-      "decimals": 6,
-      "logoURI": "https://ipfs.io/ipfs/QmSxm7jD7FT4u4KUhM4stgj3H15wqSyMadpps7q49cZjs3"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "8bXZuG6NVuhdmGeMEjypYZGny48DgpZ68TvkvVTmFDdF",
-      "name": "Saylor",
-      "symbol": "SAYLOR",
-      "decimals": 9,
-      "logoURI": "https://bafybeihsvj7r5hypkjrkayfq5sgh5fz3ef6hpa5wpnfeesmbc52ujjuvue.ipfs.nftstorage.link"
     },
     {
       "chainId": 1000000001,
@@ -1433,27 +1273,11 @@
     },
     {
       "chainId": 1000000001,
-      "address": "9Ttyez3xiruyj6cqaR495hbBkJU6SUWdV6AmQ9MvbyyS",
-      "name": "smolecoin",
-      "symbol": "smole",
-      "decimals": 6,
-      "logoURI": "https://ipfs.io/ipfs/QmcXAf2KasPyu8UtLnafsj3MR3YSjPH4huRc4NQ8YSanoX"
-    },
-    {
-      "chainId": 1000000001,
       "address": "9WPTUkh8fKuCnepRWoPYLH3aK9gSjPHFDenBq2X1Czdp",
       "name": "SelfieDogCoin",
       "symbol": "SELFIE",
       "decimals": 6,
       "logoURI": "https://ipfs.io/ipfs/QmcrXYhDD6mcCWziAZfmMp9zwv1RvMAXaShBHEQzQjpaRj"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "9XRpjZjhJPeWtUymiEWn3FW7uAnMeQca14ucTWWWyP2g",
-      "name": "ArgentinaCoin",
-      "symbol": "ARG",
-      "decimals": 6,
-      "logoURI": "https://ipfs.io/ipfs/QmeZBCD8fvvp53LFQf3xHWVsvwwtNZGZn3VZFHC2m8EKFE"
     },
     {
       "chainId": 1000000001,
@@ -1669,14 +1493,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "ARt4N4WY4PEdYUuBG7qENwuYSSiQUqP1RXFiahhwfzH9",
-      "name": "EGIRL",
-      "symbol": "EGIRL",
-      "decimals": 9,
-      "logoURI": "https://bafkreid6lv4sec5o74hm2n43cjgoqt3g4ar3qx7fc3zw3niouxzbkudz24.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
       "address": "AT79ReYU9XtHUTF5vM6Q4oa9K8w7918Fp5SU7G1MDMQY",
       "name": "SpiderSwap",
       "symbol": "SPDR",
@@ -1722,14 +1538,6 @@
       "symbol": "LONG",
       "decimals": 5,
       "logoURI": "https://bafkreiayokuebuh72owe7axyonjlea2o7kfnjnftzoidyvghlql4igxpea.ipfs.nftstorage.link/"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "AYyYgh3i43s1QSpvG4vwhJ6s3gewfN7uteFwYrswgMGw",
-      "name": "ps1 hagrid",
-      "symbol": "HAGGORD",
-      "decimals": 9,
-      "logoURI": "https://bafkreiak2a2gbdqqnz77xup3bi72lon5fe4ri4cpozxp5o4ekjnugm77wm.ipfs.nftstorage.link"
     },
     {
       "chainId": 1000000001,
@@ -1920,14 +1728,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "BYATmZ7ry2pewxW3213sczJYB7ZJzPr921uvcRcJYYZQ",
-      "name": "Byat",
-      "symbol": "BYAT",
-      "decimals": 9,
-      "logoURI": "https://bafybeiebc4yrvojgwxcbhla4hgg6vswqapei4vos2wivdo5whpzh4kgybe.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
       "address": "BZLbGTNCSFfoth2GYDtwr7e4imWzpR5jqcUuGEwr646K",
       "name": "IO",
       "symbol": "IO",
@@ -1984,14 +1784,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "BxXmDhM8sTF3QG4foaVM2v1EUvg9DLSVUsDRTjR8tMyS",
-      "name": "TIMMI",
-      "symbol": "TIMMI",
-      "decimals": 6,
-      "logoURI": "https://bafkreihnelxawqpzkw55hrbb3a46kgyo4vmiupsrio3nngecrbtt2tleam.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
       "address": "Bz7Nx1F3Mti1BVS7ZAVDLSKGEaejufxvX2DPdjpf8PqT",
       "name": "FISH N CHIPS",
       "symbol": "CHIPPY",
@@ -2037,14 +1829,6 @@
       "symbol": "Mail",
       "decimals": 6,
       "logoURI": "https://ipfs.io/ipfs/QmcAtxKADTdcZvZxZj3Gkc5YR4Ket1TDodrwzhHt49u3Bn"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "CEYNkwuEXU1KD3MN47NaMvHznPPimR15Sjfv6Y2r1SVw",
-      "name": "KEKW",
-      "symbol": "KEKW",
-      "decimals": 6,
-      "logoURI": "https://ipfs.io/ipfs/QmTSxnMHGHdFpjZVUshFSvmmcpCYom9XEkJsS63mYMiDyw"
     },
     {
       "chainId": 1000000001,
@@ -2112,14 +1896,6 @@
       "symbol": "CRWNY",
       "decimals": 6,
       "logoURI": "https://cdn.crowny.dev/app-icon-min.png"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "CUwif1FiX5b3bwwb2n5Bm35AixvnR8LJjGUVmEwNZNgR",
-      "name": "Solamander",
-      "symbol": "SOLY",
-      "decimals": 9,
-      "logoURI": "https://img.solyonsol.io/soly.png"
     },
     {
       "chainId": 1000000001,
@@ -2249,22 +2025,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "DXCoKQ7iLpux398fNHewQn6djfGobzFuPiR5o8hrVHAb",
-      "name": "Fatality Coin",
-      "symbol": "FATALITY",
-      "decimals": 9,
-      "logoURI": "https://bafkreie3tk2pnz2tap2onh2eqf5cvg4uda3ec3m7x5mxb5frp2lim2mbbm.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "DcUoGUeNTLhhzyrcz49LE7z3MEFwca2N9uSw1xbVi1gm",
-      "name": "K-Pop",
-      "symbol": "KPOP",
-      "decimals": 9,
-      "logoURI": "https://arweave.net/rzUo3sj5mtF5Q1ceUp0R7X_BOdULgdbL9OhzaFoP11U"
-    },
-    {
-      "chainId": 1000000001,
       "address": "DeaKMzAeZja3Mh5okZE6WUvygLP3Lfuvm6Rg78HqXTz9",
       "name": "Solnic",
       "symbol": "SOLNIC",
@@ -2302,22 +2062,6 @@
       "symbol": "COK",
       "decimals": 6,
       "logoURI": "https://pbs.twimg.com/profile_images/1792570983183781889/-jLe-2lo_400x400.jpg"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "Doggoyb1uHFJGFdHhJf8FKEBUMv58qo98CisWgeD7Ftk",
-      "name": "DOGGO",
-      "symbol": "DOGGO",
-      "decimals": 5,
-      "logoURI": "https://shdw-drive.genesysgo.net/BBwXjBB6LtWGjKW5GveUSau5z9KZv2CK5AWmb7FCDF6K/doggies_coin.png"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "DoxsC4PpVHiUxCKYeKSkPXVVVSJYzidZZJxW4XCFF2t",
-      "name": "Bonk of America",
-      "symbol": "BONKFA",
-      "decimals": 6,
-      "logoURI": "https://i.degencdn.com/ipfs/bafybeifexskt57d55ehwbaopibzfddcnccsgakjme62fq5aizdcnfo4g5e"
     },
     {
       "chainId": 1000000001,
@@ -2401,14 +2145,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "E63CDwLy9Dwr3EptAzopV9RuWoQnn5ZVYEjLWnJX8dCw",
-      "name": "Beluga Cat",
-      "symbol": "BELUGA",
-      "decimals": 9,
-      "logoURI": "https://bafybeid6xz4mx75na6wmjhn3axywvgs3d3gceie2evbg3koharbz4eptry.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
       "address": "E6UU5M1z4CvSAAF99d9wRoXsasWMEXsvHrz3JQRXtm2X",
       "name": "Dogelana",
       "symbol": "DGLN",
@@ -2425,27 +2161,11 @@
     },
     {
       "chainId": 1000000001,
-      "address": "E9pBR4xjscYLPqFZ4YM4gUkczqz7MHpB6dk4sfSQTnJD",
-      "name": "Pussy In Bio",
-      "symbol": "pussyinbio",
-      "decimals": 6,
-      "logoURI": "https://ipfs.io/ipfs/QmdVwp45yBtPgTu1afbZqbr5JvC6HvtYLUUyVJ32vqxnD4"
-    },
-    {
-      "chainId": 1000000001,
       "address": "EATGZHJViJsk7nEKkrdJicwNbfpkJfAtmrEmrjXR8NBj",
       "name": "PopDog",
       "symbol": "POPDOG",
       "decimals": 6,
       "logoURI": "https://res.cloudinary.com/dsknxrxol/image/upload/v1760033457/IMG_2135_wjmrov.jpg"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "EDavhezsuNnhdoAKPExWaMtnuhq6FVqoBYnyFEJLLBqC",
-      "name": "xiaojie",
-      "symbol": "XIAO",
-      "decimals": 6,
-      "logoURI": "https://bafybeibqz4chze636s7ypnob4xogp7vobosqsbwmeu36w4x62iyqb6n6hm.ipfs.cf-ipfs.com/"
     },
     {
       "chainId": 1000000001,
@@ -2510,14 +2230,6 @@
       "symbol": "MEDIA",
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ETAtLmCmsoiEEKfNrHKJ2kYy3MoABhU6NQvpSfij5tDs/logo.png"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "EWMfSJgDCE7CXDAYz3hbCaA7NsFHTnddySXx3shco2Hs",
-      "name": "STASH INU",
-      "symbol": "STASH",
-      "decimals": 6,
-      "logoURI": "https://bafybeidtlz6sjkwkxmgccxy35fdmcjis6xpqep7ll5w2udhmmjx7qjes3u.ipfs.nftstorage.link"
     },
     {
       "chainId": 1000000001,
@@ -2763,14 +2475,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "FabjHjc1druUQoHVtudpNiCpnf73rtLzMkRM1b5NSbb6",
-      "name": "D/ACC",
-      "symbol": "D/ACC",
-      "decimals": 9,
-      "logoURI": "https://nftstorage.link/ipfs/bafkreiaad6yxjxad6qpkb7taodfnbfv74hmgmnorqatab27r54jpgroqci/"
-    },
-    {
-      "chainId": 1000000001,
       "address": "Faf89929Ni9fbg4gmVZTca7eW6NFg877Jqn6MizT3Gvw",
       "name": "LandWolf",
       "symbol": "$WOLF",
@@ -2891,14 +2595,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "Fxgdfsy1Z5Mvh53o69s2Ev6TGxtAJ1RQ5RJ5moCpKmQZ",
-      "name": "sealwifhat",
-      "symbol": "SI",
-      "decimals": 9,
-      "logoURI": "https://bafybeiay63g7wqdbndfp6yxuvonuigsp4qrgm22ultyndxurnuu7tkkbbi.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
       "address": "G3q2zUkuxDCXMnhdBPujjPHPw9UTMDbXqzcc2UHM3jiy",
       "name": "I CHOOSE RICH EVERYTIME!",
       "symbol": "NICK",
@@ -2912,14 +2608,6 @@
       "symbol": "sboy",
       "decimals": 6,
       "logoURI": "https://ipfs.io/ipfs/QmaLWmZgBvf2vhM2HCooXPNfJ6HdKgKGyB681pEncQHFzD"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "G8Vy25NzjRmuQtnN35xF7j3X2Z1TrV39XijZu8Mg4w8n",
-      "name": "Let Him Cook",
-      "symbol": "COOK",
-      "decimals": 6,
-      "logoURI": "https://ipfs.io/ipfs/QmNQ2Ah6xTokMuEmpTKcXBpTpECsADXNtng9mmbRw6XBVr"
     },
     {
       "chainId": 1000000001,
@@ -3047,14 +2735,6 @@
       "symbol": "CRODIE",
       "decimals": 9,
       "logoURI": "https://gateway.irys.xyz/s1WSRMI9z06trgN6PLpggkUvfP69vrLPJvE--6eBJJM"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "GwyxednWbrhgT2K6iPUsbtadErA7TBGqsJjyzAody2mv",
-      "name": "TOLYS CAT",
-      "symbol": "OPPIE",
-      "decimals": 6,
-      "logoURI": "https://ipfs.io/ipfs/QmYjzkwSw5NZUREa1KARWuHCp6QZP29rGEDDzs7kwRKYkA"
     },
     {
       "chainId": 1000000001,
@@ -3200,14 +2880,6 @@
       "name": "Cryowar Token",
       "symbol": "CWAR",
       "decimals": 9
-    },
-    {
-      "chainId": 1000000001,
-      "address": "HhJpBhRRn4g56VsyLuT8DL5Bv31HkXqsrahTTUCZeZg4",
-      "name": "Myro",
-      "symbol": "$MYRO",
-      "decimals": 9,
-      "logoURI": "https://i.ibb.co/9nr3xFp/MYRO-200x200.png"
     },
     {
       "chainId": 1000000001,
@@ -3406,14 +3078,6 @@
     },
     {
       "chainId": 1000000001,
-      "address": "LGNDeXXXaDDeRerwwHfUtPBNz5s6vrn1NMSt9hdaCwx",
-      "name": "Legends of SOL",
-      "symbol": "LEGEND",
-      "decimals": 9,
-      "logoURI": "https://arweave.net/sCGvXDlbFn8p0s0cfqtznbjn9K_cyYY2aa9HGC1XWR8"
-    },
-    {
-      "chainId": 1000000001,
       "address": "LMFzmYL6y1FX8HsEmZ6yNKNzercBmtmpg2ZoLwuUboU",
       "name": "Lamas Finance",
       "symbol": "LMF",
@@ -3442,14 +3106,6 @@
       "name": "Larix",
       "symbol": "LARIX",
       "decimals": 6
-    },
-    {
-      "chainId": 1000000001,
-      "address": "M9i5xQz8Z2Ua3VHuBkjBSkP5HYwdetu7N9RP5VUsW4z",
-      "name": "Chinese Beaver",
-      "symbol": "BEAVER",
-      "decimals": 6,
-      "logoURI": "https://gateway.irys.xyz/vhQEI53x9msYz5gHSBofNA1oljDH9xKjGAqkQmge-1o"
     },
     {
       "chainId": 1000000001,
@@ -3612,9 +3268,9 @@
     {
       "chainId": 1000000001,
       "address": "So11111111111111111111111111111111111111112",
-      "name": "Wrapped SOL",
-      "symbol": "SOL",
       "decimals": 9,
+      "name": "Wrapped SOL",
+      "symbol": "WSOL",
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png"
     },
     {
@@ -3736,14 +3392,6 @@
       "symbol": "HAPPI",
       "decimals": 6,
       "logoURI": "https://bafybeiemgqcqgeu4mqvrmdncrlch7zhwbvb2xlsfnovuqcp4hb4jhsjsfm.ipfs.nftstorage.link"
-    },
-    {
-      "chainId": 1000000001,
-      "address": "acatzTjUeHDT3SoufN6NMxGUmBFtoqFHnFwusdw8kYX",
-      "name": "Apple Cat",
-      "symbol": "acat",
-      "decimals": 6,
-      "logoURI": "https://bafkreifcnqbrplil4wqfd54ey3tw25c3haucpzr6f6acltfee3pbprkgzq.ipfs.nftstorage.link/"
     },
     {
       "chainId": 1000000001,
@@ -4022,14 +3670,6 @@
       "extensions": {
         "isToken2022": true
       }
-    },
-    {
-      "chainId": 1000000001,
-      "address": "to1yVXiNRMVVgS8i54Yjj3xB51MTorFrCMz7N8cirbK",
-      "name": "Anatoly Coin",
-      "symbol": "TOLY",
-      "decimals": 9,
-      "logoURI": "https://shdw-drive.genesysgo.net/3YZtwGNZZisAUxKokcivJEwq2ag93APVXYqeyfaqb9Rq/toly-img.png"
     },
     {
       "chainId": 1000000001,

--- a/src/public/SolanaOverrides.json
+++ b/src/public/SolanaOverrides.json
@@ -1,0 +1,18 @@
+[
+  {
+    "chainId": 1000000001,
+    "address": "So11111111111111111111111111111111111111112",
+    "decimals": 9,
+    "name": "Wrapped SOL",
+    "symbol": "WSOL",
+    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png"
+  },
+  {
+    "chainId": 1000000001,
+    "address": "11111111111111111111111111111111",
+    "decimals": 9,
+    "name": "SOL",
+    "symbol": "SOL",
+    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png"
+  }
+]

--- a/src/scripts/solana.ts
+++ b/src/scripts/solana.ts
@@ -1,6 +1,8 @@
+import path from 'path'
+import fs from 'fs'
 import type { TokenInfo, TokenList } from '@uniswap/token-lists'
 import pRetry, { AbortError } from 'p-retry'
-import { getTokenListVersion, writeTokenListToBuild, writeTokenListToSrc } from './tokenListUtils'
+import { getTokenListVersion, SRC_DIR, writeTokenListToBuild, writeTokenListToSrc } from './tokenListUtils'
 
 /**
  * Fetches the Solana default token list from Jupiter and writes it as
@@ -12,6 +14,7 @@ import { getTokenListVersion, writeTokenListToBuild, writeTokenListToSrc } from 
  */
 
 const OUTPUT_FILE = 'SolanaDefault.json'
+const OVERRIDES_FILE = 'SolanaOverrides.json'
 const LIST_NAME = 'Solana Default'
 const SOLANA_CHAIN_ID = 1000000001
 const JUPITER_VERIFIED_URL = 'https://lite-api.jup.ag/tokens/v2/tag?query=verified'
@@ -106,6 +109,46 @@ function sortByAddress(a: TokenInfo, b: TokenInfo): number {
   return a.address < b.address ? -1 : a.address > b.address ? 1 : 0
 }
 
+// Read hand-maintained overrides. Missing/invalid file → no overrides applied.
+function readOverrides(): TokenInfo[] {
+  const filePath = path.join(SRC_DIR, OVERRIDES_FILE)
+  if (!fs.existsSync(filePath)) {
+    console.log(`No overrides file at ${filePath}, skipping`)
+    return []
+  }
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+  if (!Array.isArray(parsed)) {
+    console.warn(`Unexpected ${OVERRIDES_FILE} shape (expected array), skipping overrides`)
+    return []
+  }
+  return parsed as TokenInfo[]
+}
+
+// Merge overrides into the token list, keyed by `address`.
+// An override replaces a matching token entirely; otherwise it's appended.
+function applyOverrides(tokens: TokenInfo[], overrides: TokenInfo[]): TokenInfo[] {
+  if (overrides.length === 0) return tokens
+
+  const byAddress = new Map<string, TokenInfo>()
+  for (const token of tokens) {
+    byAddress.set(token.address, token)
+  }
+
+  let replaced = 0
+  let added = 0
+  for (const override of overrides) {
+    if (byAddress.has(override.address)) {
+      replaced++
+    } else {
+      added++
+    }
+    byAddress.set(override.address, override)
+  }
+
+  console.log(`Applied ${overrides.length} overrides (${replaced} replaced, ${added} added)`)
+  return [...byAddress.values()]
+}
+
 function buildTokenList(tokens: TokenInfo[], version: TokenList['version']): TokenList {
   return {
     name: LIST_NAME,
@@ -124,10 +167,12 @@ async function main() {
   const strict = raw.filter(isStrict)
   console.log(`${strict.length} carry the "strict" tag`)
 
-  const tokens = strict.filter(isValidToken).map(toTokenInfo).sort(sortByAddress)
+  const jupiterTokens = strict.filter(isValidToken).map(toTokenInfo)
 
-  const dropped = strict.length - tokens.length
-  console.log(`Kept ${tokens.length} tokens, dropped ${dropped} (bad fields / unknown program)`)
+  const dropped = strict.length - jupiterTokens.length
+  console.log(`Kept ${jupiterTokens.length} tokens, dropped ${dropped} (bad fields / unknown program)`)
+
+  const tokens = applyOverrides(jupiterTokens, readOverrides()).sort(sortByAddress)
 
   const version = await getTokenListVersion(OUTPUT_FILE)
   const tokenList = buildTokenList(tokens, version)


### PR DESCRIPTION
The source of tokens doesn't define SOL and WSOL well, so I added a static `SolanaOverrides.json` to control that.
In the future we can use it to fix other tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for curated Solana token overrides, including SOL and WSOL metadata.
  * Token overrides can now add or replace entries in the generated token list.
  * Added Token-2022 metadata for supported tokens.

* **Bug Fixes**
  * Corrected Wrapped SOL symbol display from SOL to WSOL.
  * Improved filtering of invalid or unsupported token entries.

* **Chores**
  * Standardized the project’s package manager configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->