### PR TITLE
fix: improve cowfi tokens gh action

### DIFF
--- a/.github/workflows/cowFi-tokens.yml
+++ b/.github/workflows/cowFi-tokens.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate token lists for cow.fi
         env:
           COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
-        run: USE_CACHE=false yarn cowFi:tokens
+        run: yarn cowFi:tokens
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/cowFi-tokens.yml
+++ b/.github/workflows/cowFi-tokens.yml
@@ -3,6 +3,7 @@ name: 'Cron: cow.fi tokens list'
 on:
   schedule:
     - cron: '0 */3 * * *' # Every 3 hours
+  workflow_dispatch:
 
 # Required for authenticating with AWS IAM
 permissions:

--- a/.github/workflows/cowFi-tokens.yml
+++ b/.github/workflows/cowFi-tokens.yml
@@ -9,10 +9,17 @@ permissions:
   id-token: write
   contents: read
 
+# Prevent overlapping runs: with the fetch now taking minutes instead of hours this shouldn't trigger
+# in practice, but it's cheap insurance against a slow CoinGecko incident causing another overlap.
+concurrency:
+  group: cowfi-tokens
+  cancel-in-progress: true
+
 jobs:
   generate-and-upload:
     name: Generate and Upload cow.fi tokens
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -26,6 +33,8 @@ jobs:
           authToken: ${{ secrets.PACKAGE_READ_AUTH_TOKEN }}
 
       - name: Generate token lists for cow.fi
+        env:
+          COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
         run: USE_CACHE=false yarn cowFi:tokens
 
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ build
 yalc.lock
 
 # Temporary files
-src/cowFi/TEMP*
 
 # logs
 *.log

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "ajv-cli": "^5.0.0",
     "ajv-formats": "^2.1.1",
     "csv-parser": "^3.0.0",
-    "lodash": "^4.17.21",
     "p-retry": "^6.2.1",
     "p-throttle": "^5.1.0",
     "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "ajv-cli": "^5.0.0",
     "ajv-formats": "^2.1.1",
     "csv-parser": "^3.0.0",
-    "exponential-backoff": "^3.1.2",
     "lodash": "^4.17.21",
     "p-retry": "^6.2.1",
     "p-throttle": "^5.1.0",

