### PR TITLE
fix: remove legacy EURe and GBPe from coingecko list

### DIFF
--- a/src/public/CoinGecko.100.json
+++ b/src/public/CoinGecko.100.json
@@ -100,14 +100,6 @@
     },
     {
       "chainId": 100,
-      "address": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
-      "name": "Monerium EUR emoney [OLD]",
-      "symbol": "EURE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/23354/large/eur.png?1696522569"
-    },
-    {
-      "chainId": 100,
       "address": "0x2a22f9c3b484c3629090feed35f17ff8f88f76f0",
       "name": "Gnosis xDAI Bridged USDC (Gnosis)",
       "symbol": "USDC.E",
@@ -265,14 +257,6 @@
       "symbol": "SPACE",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/20676/large/jYw3kgsY_400x400.png?1696520076"
-    },
-    {
-      "chainId": 100,
-      "address": "0x5cb9073902f2035222b9749f8fb0c9bfe5527108",
-      "name": "Monerium GBP emoney",
-      "symbol": "GBPE",
-      "decimals": 18,
-      "logoURI": "https://assets.coingecko.com/coins/images/39004/large/gbp.png?1719840784"
     },
     {
       "chainId": 100,

--- a/src/scripts/auxLists/index.ts
+++ b/src/scripts/auxLists/index.ts
@@ -13,8 +13,8 @@ OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0xe91d153e0b41518a2ce8dd3d7944fa863463
 OVERRIDES[SupportedChainId.POLYGON]['0x0000000000000000000000000000000000001010'] = null // POL native token address
 OVERRIDES[SupportedChainId.MAINNET]['0x3231cb76718cdef2155fc47b5286d82e6eda273f'] = null // Legacy EURe
 OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0x3231cb76718cdef2155fc47b5286d82e6eda273f'] = null // Legacy EURe
-OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0xcB444e90D8198415266c6a2724b7900fb12FC56E'] = null // Legacy EURe
-OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0x5Cb9073902F2035222B9749F8fB0c9BFe5527108'] = null // Legacy GBPe
+OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0xcb444e90d8198415266c6a2724b7900fb12fc56e'] = null // Legacy EURe
+OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0x5cb9073902f2035222b9749f8fb0c9bfe5527108'] = null // Legacy GBPe
 
 async function main(): Promise<void> {
   const COINGECKO_IDS_MAP = await getCoingeckoTokenIdsMap()

--- a/src/scripts/auxLists/index.ts
+++ b/src/scripts/auxLists/index.ts
@@ -13,6 +13,8 @@ OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0xe91d153e0b41518a2ce8dd3d7944fa863463
 OVERRIDES[SupportedChainId.POLYGON]['0x0000000000000000000000000000000000001010'] = null // POL native token address
 OVERRIDES[SupportedChainId.MAINNET]['0x3231cb76718cdef2155fc47b5286d82e6eda273f'] = null // Legacy EURe
 OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0x3231cb76718cdef2155fc47b5286d82e6eda273f'] = null // Legacy EURe
+OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0xcB444e90D8198415266c6a2724b7900fb12FC56E'] = null // Legacy EURe
+OVERRIDES[SupportedChainId.GNOSIS_CHAIN]['0x5Cb9073902F2035222B9749F8fB0c9BFe5527108'] = null // Legacy GBPe
 
 async function main(): Promise<void> {
   const COINGECKO_IDS_MAP = await getCoingeckoTokenIdsMap()


### PR DESCRIPTION
Removed legacy EURe and GBPe from Gnosis coingecko lists:

- https://gnosisscan.io/token/0x5Cb9073902F2035222B9749F8fB0c9BFe5527108
- https://gnosisscan.io/token/0xcB444e90D8198415266c6a2724b7900fb12FC56E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete Monerium EUR and GBP token listings from the Gnosis Chain token list.
  * Excluded legacy EURe and GBPe token addresses from processing to prevent outdated assets from appearing or being handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->