### PR TITLE
fix: change Liquidity to Market cap

### DIFF
--- a/.github/workflows/processRequest.yml
+++ b/.github/workflows/processRequest.yml
@@ -83,11 +83,11 @@ jobs:
 
         ### Token metrics
 
-        | Liquidity | 24h Volume | Holders |
+        | Market cap | 24h Volume | Holders |
         |-----------|-----------|---------|
-        | ${{ fromJSON(needs.process-request.outputs.issueInfo).tokenLiquidity }} | ${{ fromJSON(needs.process-request.outputs.issueInfo).tokenVolume24h }} | ${{ fromJSON(needs.process-request.outputs.issueInfo).tokenHolders }} |
+        | ${{ fromJSON(needs.process-request.outputs.issueInfo).marketCap }} | ${{ fromJSON(needs.process-request.outputs.issueInfo).tokenVolume24h }} | ${{ fromJSON(needs.process-request.outputs.issueInfo).tokenHolders }} |
 
-        Liquidity & 24h volume via [GeckoTerminal ↗︎](${{ fromJSON(needs.process-request.outputs.issueInfo).geckoTerminalUrl }}) · holders via [CoinMarketCap ↗︎](${{ fromJSON(needs.process-request.outputs.issueInfo).cmcUrl }})
+        Market Cap & 24h volume via [GeckoTerminal ↗︎](${{ fromJSON(needs.process-request.outputs.issueInfo).geckoTerminalUrl }}) · holders via [CoinMarketCap ↗︎](${{ fromJSON(needs.process-request.outputs.issueInfo).cmcUrl }})
 
         ### Reason
 