--- a/src/scripts/cowFi-tokens.js
+++ b/src/scripts/cowFi-tokens.js
@@ -39,7 +39,7 @@ async function fetchJson(url) {
 const throttledFetch = pThrottle({ limit: COINGECKO_REQUESTS_PER_MINUTE, interval: 60_000 })(fetch)
 
 function getRetryDelay(retryAfter, attempt) {
-  const retryAfterMs = Number(retryAfter) * 1000
+  const retryAfterMs = Number.parseFloat(retryAfter) * 1000
   return Number.isFinite(retryAfterMs) && retryAfterMs >= 0
     ? Math.min(retryAfterMs, MAX_RETRY_AFTER_MS)
     : 1000 * 2 ** attempt

--- a/src/scripts/cowFi-tokens.js
+++ b/src/scripts/cowFi-tokens.js
@@ -3,14 +3,12 @@ import path from 'path'
 
 import pThrottle from 'p-throttle'
 
-const USE_CACHE = (process.env.USE_CACHE ?? 'true') === 'true'
 const COINGECKO_API_KEY = process.env.COINGECKO_API_KEY
 const COINGECKO_API_BASE = 'https://pro-api.coingecko.com/api/v3'
 
 const cowListUrl = 'https://files.cow.fi/tokens/CowSwap.json'
 
 const LIST_DIR = path.join('src', 'cowFi')
-const CANDIDATES_CACHE_PATH = path.join(LIST_DIR, 'TEMP-candidates-raw.json')
 const CUSTOM_DESCRIPTION_PATH = path.join('src', 'files', 'description.json')
 
 const IDS_FILE_NAME_FINAL = 'cowFi-tokenIds.json'
@@ -124,19 +122,6 @@ export function filterCandidates(coingeckoList, cowFiAddressesByChain) {
   return candidates
 }
 
-async function getCandidates(cowFiAddressesByChain) {
-  if (USE_CACHE && fs.existsSync(CANDIDATES_CACHE_PATH)) {
-    return JSON.parse(fs.readFileSync(CANDIDATES_CACHE_PATH, 'utf8'))
-  }
-
-  const coingeckoList = await fetchCoingecko('/coins/list?include_platform=true&status=active')
-  const candidates = filterCandidates(coingeckoList, cowFiAddressesByChain)
-
-  writeFile(LIST_DIR, path.basename(CANDIDATES_CACHE_PATH), candidates)
-
-  return candidates
-}
-
 export function sortByMarketCapDesc(candidates, marketCapById) {
   return [...candidates].sort((a, b) => (marketCapById.get(b.id) ?? 0) - (marketCapById.get(a.id) ?? 0))
 }
@@ -198,7 +183,8 @@ async function main() {
 
   const cowFiAddressesByChain = await getCowFiAddressesByChain()
 
-  const candidates = await getCandidates(cowFiAddressesByChain)
+  const coingeckoList = await fetchCoingecko('/coins/list?include_platform=true&status=active')
+  const candidates = filterCandidates(coingeckoList, cowFiAddressesByChain)
   console.log(`Candidates after address/platform filter: ${candidates.length}`)
 
   const ranked = await rankByMarketCap(candidates)

--- a/src/scripts/cowFi-tokens.js
+++ b/src/scripts/cowFi-tokens.js
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 
-import _ from 'lodash'
 import pThrottle from 'p-throttle'
 
 const USE_CACHE = (process.env.USE_CACHE ?? 'true') === 'true'
@@ -143,10 +142,11 @@ export function sortByMarketCapDesc(candidates, marketCapById) {
 }
 
 async function rankByMarketCap(candidates) {
-  const chunks = _.chunk(
-    candidates.map(({ id }) => id),
-    MARKET_API_CHUNK_SIZE,
-  )
+  const ids = candidates.map(({ id }) => id)
+  const chunks = []
+  for (let index = 0; index < ids.length; index += MARKET_API_CHUNK_SIZE) {
+    chunks.push(ids.slice(index, index + MARKET_API_CHUNK_SIZE))
+  }
 
   const pages = await Promise.all(
     chunks.map((ids) =>

--- a/src/scripts/cowFi-tokens.js
+++ b/src/scripts/cowFi-tokens.js
@@ -1,56 +1,80 @@
 import fs from 'fs'
 import path from 'path'
-import { backOff } from 'exponential-backoff'
 
 import _ from 'lodash'
+import pThrottle from 'p-throttle'
 
 const USE_CACHE = (process.env.USE_CACHE ?? 'true') === 'true'
+const COINGECKO_API_KEY = process.env.COINGECKO_API_KEY
+const COINGECKO_API_BASE = 'https://pro-api.coingecko.com/api/v3'
 
 const cowListUrl = 'https://files.cow.fi/tokens/CowSwap.json'
-// const coinGeckoListUrl = "https://files.cow.fi/tokens/CoinGecko.json";
-const coinGeckoCoinsUrl = 'https://api.coingecko.com/api/v3/coins'
-const coinGeckoCoinsQuoteParams = `localization=false&tickers=false&market_data=true&community_data=false&developer_data=false&sparkline=false`
-const coinGeckoIdListUrl = `${coinGeckoCoinsUrl}/list`
 
 const LIST_DIR = path.join('src', 'cowFi')
-
-const IDS_FILE_NAME_RAW = 'TEMP-id-list-raw.json'
-const STATIC_LIST_NAME_RAW = 'TEMP-static-list-raw.json'
+const CANDIDATES_CACHE_PATH = path.join(LIST_DIR, 'TEMP-candidates-raw.json')
+const CUSTOM_DESCRIPTION_PATH = path.join('src', 'files', 'description.json')
 
 const IDS_FILE_NAME_FINAL = 'cowFi-tokenIds.json'
 const STATIC_LIST_NAME_FINAL = 'cowFi-tokens.json'
 
-const IDS_FILE_PATH_RAW = path.join(LIST_DIR, IDS_FILE_NAME_RAW)
-const STATIC_LIST_PATH_RAW = path.join(LIST_DIR, STATIC_LIST_NAME_RAW)
-const CUSTOM_DESCRIPTION_PATH = path.join('src', 'files', 'description.json')
-
 const TOTAL_LIST_LENGTH = 50
+// Fetch a few extra top-ranked candidates in case some get dropped below (denylisted or missing a description),
+// so the final list can still reach TOTAL_LIST_LENGTH without a second round-trip.
+const DETAIL_FETCH_BUFFER = 20
+const MARKET_API_CHUNK_SIZE = 250
+const COINGECKO_REQUESTS_PER_MINUTE = 25
+const COINGECKO_RETRIES = 2
+const MAX_RETRY_AFTER_MS = 10_000
 
 const TOKENS_TO_REMOVE = ['agave-token', 'fraction', 'minerva-wallet']
 
-async function fetchWithBackoff(url) {
-  return backOff(
-    () =>
-      fetch(url).then((res) => {
-        if (!res.ok) {
-          throw new Error(`Error fetching list ${url}`, res)
-        }
+// cow.fi's showcase list only cares about tokens on these two networks (CoinGecko platform names)
+const RELEVANT_CHAINS = { 1: 'ethereum', 100: 'xdai' }
 
-        return res.json()
-      }),
-    {
-      numOfAttempts: 50,
-      maxDelay: 36000000, // 10min
-      startingDelay: 5000, // 5s
-      retry: (e, attemptNum) => {
-        console.log(`Error fetching ${url}, attempt ${attemptNum}. Retrying soon...`)
-        return true
-      },
-    },
-  )
+async function fetchJson(url) {
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`Error fetching ${url}: ${res.status}`)
+  }
+  return res.json()
 }
 
-async function writeFile(dir, filename, input) {
+const throttledFetch = pThrottle({ limit: COINGECKO_REQUESTS_PER_MINUTE, interval: 60_000 })(fetch)
+
+function getRetryDelay(retryAfter, attempt) {
+  const retryAfterMs = Number(retryAfter) * 1000
+  return Number.isFinite(retryAfterMs) && retryAfterMs >= 0
+    ? Math.min(retryAfterMs, MAX_RETRY_AFTER_MS)
+    : 1000 * 2 ** attempt
+}
+
+function isRetryable(error) {
+  return error instanceof TypeError || error.status === 429 || (error.status >= 500 && error.status < 600)
+}
+
+export async function requestWithRetries(request, sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))) {
+  for (let attempt = 0; attempt <= COINGECKO_RETRIES; attempt++) {
+    try {
+      const res = await request()
+      if (res.ok) return res.json()
+
+      const error = new Error(`Error fetching CoinGecko: ${res.status}`)
+      error.status = res.status
+      error.retryAfter = res.headers.get('Retry-After')
+      throw error
+    } catch (error) {
+      if (!isRetryable(error) || attempt === COINGECKO_RETRIES) throw error
+      await sleep(getRetryDelay(error.retryAfter, attempt))
+    }
+  }
+}
+
+async function fetchCoingecko(path) {
+  const headers = COINGECKO_API_KEY ? { 'X-Cg-Pro-Api-Key': COINGECKO_API_KEY } : undefined
+  return requestWithRetries(() => throttledFetch(`${COINGECKO_API_BASE}${path}`, { headers }))
+}
+
+function writeFile(dir, filename, input) {
   const data = JSON.stringify(input, null, 4)
   const filePath = path.join(dir, filename)
 
@@ -63,165 +87,108 @@ async function writeFile(dir, filename, input) {
   fs.writeFileSync(filePath, data)
 }
 
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
+async function getCowFiAddressesByChain() {
+  const { tokens } = await fetchJson(cowListUrl)
 
-async function getTokenLists() {
-  // Get token lists
-  const cowList = await fetchWithBackoff(cowListUrl)
-  // const coinGeckoList = await fetchFromCoingecko(coinGeckoListUrl);
-
-  // Create input token list
-  // const result = [...cowList.tokens, ...coinGeckoList.tokens];
-  const list = [...cowList.tokens]
-
-  // Make the list unique by symbol
-  // TODO: use some unique field like address+chain
-  const unique = _.uniqBy(list, ({ symbol }) => symbol)
-
-  // Get an address and lowercase symbols
-  const result = unique.map(({ symbol, address }) => ({
-    symbol: symbol.toLowerCase(),
-    address: address.toLowerCase(),
-  }))
-
-  console.log('Input token list', result.length)
-
-  return result
-}
-
-async function getIds() {
-  // If ID's file exist
-  if (USE_CACHE && fs.existsSync(IDS_FILE_PATH_RAW)) {
-    const json = fs.readFileSync(IDS_FILE_PATH_RAW, 'utf8')
-    return JSON.parse(json)
+  const byChain = {}
+  for (const chainId of Object.keys(RELEVANT_CHAINS)) {
+    byChain[chainId] = new Set()
   }
 
-  // Get input list
-  const inputList = await getTokenLists()
+  for (const token of tokens) {
+    const addresses = byChain[token.chainId]
+    if (addresses) {
+      addresses.add(token.address.toLowerCase())
+    }
+  }
 
-  // Get Coingecko id list
-  const coinGeckoIdList = await fetchWithBackoff(coinGeckoIdListUrl)
-
-  // Get coin gecko list of ids for that uniq list
-  const idsData = coinGeckoIdList.filter((el) => inputList.some((input) => input.symbol === el.symbol.toLowerCase()))
-
-  // Write ID's file
-  writeFile(LIST_DIR, IDS_FILE_NAME_RAW, idsData)
-
-  return idsData
+  return byChain
 }
 
-async function getStaticData(idsData) {
-  // If static data file exists, read and return it
-  if (USE_CACHE && fs.existsSync(STATIC_LIST_PATH_RAW)) {
-    const json = fs.readFileSync(STATIC_LIST_PATH_RAW, 'utf8')
-    return JSON.parse(json)
-  }
+// Matches CoinGecko's full coin list against cow.fi's own token addresses *before* fetching any
+// per-token detail, so we only ever fetch detail for tokens we actually care about.
+export function filterCandidates(coingeckoList, cowFiAddressesByChain) {
+  const candidates = []
 
-  const successDelay = 3000 // Delay in milliseconds for successful requests
-  const staticData = []
+  for (const entry of coingeckoList) {
+    if (TOKENS_TO_REMOVE.includes(entry.id)) continue
 
-  let index = 0
-  const totalTokens = idsData.length + 1
-
-  while (index < idsData.length) {
-    const idItem = idsData[index]
-    const url = `${coinGeckoCoinsUrl}/${idItem.id}?${coinGeckoCoinsQuoteParams}`
-
-    console.log(`[${index + 1}/${totalTokens}] Fetching data for ID: ${idItem.id}`)
-
-    const data = await fetchWithBackoff(url)
-    staticData.push(data)
-    await sleep(successDelay) // Delay after a successful fetch
-    index++ // Move to the next item
-  }
-
-  // Write static data file
-  writeFile(LIST_DIR, STATIC_LIST_NAME_RAW, staticData)
-
-  return staticData
-}
-
-async function getStaticDataFinal(data) {
-  // Get only USD values for market data
-  let customDescriptionFile = null
-
-  if (USE_CACHE && fs.existsSync(CUSTOM_DESCRIPTION_PATH)) {
-    const json = fs.readFileSync(CUSTOM_DESCRIPTION_PATH, 'utf8')
-    customDescriptionFile = JSON.parse(json)
-  }
-
-  // Modify the data
-  const parsed = data.map((item) => {
-    const output = { ...item }
-
-    // Parse Market data to only get USD values
-    const market_data = output.market_data
-
-    for (let [key, value] of Object.entries(market_data)) {
-      if (value && typeof value === 'object' && 'usd' in value) {
-        market_data[key] = { usd: value.usd }
+    for (const [chainId, platformName] of Object.entries(RELEVANT_CHAINS)) {
+      const address = entry.platforms?.[platformName]?.toLowerCase()
+      if (address && cowFiAddressesByChain[chainId]?.has(address)) {
+        candidates.push({ id: entry.id, address })
+        break
       }
     }
-    output.market_data = market_data
+  }
 
-    // Add custom description
-    if (customDescriptionFile && customDescriptionFile[item.id]) {
-      output.description = customDescriptionFile[item.id]
-    }
-
-    return output
-  })
-
-  // Get hash map (object) of token IDS from our input list
-  const combined = await getTokenLists()
-  const combined_ids = combined.reduce((acc, { address }) => {
-    acc[address.toLowerCase()] = true
-    return acc
-  }, {})
-
-  // Filter current static list with only tokens from our 2 exists list
-  const filtered = parsed.filter(({ platforms, description, id }) => {
-    if (!description?.en?.trim().length || TOKENS_TO_REMOVE.includes(id) || !platforms) {
-      return false
-    }
-
-    return Object.entries(platforms).some(([chain, address]) => {
-      if (typeof address !== 'string' || !address) {
-        console.warn(
-          `Platform entry for chain="${chain}" has no address. Skipping... Debug URL: ${coinGeckoCoinsUrl}/${id}?${coinGeckoCoinsQuoteParams}`,
-        )
-        return false
-      }
-
-      return (
-        combined_ids[address.toLowerCase()] && ['ethereum', 'xdai'].includes(chain)
-      )
-    })
-  })
-
-  // Sort the data by market cap and take limit the list
-  const output = filtered.slice(0, TOTAL_LIST_LENGTH)
-
-  writeFile(LIST_DIR, STATIC_LIST_NAME_FINAL, output)
-
-  return output
+  return candidates
 }
 
-async function getIdsFinal(data) {
-  const ids = data.map(({ name, symbol, address, id, description }) => ({
+async function getCandidates(cowFiAddressesByChain) {
+  if (USE_CACHE && fs.existsSync(CANDIDATES_CACHE_PATH)) {
+    return JSON.parse(fs.readFileSync(CANDIDATES_CACHE_PATH, 'utf8'))
+  }
+
+  const coingeckoList = await fetchCoingecko('/coins/list?include_platform=true&status=active')
+  const candidates = filterCandidates(coingeckoList, cowFiAddressesByChain)
+
+  writeFile(LIST_DIR, path.basename(CANDIDATES_CACHE_PATH), candidates)
+
+  return candidates
+}
+
+export function sortByMarketCapDesc(candidates, marketCapById) {
+  return [...candidates].sort((a, b) => (marketCapById.get(b.id) ?? 0) - (marketCapById.get(a.id) ?? 0))
+}
+
+async function rankByMarketCap(candidates) {
+  const chunks = _.chunk(
+    candidates.map(({ id }) => id),
+    MARKET_API_CHUNK_SIZE,
+  )
+
+  const pages = await Promise.all(
+    chunks.map((ids) =>
+      fetchCoingecko(`/coins/markets?vs_currency=usd&per_page=${MARKET_API_CHUNK_SIZE}&ids=${ids.join(',')}`),
+    ),
+  )
+
+  const marketCapById = new Map(pages.flat().map((coin) => [coin.id, coin.market_cap ?? 0]))
+  return sortByMarketCapDesc(candidates, marketCapById)
+}
+
+async function getTokenDetails(ids) {
+  return Promise.all(
+    ids.map((id) =>
+      fetchCoingecko(
+        `/coins/${id}?localization=false&tickers=false&market_data=true&community_data=false&developer_data=false&sparkline=false`,
+      ),
+    ),
+  )
+}
+
+export function trimToUsd(marketData) {
+  const trimmed = {}
+  for (const [key, value] of Object.entries(marketData ?? {})) {
+    trimmed[key] = value && typeof value === 'object' && 'usd' in value ? { usd: value.usd } : value
+  }
+  return trimmed
+}
+
+function readCustomDescriptions() {
+  if (!fs.existsSync(CUSTOM_DESCRIPTION_PATH)) return null
+  return JSON.parse(fs.readFileSync(CUSTOM_DESCRIPTION_PATH, 'utf8'))
+}
+
+function getIdsFinal(data) {
+  return data.map(({ name, symbol, address, id, description }) => ({
     id,
     name,
     symbol,
     address,
     description: description.en,
   }))
-
-  writeFile(LIST_DIR, IDS_FILE_NAME_FINAL, ids)
-
-  return ids
 }
 
 async function main() {
@@ -229,13 +196,37 @@ async function main() {
     fs.mkdirSync(LIST_DIR)
   }
 
-  const idsDataRaw = await getIds()
-  const staticDataRaw = await getStaticData(idsDataRaw)
-  const staticDataFinal = await getStaticDataFinal(staticDataRaw)
-  const idsDataFinal = await getIdsFinal(staticDataFinal)
+  const cowFiAddressesByChain = await getCowFiAddressesByChain()
 
-  console.log('Final output token length', idsDataFinal.length)
+  const candidates = await getCandidates(cowFiAddressesByChain)
+  console.log(`Candidates after address/platform filter: ${candidates.length}`)
+
+  const ranked = await rankByMarketCap(candidates)
+  const topCandidates = ranked.slice(0, TOTAL_LIST_LENGTH + DETAIL_FETCH_BUFFER)
+  const addressById = new Map(topCandidates.map(({ id, address }) => [id, address]))
+
+  const details = await getTokenDetails(topCandidates.map(({ id }) => id))
+  const customDescriptions = readCustomDescriptions()
+
+  const finalTokens = details
+    .map((item) => ({
+      ...item,
+      market_data: trimToUsd(item.market_data),
+      address: addressById.get(item.id),
+      description: customDescriptions?.[item.id] ?? item.description,
+    }))
+    .filter((item) => item.description?.en?.trim().length)
+    .slice(0, TOTAL_LIST_LENGTH)
+
+  writeFile(LIST_DIR, STATIC_LIST_NAME_FINAL, finalTokens)
+
+  const idsFinal = getIdsFinal(finalTokens)
+  writeFile(LIST_DIR, IDS_FILE_NAME_FINAL, idsFinal)
+
+  console.log('Final output token length', idsFinal.length)
   console.log('Done!!!')
 }
 
-main()
+if (import.meta.main) {
+  main()
+}

--- a/src/scripts/cowFi-tokens.test.mjs
+++ b/src/scripts/cowFi-tokens.test.mjs
@@ -1,0 +1,127 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { filterCandidates, requestWithRetries, sortByMarketCapDesc, trimToUsd } from './cowFi-tokens.js'
+
+describe('filterCandidates', () => {
+  const cowFiAddressesByChain = {
+    1: new Set(['0xmainnet']),
+    100: new Set(['0xgnosis']),
+  }
+
+  it('keeps entries whose mainnet or gnosis address is in the cow.fi list', () => {
+    const result = filterCandidates(
+      [
+        { id: 'token-a', platforms: { ethereum: '0xMAINNET' } },
+        { id: 'token-b', platforms: { xdai: '0xGNOSIS' } },
+        { id: 'token-c', platforms: { ethereum: '0xsomethingelse' } },
+      ],
+      cowFiAddressesByChain,
+    )
+
+    assert.deepEqual(result, [
+      { id: 'token-a', address: '0xmainnet' },
+      { id: 'token-b', address: '0xgnosis' },
+    ])
+  })
+
+  it('drops denylisted tokens even if the address matches', () => {
+    const result = filterCandidates(
+      [{ id: 'agave-token', platforms: { ethereum: '0xmainnet' } }],
+      cowFiAddressesByChain,
+    )
+
+    assert.deepEqual(result, [])
+  })
+
+  it('ignores entries with no matching platform', () => {
+    const result = filterCandidates([{ id: 'token-d', platforms: { polygon: '0xmainnet' } }], cowFiAddressesByChain)
+
+    assert.deepEqual(result, [])
+  })
+})
+
+describe('sortByMarketCapDesc', () => {
+  it('sorts candidates by market cap, highest first', () => {
+    const candidates = [{ id: 'small' }, { id: 'big' }, { id: 'mid' }]
+    const marketCapById = new Map([
+      ['small', 1],
+      ['big', 100],
+      ['mid', 50],
+    ])
+
+    const result = sortByMarketCapDesc(candidates, marketCapById)
+
+    assert.deepEqual(
+      result.map((c) => c.id),
+      ['big', 'mid', 'small'],
+    )
+  })
+
+  it('treats unknown ids as zero market cap', () => {
+    const candidates = [{ id: 'unknown' }, { id: 'known' }]
+    const marketCapById = new Map([['known', 10]])
+
+    const result = sortByMarketCapDesc(candidates, marketCapById)
+
+    assert.deepEqual(
+      result.map((c) => c.id),
+      ['known', 'unknown'],
+    )
+  })
+})
+
+describe('trimToUsd', () => {
+  it('keeps only the usd value for object fields', () => {
+    const result = trimToUsd({
+      current_price: { usd: 1.5, eur: 1.3 },
+      market_cap: { usd: 1000, eur: 900 },
+    })
+
+    assert.deepEqual(result, {
+      current_price: { usd: 1.5 },
+      market_cap: { usd: 1000 },
+    })
+  })
+
+  it('passes through non-object fields unchanged', () => {
+    const result = trimToUsd({ ath_date: { usd: '2021-01-01' }, market_cap_rank: 5 })
+
+    assert.deepEqual(result, { ath_date: { usd: '2021-01-01' }, market_cap_rank: 5 })
+  })
+})
+
+describe('requestWithRetries', () => {
+  it('retries a rate-limited response after its Retry-After delay', async () => {
+    let calls = 0
+    const delays = []
+
+    const result = await requestWithRetries(
+      async () => {
+        calls++
+        return calls === 1
+          ? { ok: false, status: 429, headers: new Headers({ 'Retry-After': '2' }) }
+          : { ok: true, json: async () => ({ id: 'token' }) }
+      },
+      async (delay) => delays.push(delay),
+    )
+
+    assert.deepEqual(result, { id: 'token' })
+    assert.equal(calls, 2)
+    assert.deepEqual(delays, [2000])
+  })
+
+  it('does not retry a permanent response', async () => {
+    let calls = 0
+
+    await assert.rejects(
+      requestWithRetries(async () => {
+        calls++
+        return { ok: false, status: 400, headers: new Headers() }
+      }),
+      /400/,
+    )
+
+    assert.equal(calls, 1)
+  })
+})

--- a/src/scripts/cowFi-tokens.test.mjs
+++ b/src/scripts/cowFi-tokens.test.mjs
@@ -111,6 +111,24 @@ describe('requestWithRetries', () => {
     assert.deepEqual(delays, [2000])
   })
 
+  it('uses exponential backoff when Retry-After is missing', async () => {
+    let calls = 0
+    const delays = []
+
+    await requestWithRetries(
+      async () => {
+        calls++
+        return calls === 1
+          ? { ok: false, status: 429, headers: new Headers() }
+          : { ok: true, json: async () => ({ id: 'token' }) }
+      },
+      async (delay) => delays.push(delay),
+    )
+
+    assert.equal(calls, 2)
+    assert.deepEqual(delays, [1000])
+  })
+
   it('does not retry a permanent response', async () => {
     let calls = 0
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2995,11 +2995,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
 logform@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/logform/-/logform-2.7.0.tgz#cfca97528ef290f2e125a08396805002b2d060d1"


### PR DESCRIPTION
# Summary

Fixes https://linear.app/cowswap/issue/FE-352/reduce-runtime-and-overlap-in-the-token-list-workflow

Rework how cowFi tokens script is fetched so it doesn't take 3h...
Actually, now it has a time limit of 15min.

Use the paid coingecko api key.

Now it completes in 2 min

<img width="916" height="302" alt="image" src="https://github.com/user-attachments/assets/25f58f86-34e4-4546-9fe5-a51d2e5432d4" />

## ⚠️ Important! ⚠️ 

This change also fixes a bug where it now _actually_ sorts by market cap.
That means that the previously listed token will change.

For example, right now 1inch, aave, across are in the list: https://files.cow.fi/tokens/cowFi-tokens.json
<img width="575" height="209" alt="image" src="https://github.com/user-attachments/assets/11bb6a68-267b-40c2-8f8f-dfbee1c8f904" />

The new list has the actual top market cap tokens on top
<img width="645" height="379" alt="image" src="https://github.com/user-attachments/assets/6af97d09-7032-4e14-b928-33d3867f4a54" />

# Testing

- Unit tests
- Ran the script locally
- Ran the scrip manually once merged to test with workflow_dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

- Improved CowFi token data generation with more accurate address matching across supported networks.
- Token listings are now ranked by market capitalization and include cleaner USD market data.
- Added custom descriptions and filters to remove incomplete token entries.
- Improved handling of API rate limits and temporary service errors for more reliable updates.

## Chores

- Token updates can be started manually and are protected against overlapping runs.
- Removed an unused runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->