--- a/scripts/processRequest.test.mjs
+++ b/scripts/processRequest.test.mjs
@@ -155,7 +155,7 @@ describe('processRequest', () => {
     assert.equal(info.network, 'POLYGON')
     assert.equal(info.chainId, 137)
     // Enrichment ran but the token is "unlisted" (404) -> n/a, PR still proceeds.
-    assert.equal(info.tokenLiquidity, 'n/a')
+    assert.equal(info.marketCap, 'n/a')
     assert.equal(info.tokenHolders, 'n/a')
     assert.equal(info.cmcUrl, 'https://dex.coinmarketcap.com/token/polygon/0x123/')
     assert.equal(info.geckoTerminalUrl, 'https://www.geckoterminal.com/polygon_pos/tokens/0x123')
@@ -186,7 +186,7 @@ describe('processRequest', () => {
 
     assert.equal(fetchMock.mock.callCount(), 0)
     const info = getIssueInfo(core)
-    assert.equal(info.tokenLiquidity, undefined)
+    assert.equal(info.marketCap, undefined)
   })
 
   it('handles errors', async () => {

--- a/scripts/tokenMetrics.mjs
+++ b/scripts/tokenMetrics.mjs
@@ -1,6 +1,6 @@
 // Fetch token market metrics for automated PR descriptions.
 //
-//   - Liquidity + 24h volume: GeckoTerminal public API (keyless, token-aggregate
+//   - marketCap + 24h volume: GeckoTerminal public API (keyless, token-aggregate
 //     across pools, documented JSON contract).
 //   - Holders: scraped from the CoinMarketCap DEX page — holder count is not
 //     exposed by GeckoTerminal, and CMC's free API does not provide it either.
@@ -21,7 +21,7 @@ export const NETWORK_TO_GECKOTERMINAL = {
   BNB: 'bsc',
   GNOSIS_CHAIN: 'xdai',
   LINEA: 'linea',
-  // PLASMA, INK: not on GeckoTerminal -> liquidity/volume stay 'n/a'.
+  // PLASMA, INK: not on GeckoTerminal -> marketCap/volume stay 'n/a'.
 }
 
 // token-lists network identifiers (NETWORK_CONFIG keys) -> CoinMarketCap DEX chain slug.
@@ -73,16 +73,16 @@ export function cmcTokenUrl(cmcSlug, address) {
   return `https://dex.coinmarketcap.com/token/${cmcSlug}/${address}/`
 }
 
-/** Fetch token-aggregate liquidity + 24h volume (USD) from GeckoTerminal. */
-export async function fetchLiquidityAndVolume({ gtNetwork, address }) {
+/** Fetch token-aggregate marketCap + 24h volume (USD) from GeckoTerminal. */
+export async function fetchMarketCapAndVolume({ gtNetwork, address }) {
   const url = `https://api.geckoterminal.com/api/v2/networks/${gtNetwork}/tokens/${address}`
   const res = await fetchWithRetry(url, { headers: { Accept: 'application/json' } })
   if (!res.ok) throw new Error(`GeckoTerminal returned HTTP ${res.status} for ${url}`)
 
   const attr = (await res.json())?.data?.attributes ?? {}
-  const liquidity = attr.total_reserve_in_usd != null ? Number(attr.total_reserve_in_usd) : null
+  const marketCap = attr.market_cap_usd != null ? Number(attr.market_cap_usd) : null
   const volume24h = attr.volume_usd?.h24 != null ? Number(attr.volume_usd.h24) : null
-  return { liquidity, volume24h }
+  return { marketCap, volume24h }
 }
 
 /** Scrape the holder count from the CoinMarketCap DEX page's __NEXT_DATA__ JSON. */
@@ -114,7 +114,7 @@ export function count(x) {
  * Enrich `results` with formatted token metrics. NEVER throws.
  *
  * Sets (all formatted strings, 'n/a' on miss):
- *   - tokenLiquidity, tokenVolume24h  (via GeckoTerminal)
+ *   - marketCap, tokenVolume24h  (via GeckoTerminal)
  *   - tokenHolders                    (scraped from CoinMarketCap)
  * and the source page URLs geckoTerminalUrl / cmcUrl (token pages when the
  * chain is mapped, otherwise the site homepages).
@@ -124,7 +124,7 @@ export function count(x) {
 export async function enrichWithTokenMetrics(values) {
   const results = { ...values }
 
-  results.tokenLiquidity = 'n/a'
+  results.marketCap = 'n/a'
   results.tokenVolume24h = 'n/a'
   results.tokenHolders = 'n/a'
   results.geckoTerminalUrl = 'https://www.geckoterminal.com'
@@ -133,16 +133,16 @@ export async function enrichWithTokenMetrics(values) {
   const network = String(values.network || '').toUpperCase()
   const address = values.address
 
-  // Liquidity + 24h volume via GeckoTerminal.
+  // market_cap_usd + 24h volume via GeckoTerminal.
   const gtNetwork = NETWORK_TO_GECKOTERMINAL[network]
   if (gtNetwork && address) {
     results.geckoTerminalUrl = geckoTerminalUrl(gtNetwork, address)
     try {
-      const { liquidity, volume24h } = await fetchLiquidityAndVolume({ gtNetwork, address })
-      results.tokenLiquidity = usd(liquidity)
+      const { marketCap, volume24h } = await fetchMarketCapAndVolume({ gtNetwork, address })
+      results.marketCap = usd(marketCap)
       results.tokenVolume24h = usd(volume24h)
     } catch (err) {
-      console.warn(`Could not fetch liquidity/volume for ${address}: ${err?.message ?? err}`)
+      console.warn(`Could not fetch marketCap/volume for ${address}: ${err?.message ?? err}`)
     }
   }
 

--- a/scripts/tokenMetrics.test.mjs
+++ b/scripts/tokenMetrics.test.mjs
@@ -4,11 +4,11 @@ import assert from 'node:assert/strict'
 import { enrichWithTokenMetrics, usd, count } from './tokenMetrics.mjs'
 
 // GeckoTerminal token response, mirroring data.attributes.{total_reserve_in_usd, volume_usd.h24}.
-const geckoJson = ({ liquidity, volume24h }) => ({
+const geckoJson = ({ marketCap, volume24h }) => ({
   ok: true,
   status: 200,
   json: async () => ({
-    data: { attributes: { total_reserve_in_usd: liquidity, volume_usd: { h24: volume24h } } },
+    data: { attributes: { market_cap_usd: marketCap, volume_usd: { h24: volume24h } } },
   }),
   text: async () => '',
 })
@@ -60,12 +60,12 @@ describe('enrichWithTokenMetrics', () => {
 
   it('populates all three metrics from both sources on success', async () => {
     global.fetch = routedFetch({
-      gecko: () => geckoJson({ liquidity: '1234567.89', volume24h: '98765.4' }),
+      gecko: () => geckoJson({ marketCap: '1234567.89', volume24h: '98765.4' }),
       cmc: () => cmcHtml({ holders: 12345 }),
     })
     const values = { network: 'MAINNET', address: '0xabc' }
     const results = await enrichWithTokenMetrics(values)
-    assert.equal(results.tokenLiquidity, '$1,234,568')
+    assert.equal(results.marketCap, '$1,234,568')
     assert.equal(results.tokenVolume24h, '$98,765')
     assert.equal(results.tokenHolders, '12,345')
     assert.equal(results.geckoTerminalUrl, 'https://www.geckoterminal.com/eth/tokens/0xabc')
@@ -82,20 +82,20 @@ describe('enrichWithTokenMetrics', () => {
     })
     const values = { network: 'MAINNET', address: '0xabc' }
     const results = await enrichWithTokenMetrics(values)
-    assert.equal(results.tokenLiquidity, 'n/a')
+    assert.equal(results.marketCap, 'n/a')
     assert.equal(results.tokenVolume24h, 'n/a')
     assert.equal(results.tokenHolders, '999')
   })
 
-  it('is independent: CMC scrape failure still yields liquidity/volume', async () => {
+  it('is independent: CMC scrape failure still yields marketCap/volume', async () => {
     mock.method(console, 'warn', () => {})
     global.fetch = routedFetch({
-      gecko: () => geckoJson({ liquidity: '5000', volume24h: '250' }),
+      gecko: () => geckoJson({ marketCap: '5000', volume24h: '250' }),
       cmc: () => ({ ok: false, status: 404, text: async () => '', json: async () => ({}) }),
     })
     const values = { network: 'BASE', address: '0xdef' }
     const results = await enrichWithTokenMetrics(values)
-    assert.equal(results.tokenLiquidity, '$5,000')
+    assert.equal(results.marketCap, '$5,000')
     assert.equal(results.tokenVolume24h, '$250')
     assert.equal(results.tokenHolders, 'n/a')
   })
@@ -112,7 +112,7 @@ describe('enrichWithTokenMetrics', () => {
     })
     const values = { network: 'MAINNET', address: '0xabc' }
     const results = await enrichWithTokenMetrics(values)
-    assert.equal(results.tokenLiquidity, 'n/a')
+    assert.equal(results.marketCap, 'n/a')
     assert.equal(results.tokenHolders, 'n/a')
   })
 
@@ -121,7 +121,7 @@ describe('enrichWithTokenMetrics', () => {
     global.fetch = fetchMock
     const values = { network: 'PLASMA', address: '0xabc' }
     const results = await enrichWithTokenMetrics(values)
-    assert.equal(results.tokenLiquidity, 'n/a')
+    assert.equal(results.marketCap, 'n/a')
     assert.equal(results.tokenHolders, 'n/a')
     assert.equal(fetchMock.mock.callCount(), 0)
     assert.equal(results.geckoTerminalUrl, 'https://www.geckoterminal.com')


### PR DESCRIPTION
It turned out the liquidity parameter is not really precise. Market cap has better precision.

Example: https://api.geckoterminal.com/api/v2/networks/eth/tokens/0xa12cc123ba206d4031d1c7f6223d1c2ec249f4f3